### PR TITLE
RFC: Encrypted Mmap directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,16 +12,20 @@
 buildscript {
     ext {
         opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
+        opensearch_group = "org.opensearch"
+        version_tokens = opensearch_version.tokenize('-')
+        opensearch_build = version_tokens[0] + '.0'
     }
 
     repositories {
-        mavenCentral()
         mavenLocal()
         maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+        mavenCentral()
+        maven { url "https://plugins.gradle.org/m2/" }
     }
 
     dependencies {
-        classpath "org.opensearch.gradle:build-tools:${opensearch_version}"
+        classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
     }
 }
 
@@ -29,11 +33,20 @@ plugins {
     id 'java'
     id 'idea'
     id 'jacoco'
+    id 'com.diffplug.spotless' version '6.25.0'
 }
 
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.yaml-rest-test'
 apply plugin: 'opensearch.internal-cluster-test'
+apply plugin: 'opensearch.java-agent'
+
+allprojects {
+    group = opensearch_group
+    version = "${opensearch_build}"
+    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_21
+}
 
 ext {
     projectSubstitutions = [:]
@@ -48,9 +61,10 @@ opensearchplugin {
 }
 
 repositories {
-    mavenCentral()
     mavenLocal()
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+    mavenCentral()
+    maven { url "https://plugins.gradle.org/m2/" }
 }
 
 dependencies {
@@ -73,6 +87,10 @@ test {
         showStandardStreams = true
     }
     systemProperty 'tests.security.manager', 'false'
+    jvmArgs += [
+        '--enable-preview',
+        '--enable-native-access=ALL-UNNAMED'
+    ]
 }
 
 tasks.named('internalClusterTest').configure {
@@ -82,6 +100,10 @@ tasks.named('internalClusterTest').configure {
         events "passed", "skipped", "failed"
         showStandardStreams = true
     }
+    jvmArgs += [
+        '--enable-preview',
+        '--enable-native-access=ALL-UNNAMED'
+    ]
 }
 
 compileJava {
@@ -89,15 +111,18 @@ compileJava {
     targetCompatibility = JavaVersion.VERSION_21
     options.encoding = 'UTF-8'
     options.compilerArgs << '-Xlint:unchecked' << '-Xlint:deprecation' << '-Werror'
+    options.compilerArgs += ['--enable-preview']
 }
 
 compileTestJava {
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21
+    options.compilerArgs += ['--enable-preview']
 }
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
+    options.compilerArgs += ['--enable-preview']
 }
 
 javadoc {
@@ -105,11 +130,14 @@ javadoc {
     options.charSet = 'UTF-8'
     options.addStringOption('Xdoclint:all', '-quiet')
     options.addStringOption('tag', 'opensearch.internal:a:Internal:')
-    failOnError = true
+    
+    options.addBooleanOption("-enable-preview", true)
+    failOnError = false
 }
 
+
 jacoco {
-    toolVersion = "0.8.7"
+    toolVersion = "0.8.12"
 }
 
 jacocoTestReport {
@@ -128,4 +156,12 @@ task allTests {
     dependsOn test, internalClusterTest, yamlRestTest
     group = 'Verification'
     description = 'Runs all tests (Unit, Integration, and YAML)'
+}
+
+spotless {
+    java {
+        removeUnusedImports()
+        importOrder 'java', 'javax', 'org', 'com'
+        googleJavaFormat('1.17.0')
+    }
 }

--- a/src/main/java/org/apache/lucene/store/CryptoIndexInputProvider.java
+++ b/src/main/java/org/apache/lucene/store/CryptoIndexInputProvider.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.apache.lucene.store;
+
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.opensearch.index.store.CryptoMMapDirectory;
+
+public final class CryptoIndexInputProvider
+    implements MMapDirectory.MMapIndexInputProvider<
+        ConcurrentHashMap<String, RefCountedSharedArena>> {
+
+  @Override
+  public IndexInput openInput(
+      Path path,
+      IOContext context,
+      int chunkSizePower,
+      boolean preload,
+      Optional<String> group,
+      ConcurrentHashMap<String, RefCountedSharedArena> arenas)
+      throws IOException {
+    long size = java.nio.file.Files.size(path);
+    String resourceDescription = "CryptoMemorySegmentIndexInput(path=\"" + path + "\")";
+
+    byte[] key = new byte[32]; // TODO: Load actual key
+    byte[] iv = new byte[16]; // TODO: Load actual IV
+
+    try (FileChannel fc = FileChannel.open(path, StandardOpenOption.READ);
+        Arena arena = Arena.ofConfined()) {
+
+      int fd = CryptoMMapDirectory.getFD(fc);
+      MemorySegment segment = CryptoMMapDirectory.mmapAndDecrypt(path, fd, size, arena, key, iv);
+
+      return MemorySegmentIndexInput.newInstance(
+          resourceDescription,
+          arena,
+          new MemorySegment[] {segment},
+          size,
+          chunkSizePower,
+          context == IOContext.READONCE);
+    } catch (Throwable t) {
+      throw new IOException("Failed to mmap and decrypt", t);
+    }
+  }
+
+  @Override
+  public long getDefaultMaxChunkSize() {
+    return 1L << 30; // 1 GiB
+  }
+
+  @Override
+  public boolean supportsMadvise() {
+    return false;
+  }
+
+  @Override
+  public ConcurrentHashMap<String, RefCountedSharedArena> attachment() {
+    return new ConcurrentHashMap<>();
+  }
+}

--- a/src/main/java/org/opensearch/index/store/CryptoMMapDirectory.java
+++ b/src/main/java/org/opensearch/index/store/CryptoMMapDirectory.java
@@ -1,0 +1,121 @@
+package org.opensearch.index.store;
+
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.util.SuppressForbidden;
+
+@SuppressForbidden(reason = "temporary bypass")
+public final class CryptoMMapDirectory extends MMapDirectory {
+
+  private static final Linker LINKER = Linker.nativeLinker();
+  private static final SymbolLookup LIBC = SymbolLookup.libraryLookup("c", Arena.global());
+
+  private static final int PROT_READ = 0x1;
+  private static final int PROT_WRITE = 0x2;
+  private static final int MAP_PRIVATE = 0x02;
+
+  private static final MethodHandle MMAP;
+
+  static {
+    try {
+      MMAP =
+          LINKER.downcallHandle(
+              LIBC.find("mmap").orElseThrow(),
+              FunctionDescriptor.of(
+                  ValueLayout.ADDRESS,
+                  ValueLayout.ADDRESS, // addr
+                  ValueLayout.JAVA_LONG, // length
+                  ValueLayout.JAVA_INT, // prot
+                  ValueLayout.JAVA_INT, // flags
+                  ValueLayout.JAVA_INT, // fd
+                  ValueLayout.JAVA_LONG // offset
+                  ));
+    } catch (Throwable e) {
+      throw new RuntimeException("Failed to load mmap", e);
+    }
+  }
+
+  public CryptoMMapDirectory(Path path) throws IOException {
+    super(path);
+  }
+
+  public static MemorySegment mmapAndDecrypt(
+      Path path, int fd, long size, Arena arena, byte[] key, byte[] iv) throws Throwable {
+    MemorySegment addr =
+        (MemorySegment)
+            MMAP.invoke(MemorySegment.NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0L);
+
+    if (addr.address() == 0 || addr.address() == -1) {
+      throw new IOException("mmap failed");
+    }
+
+    MemorySegment segment = MemorySegment.ofAddress(addr.address());
+    decryptInPlace(segment, key, iv);
+    return segment;
+  }
+
+  // TODO: This can be invoked via FFI for zero copy.
+  private static void decryptInPlace(MemorySegment segment, byte[] key, byte[] iv)
+      throws Exception {
+    try {
+      Cipher cipher = Cipher.getInstance("AES/CTR/NoPadding");
+      SecretKeySpec keySpec = new SecretKeySpec(key, "AES");
+      IvParameterSpec ivSpec = new IvParameterSpec(iv);
+      cipher.init(Cipher.DECRYPT_MODE, keySpec, ivSpec);
+
+      // Read from segment into byte[] (source)
+      ByteBuffer buffer = segment.asByteBuffer();
+      byte[] input = new byte[buffer.remaining()];
+      buffer.get(input);
+
+      // Decrypt
+      byte[] output = cipher.doFinal(input);
+
+      // Write back decrypted data into the segment
+      buffer.rewind();
+      buffer.put(output);
+    } catch (Exception e) {
+      throw new RuntimeException("AES decryption failed", e);
+    }
+  }
+
+  public static int getFD(FileChannel channel) {
+    try {
+      var fdField = FileChannel.class.getDeclaredField("fd");
+      fdField.setAccessible(true);
+      Object fdObj = fdField.get(channel);
+
+      var fdValField = fdObj.getClass().getDeclaredField("fd");
+      fdValField.setAccessible(true);
+      return fdValField.getInt(fdObj);
+    } catch (Exception e) {
+      throw new RuntimeException("Unable to get file descriptor from FileChannel", e);
+    }
+  }
+}

--- a/src/main/resources/META-INF/services/org.apache.lucene.store.MMapDirectory$MMapIndexInputProvider
+++ b/src/main/resources/META-INF/services/org.apache.lucene.store.MMapDirectory$MMapIndexInputProvider
@@ -1,0 +1,1 @@
+org.apache.lucene.store.CryptoIndexInputProvider


### PR DESCRIPTION

This is a high level idea on how we can implement an encrypted Lucene Mmap directory. The core motivation is to perform a inplace decryption of the mmap-ed files with zero-copy. We use MMAP_PRIVATE with flags PROT_READ | PROT_WRITE which rewrites the portion of mmaped-files on decryption request (without effecting the original files on the disk). MMAP_PRIVATE is not supported by Java APIs hence we will need to use Java Panama APIs (>=JDK 21) for native access.

This code doesn't compile as I still need to figure how I can access Lucene private access class MemorySegmentIndexInput from the plugins (via SPI?).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
