### PR TITLE
Advise the kernel to release MMAP private pages on Index input close

### DIFF
--- a/src/main/java/org/opensearch/index/store/mmap/PanamaNativeAccess.java
+++ b/src/main/java/org/opensearch/index/store/mmap/PanamaNativeAccess.java
@@ -30,6 +30,8 @@ public class PanamaNativeAccess {
     private static final SymbolLookup LIBC = loadLibc();
 
     public static final int MADV_WILLNEED = 3;
+    public static final int MADV_DONTNEED = 4;
+
     public static final int PROT_READ = 0x1;
     public static final int PROT_WRITE = 0x2;
     public static final int MAP_PRIVATE = 0x02;

--- a/src/main/java/org/opensearch/index/store/niofs/CryptoBufferedIndexInput.java
+++ b/src/main/java/org/opensearch/index/store/niofs/CryptoBufferedIndexInput.java
@@ -115,9 +115,9 @@ final class CryptoBufferedIndexInput extends BufferedIndexInput {
     @SuppressForbidden(reason = "FileChannel#read is efficient and used intentionally")
     private int read(ByteBuffer dst, long position) throws IOException {
 
-        //initialize buffer lazy because Lucene may open input slices and clones ahead but never use them
-        //see org.apache.lucene.store.BufferedIndexInput
-        if( tmpBuffer == EMPTY_BYTEBUFFER ) {
+        // initialize buffer lazy because Lucene may open input slices and clones ahead but never use them
+        // see org.apache.lucene.store.BufferedIndexInput
+        if (tmpBuffer == EMPTY_BYTEBUFFER) {
             tmpBuffer = ByteBuffer.allocate(CHUNK_SIZE);
         }
 


### PR DESCRIPTION
### Description

### Note this only works for Linux. 

Advise the kernel to release MMAP private pages on Index input close.  Unless otherwise the kernel will not release Private anonymous pages from its page cache. 

### Memory metrics from benchmarks results. 

<img width="1460" height="576" alt="Screenshot 2025-07-13 at 8 45 24 AM" src="https://github.com/user-attachments/assets/f147a197-3ee2-45cd-a248-c0ac5412365d" />
