### PR TITLE
Bumping to Java 24

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -4,7 +4,7 @@ This guide helps developers get started with building and testing the OpenSearch
 
 ## Prerequisites
 
-1. JDK 21 or higher
+1. JDK 24 or higher
 2. Git
 3. Gradle
 4. AWS Account (for KMS integration testing)
@@ -130,7 +130,6 @@ add_jvm_option() {
 }
 
 # Add required JVM options
-add_jvm_option "--enable-preview"
 add_jvm_option "--enable-native-access=ALL-UNNAMED"
 add_jvm_option "-XX:MaxDirectMemorySize=${JVM_DIRECT_MEM_SIZE}"
 ```

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -130,7 +130,6 @@ add_jvm_option() {
 }
 
 # Add required JVM options
-add_jvm_option "--enable-native-access=ALL-UNNAMED"
 add_jvm_option "-XX:MaxDirectMemorySize=${JVM_DIRECT_MEM_SIZE}"
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -78,9 +78,6 @@ test {
         showStandardStreams = true
     }
     systemProperty 'tests.security.manager', 'false'
-    jvmArgs += [
-        '--enable-native-access=ALL-UNNAMED'
-    ]
 }
 
 tasks.named('internalClusterTest').configure {
@@ -90,13 +87,6 @@ tasks.named('internalClusterTest').configure {
         events "passed", "skipped", "failed"
         showStandardStreams = true
     }
-    jvmArgs += [
-        '--enable-native-access=ALL-UNNAMED'
-    ]
-}
-
-tasks.named("yamlRestTest").configure {
-    jvmArgs += "--enable-native-access=ALL-UNNAMED"
 }
 
 compileJava {

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ opensearchplugin {
     name 'storage-encryption'
     description 'Encrypts and decrypts index data at rest.'
     classname 'org.opensearch.index.store.CryptoDirectoryPlugin'
+    version opensearch_version
 }
 
 repositories {
@@ -57,9 +58,7 @@ repositories {
 
 dependencies {
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
-    
     runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
-    
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "commons-io:commons-io:2.13.0"
 
@@ -80,7 +79,6 @@ test {
     }
     systemProperty 'tests.security.manager', 'false'
     jvmArgs += [
-        '--enable-preview',
         '--enable-native-access=ALL-UNNAMED'
     ]
 }
@@ -93,38 +91,31 @@ tasks.named('internalClusterTest').configure {
         showStandardStreams = true
     }
     jvmArgs += [
-        '--enable-preview',
         '--enable-native-access=ALL-UNNAMED'
     ]
 }
 
 tasks.named("yamlRestTest").configure {
-    jvmArgs += "--enable-preview"
     jvmArgs += "--enable-native-access=ALL-UNNAMED"
 }
 
 compileJava {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_24
+    targetCompatibility = JavaVersion.VERSION_24
     options.encoding = 'UTF-8'
     options.compilerArgs << '-Xlint:unchecked' << '-Xlint:deprecation' << '-Werror'
-    options.compilerArgs += ['--enable-preview']
 }
 
 compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
-    options.compilerArgs += ['--enable-preview']
+    sourceCompatibility = JavaVersion.VERSION_24
+    targetCompatibility = JavaVersion.VERSION_24
 }
 
 tasks.withType(JavaCompile).configureEach {
+    sourceCompatibility = JavaVersion.VERSION_24
+    targetCompatibility = JavaVersion.VERSION_24
     options.encoding = 'UTF-8'
-    options.compilerArgs += "--enable-preview"
-    options.release = 21
-}
-
-tasks.withType(Test).configureEach {
-    jvmArgs += "--enable-preview"
+    options.release = 24
 }
 
 javadoc {
@@ -132,13 +123,12 @@ javadoc {
     options.charSet = 'UTF-8'
     options.addStringOption('Xdoclint:all', '-quiet')
     options.addStringOption('tag', 'opensearch.internal:a:Internal:')
-    options.addStringOption("source", "21")
-    options.addBooleanOption("-enable-preview", true)
+    options.addStringOption("source", "24")
     failOnError = true
 }
 
 jacoco {
-    toolVersion = "0.8.12"
+    toolVersion = "0.8.13"
 }
 
 jacocoTestReport {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/org/opensearch/index/store/cipher/OpenSslNativeCipher.java
+++ b/src/main/java/org/opensearch/index/store/cipher/OpenSslNativeCipher.java
@@ -186,8 +186,8 @@ public final class OpenSslNativeCipher {
                 }
 
                 byte[] adjustedIV = computeOffsetIV(iv, filePosition);
-                MemorySegment keySeg = arena.allocateArray(ValueLayout.JAVA_BYTE, key);
-                MemorySegment ivSeg = arena.allocateArray(ValueLayout.JAVA_BYTE, adjustedIV);
+                MemorySegment keySeg = arena.allocateFrom(ValueLayout.JAVA_BYTE, key);
+                MemorySegment ivSeg = arena.allocateFrom(ValueLayout.JAVA_BYTE, adjustedIV);
 
                 int rc = (int) EVP_EncryptInit_ex.invoke(ctx, cipher, MemorySegment.NULL, keySeg, ivSeg);
                 if (rc != 1) {
@@ -196,13 +196,13 @@ public final class OpenSslNativeCipher {
 
                 int skipBytes = (int) (filePosition % AES_BLOCK_SIZE);
                 if (skipBytes > 0) {
-                    MemorySegment dummyIn = arena.allocateArray(ValueLayout.JAVA_BYTE, skipBytes);
+                    MemorySegment dummyIn = arena.allocate(ValueLayout.JAVA_BYTE, skipBytes);
                     MemorySegment dummyOut = arena.allocate(skipBytes + AES_BLOCK_SIZE);
                     MemorySegment dummyLen = arena.allocate(ValueLayout.JAVA_INT);
                     EVP_EncryptUpdate.invoke(ctx, dummyOut, dummyLen, dummyIn, skipBytes);
                 }
 
-                MemorySegment inSeg = arena.allocateArray(ValueLayout.JAVA_BYTE, input);
+                MemorySegment inSeg = arena.allocateFrom(ValueLayout.JAVA_BYTE, input);
                 MemorySegment outSeg = arena.allocate(input.length + AES_BLOCK_SIZE);
                 MemorySegment outLen = arena.allocate(ValueLayout.JAVA_INT);
 
@@ -236,8 +236,8 @@ public final class OpenSslNativeCipher {
                 throw new OpenSslException("EVP_aes_256_ctr failed");
 
             byte[] adjustedIV = computeOffsetIV(iv, fileOffset);
-            MemorySegment keySeg = arena.allocateArray(ValueLayout.JAVA_BYTE, key);
-            MemorySegment ivSeg = arena.allocateArray(ValueLayout.JAVA_BYTE, adjustedIV);
+            MemorySegment keySeg = arena.allocateFrom(ValueLayout.JAVA_BYTE, key);
+            MemorySegment ivSeg = arena.allocateFrom(ValueLayout.JAVA_BYTE, adjustedIV);
 
             int rc = (int) EVP_EncryptInit_ex.invoke(ctx, cipher, MemorySegment.NULL, keySeg, ivSeg);
             if (rc != 1)
@@ -297,8 +297,8 @@ public final class OpenSslNativeCipher {
 
                 // Compute IV with offset counter
                 byte[] adjustedIV = computeOffsetIV(iv, filePosition);
-                MemorySegment keySeg = arena.allocateArray(ValueLayout.JAVA_BYTE, key);
-                MemorySegment ivSeg = arena.allocateArray(ValueLayout.JAVA_BYTE, adjustedIV);
+                MemorySegment keySeg = arena.allocateFrom(ValueLayout.JAVA_BYTE, key);
+                MemorySegment ivSeg = arena.allocateFrom(ValueLayout.JAVA_BYTE, adjustedIV);
 
                 int rc = (int) EVP_EncryptInit_ex.invoke(ctx, cipher, MemorySegment.NULL, keySeg, ivSeg);
                 if (rc != 1) {
@@ -308,13 +308,13 @@ public final class OpenSslNativeCipher {
                 // Skip any partial block
                 int partialOffset = (int) (filePosition % AES_BLOCK_SIZE);
                 if (partialOffset > 0) {
-                    MemorySegment dummyIn = arena.allocateArray(ValueLayout.JAVA_BYTE, partialOffset);
+                    MemorySegment dummyIn = arena.allocate(ValueLayout.JAVA_BYTE, partialOffset);
                     MemorySegment dummyOut = arena.allocate(partialOffset + AES_BLOCK_SIZE);
                     MemorySegment dummyLen = arena.allocate(ValueLayout.JAVA_INT);
                     EVP_EncryptUpdate.invoke(ctx, dummyOut, dummyLen, dummyIn, partialOffset);
                 }
 
-                MemorySegment inSeg = arena.allocateArray(ValueLayout.JAVA_BYTE, input);
+                MemorySegment inSeg = arena.allocateFrom(ValueLayout.JAVA_BYTE, input);
                 MemorySegment outSeg = arena.allocate(input.length + AES_BLOCK_SIZE);
                 MemorySegment outLen = arena.allocate(ValueLayout.JAVA_INT);
 
@@ -355,8 +355,8 @@ public final class OpenSslNativeCipher {
 
                 byte[] adjustedIV = computeOffsetIV(iv, fileOffset);
                 long tKeyIvStart = System.nanoTime();
-                MemorySegment keySeg = arena.allocateArray(ValueLayout.JAVA_BYTE, key);
-                MemorySegment ivSeg = arena.allocateArray(ValueLayout.JAVA_BYTE, adjustedIV);
+                MemorySegment keySeg = arena.allocateFrom(ValueLayout.JAVA_BYTE, key);
+                MemorySegment ivSeg = arena.allocateFrom(ValueLayout.JAVA_BYTE, adjustedIV);
                 long tKeyIvAlloc = System.nanoTime();
 
                 int rc = (int) EVP_EncryptInit_ex.invoke(ctx, cipher, MemorySegment.NULL, keySeg, ivSeg);
@@ -366,7 +366,7 @@ public final class OpenSslNativeCipher {
 
                 int partialBlockOffset = (int) (fileOffset % AES_BLOCK_SIZE);
                 if (partialBlockOffset > 0) {
-                    MemorySegment dummyIn = arena.allocateArray(ValueLayout.JAVA_BYTE, partialBlockOffset);
+                    MemorySegment dummyIn = arena.allocate(ValueLayout.JAVA_BYTE, partialBlockOffset);
                     MemorySegment dummyOut = arena.allocate(partialBlockOffset + AES_BLOCK_SIZE);
                     MemorySegment dummyLen = arena.allocate(ValueLayout.JAVA_INT);
                     EVP_EncryptUpdate.invoke(ctx, dummyOut, dummyLen, dummyIn, partialBlockOffset);
@@ -388,12 +388,12 @@ public final class OpenSslNativeCipher {
                     .trace(
                         """
                             Decryption breakdown ({} MiB at offset {}):
-                             > ctx alloc: {} \u00b5s
-                             > cipher lookup: {} \u00b5s
-                             > key/iv alloc: {} \u00b5s
-                             > init cipher: {} \u00b5s
-                             > update decrypt: {} \u00b5s
-                             > total time: {} \u00b5s""",
+                             > ctx alloc: {} µs
+                             > cipher lookup: {} µs
+                             > key/iv alloc: {} µs
+                             > init cipher: {} µs
+                             > update decrypt: {} µs
+                             > total time: {} µs""",
                         String.format("%.2f", length / 1048576.0),
                         fileOffset,
                         (tCtxAlloc - tCtxStart) / 1_000,
@@ -426,8 +426,8 @@ public final class OpenSslNativeCipher {
                 throw new OpenSslException("EVP_aes_256_ctr failed");
 
             byte[] adjustedIV = computeOffsetIV(iv, fileOffset);
-            MemorySegment keySeg = arena.allocateArray(ValueLayout.JAVA_BYTE, key);
-            MemorySegment ivSeg = arena.allocateArray(ValueLayout.JAVA_BYTE, adjustedIV);
+            MemorySegment keySeg = arena.allocateFrom(ValueLayout.JAVA_BYTE, key);
+            MemorySegment ivSeg = arena.allocateFrom(ValueLayout.JAVA_BYTE, adjustedIV);
 
             int rc = (int) EVP_EncryptInit_ex.invoke(ctx, cipher, MemorySegment.NULL, keySeg, ivSeg);
             if (rc != 1)
@@ -435,7 +435,7 @@ public final class OpenSslNativeCipher {
 
             int partialBlockOffset = (int) (fileOffset % AES_BLOCK_SIZE);
             if (partialBlockOffset > 0) {
-                MemorySegment dummyIn = arena.allocateArray(ValueLayout.JAVA_BYTE, partialBlockOffset);
+                MemorySegment dummyIn = arena.allocate(ValueLayout.JAVA_BYTE, partialBlockOffset);
                 MemorySegment dummyOut = arena.allocate(partialBlockOffset + AES_BLOCK_SIZE);
                 MemorySegment dummyLen = arena.allocate(ValueLayout.JAVA_INT);
                 EVP_EncryptUpdate.invoke(ctx, dummyOut, dummyLen, dummyIn, partialBlockOffset);

--- a/src/main/java/org/opensearch/index/store/mmap/PanamaNativeAccess.java
+++ b/src/main/java/org/opensearch/index/store/mmap/PanamaNativeAccess.java
@@ -124,7 +124,7 @@ public class PanamaNativeAccess {
 
     public static int openFile(String path) throws Throwable {
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment pathSegment = arena.allocateUtf8String(path);
+            MemorySegment pathSegment = arena.allocateFrom(path);
             return (int) OPEN.invoke(pathSegment, 0); // O_RDONLY = 0
         }
     }


### PR DESCRIPTION
### Description
Updating Java version to 24 for the plugin for performance boost.


OSB result
```
$ opensearch-benchmark execute-test \
  --pipeline=benchmark-only \
  --workload=http_logs \
  --target-hosts=http://localhost:9200 \
  --exclude-tasks=refresh-after-index,\
force-merge,\
refresh-after-force-merge,\
wait-until-merges-finish,\
default,\
term,\
range,\
status-200s-in-range,\
status-400s-in-range,\
hourly_agg,\
multi_term_agg,\
scroll,\
desc_sort_size,\
asc_sort_size,\
desc_sort_timestamp,\
asc_sort_timestamp,\
desc_sort_with_after_timestamp,\
asc_sort_with_after_timestamp,\
force-merge-1-seg,\
refresh-after-force-merge-1-seg,\
wait-until-merges-1-seg-finish,\
desc-sort-timestamp-after-force-merge-1-seg,\
asc-sort-timestamp-after-force-merge-1-seg,\
desc-sort-with-after-timestamp-after-force-merge-1-seg,\
asc-sort-with-after-timestamp-after-force-merge-1-seg \
  --workload-params '{
    "number_of_shards": "5",
    "number_of_replicas": "0",
    "index_settings": {
      "index.store.type": "cryptofs",
      "index.store.kms.type": "aws-kms"
    }
  }'

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] [Test Execution ID]: 587000a4-2b39-4bbc-a770-b78860a589cd
[INFO] Executing test with workload [http_logs], test_procedure [append-no-conflicts] and provision_config_instance ['external'] with version [3.1.0-SNAPSHOT].

Running delete-index                                                           [100% done]
Running create-index                                                           [100% done]
Running check-cluster-health                                                   [100% done]
Running index-append                                                           [100% done]

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------
            
|                                                         Metric |         Task |     Value |   Unit |
|---------------------------------------------------------------:|-------------:|----------:|-------:|
|                     Cumulative indexing time of primary shards |              |   96.4837 |    min |
|             Min cumulative indexing time across primary shards |              |         0 |    min |
|          Median cumulative indexing time across primary shards |              |  0.860742 |    min |
|             Max cumulative indexing time across primary shards |              |   14.2554 |    min |
|            Cumulative indexing throttle time of primary shards |              |         0 |    min |
|    Min cumulative indexing throttle time across primary shards |              |         0 |    min |
| Median cumulative indexing throttle time across primary shards |              |         0 |    min |
|    Max cumulative indexing throttle time across primary shards |              |         0 |    min |
|                        Cumulative merge time of primary shards |              |   46.8944 |    min |
|                       Cumulative merge count of primary shards |              |       387 |        |
|                Min cumulative merge time across primary shards |              |         0 |    min |
|             Median cumulative merge time across primary shards |              |   0.17655 |    min |
|                Max cumulative merge time across primary shards |              |   10.6183 |    min |
|               Cumulative merge throttle time of primary shards |              |   25.4394 |    min |
|       Min cumulative merge throttle time across primary shards |              |         0 |    min |
|    Median cumulative merge throttle time across primary shards |              | 0.0419917 |    min |
|       Max cumulative merge throttle time across primary shards |              |   6.77682 |    min |
|                      Cumulative refresh time of primary shards |              |   7.73112 |    min |
|                     Cumulative refresh count of primary shards |              |       688 |        |
|              Min cumulative refresh time across primary shards |              |         0 |    min |
|           Median cumulative refresh time across primary shards |              |  0.078975 |    min |
|              Max cumulative refresh time across primary shards |              |   1.25753 |    min |
|                        Cumulative flush time of primary shards |              |   10.3091 |    min |
|                       Cumulative flush count of primary shards |              |       107 |        |
|                Min cumulative flush time across primary shards |              |         0 |    min |
|             Median cumulative flush time across primary shards |              | 0.0109583 |    min |
|                Max cumulative flush time across primary shards |              |   1.95597 |    min |
|                                        Total Young Gen GC time |              |    11.534 |      s |
|                                       Total Young Gen GC count |              |      1528 |        |
|                                          Total Old Gen GC time |              |         0 |      s |
|                                         Total Old Gen GC count |              |         0 |        |
|                                                     Store size |              |    20.902 |     GB |
|                                                  Translog size |              |   1.49433 |     GB |
|                                         Heap used for segments |              |         0 |     MB |
|                                       Heap used for doc values |              |         0 |     MB |
|                                            Heap used for terms |              |         0 |     MB |
|                                            Heap used for norms |              |         0 |     MB |
|                                           Heap used for points |              |         0 |     MB |
|                                    Heap used for stored fields |              |         0 |     MB |
|                                                  Segment count |              |       368 |        |
|                                                 Min Throughput | index-append |    338913 | docs/s |
|                                                Mean Throughput | index-append |    372449 | docs/s |
|                                              Median Throughput | index-append |    365237 | docs/s |
|                                                 Max Throughput | index-append |    430012 | docs/s |
|                                        50th percentile latency | index-append |   61.2936 |     ms |
|                                        90th percentile latency | index-append |   291.166 |     ms |
|                                        99th percentile latency | index-append |   590.606 |     ms |
|                                      99.9th percentile latency | index-append |   894.419 |     ms |
|                                     99.99th percentile latency | index-append |    1302.3 |     ms |
|                                       100th percentile latency | index-append |   1320.78 |     ms |
|                                   50th percentile service time | index-append |   61.2936 |     ms |
|                                   90th percentile service time | index-append |   291.166 |     ms |
|                                   99th percentile service time | index-append |   590.606 |     ms |
|                                 99.9th percentile service time | index-append |   894.419 |     ms |
|                                99.99th percentile service time | index-append |    1302.3 |     ms |
|                                  100th percentile service time | index-append |   1320.78 |     ms |
|                                                     error rate | index-append |         0 |      % |


---------------------------------
[INFO] SUCCESS (took 771 seconds)
---------------------------------
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
