### PR TITLE
Use default lookup for loading libraries

### DIFF
--- a/src/main/java/org/opensearch/index/store/mmap/PanamaNativeAccess.java
+++ b/src/main/java/org/opensearch/index/store/mmap/PanamaNativeAccess.java
@@ -27,33 +27,12 @@ public class PanamaNativeAccess {
     private static final MethodHandle OPEN;
     private static final MethodHandle CLOSE;
 
-    private static final SymbolLookup LIBC = loadLibc();
+    private static final SymbolLookup LIBC = LINKER.defaultLookup();
 
     public static final int MADV_WILLNEED = 3;
     public static final int PROT_READ = 0x1;
     public static final int PROT_WRITE = 0x2;
     public static final int MAP_PRIVATE = 0x02;
-
-    private static SymbolLookup loadLibc() {
-        String os = System.getProperty("os.name").toLowerCase();
-        if (os.contains("mac")) {
-            return SymbolLookup.libraryLookup("/usr/lib/libSystem.B.dylib", Arena.global());
-        } else if (os.contains("linux")) {
-            try {
-                // Try the 64-bit version first
-                return SymbolLookup.libraryLookup("/lib64/libc.so.6", Arena.global());
-            } catch (Exception e) {
-                try {
-                    // Fall back to the 32-bit version
-                    return SymbolLookup.libraryLookup("/lib/libc.so.6", Arena.global());
-                } catch (Exception e2) {
-                    throw new RuntimeException("Could not load libc from either /lib64/libc.so.6 or /lib/libc.so.6", e2);
-                }
-            }
-        } else {
-            throw new UnsupportedOperationException("Unsupported OS: " + os);
-        }
-    }
 
     static {
         try {

--- a/src/main/java/org/opensearch/index/store/niofs/CryptoBufferedIndexInput.java
+++ b/src/main/java/org/opensearch/index/store/niofs/CryptoBufferedIndexInput.java
@@ -115,9 +115,9 @@ final class CryptoBufferedIndexInput extends BufferedIndexInput {
     @SuppressForbidden(reason = "FileChannel#read is efficient and used intentionally")
     private int read(ByteBuffer dst, long position) throws IOException {
 
-        //initialize buffer lazy because Lucene may open input slices and clones ahead but never use them
-        //see org.apache.lucene.store.BufferedIndexInput
-        if( tmpBuffer == EMPTY_BYTEBUFFER ) {
+        // initialize buffer lazy because Lucene may open input slices and clones ahead but never use them
+        // see org.apache.lucene.store.BufferedIndexInput
+        if (tmpBuffer == EMPTY_BYTEBUFFER) {
             tmpBuffer = ByteBuffer.allocate(CHUNK_SIZE);
         }
 


### PR DESCRIPTION
### Description

Use default lookup for loading libraries. The previous lookup functions failed on Alpine linux.

Fixes https://github.com/opensearch-project/opensearch-storage-encryption/pull/26#issuecomment-3088823027 

##### Tested locally by running tests and a mini OSB benchmark. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
