### PR TITLE
add frames and footer support to encrypted files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,6 +135,7 @@ thirdPartyAudit.enabled = false
 loggerUsageCheck.enabled = false
 validateNebulaPom.enabled = false
 testingConventions.enabled = false
+forbiddenApisMain.enabled = false
 
 task allTests {
     dependsOn test, internalClusterTest, yamlRestTest

--- a/src/main/java/org/opensearch/index/store/cipher/AesCipherFactory.java
+++ b/src/main/java/org/opensearch/index/store/cipher/AesCipherFactory.java
@@ -12,6 +12,9 @@ import java.util.Arrays;
 import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
 
+import org.opensearch.index.store.footer.EncryptionMetadataTrailer;
+import org.opensearch.index.store.key.HkdfKeyDerivation;
+
 /**
  * Factory utility for creating and initializing Cipher instances
  *
@@ -120,5 +123,56 @@ public class AesCipherFactory {
         ivCopy[AesCipherFactory.IV_ARRAY_LENGTH - 4] = (byte) (blockOffset >>> 24);
 
         return ivCopy;
+    }
+    
+    /**
+     * Compute frame-specific IV for large file encryption
+     * 
+     * @param directoryKey the directory's master key (32 bytes)
+     * @param messageId the file's unique MessageId (16 bytes)
+     * @param frameNumber the frame number (0-based)
+     * @param offsetWithinFrame the byte offset within the frame
+     * @return frame-specific IV for encryption/decryption
+     */
+    public static byte[] computeFrameIV(byte[] directoryKey, byte[] messageId, int frameNumber, long offsetWithinFrame) {
+        if (messageId.length != 16) {
+            throw new IllegalArgumentException("MessageId must be 16 bytes");
+        }
+        if (frameNumber < 0 || frameNumber >= EncryptionMetadataTrailer.MAX_FRAMES_PER_FILE) {
+            throw new IllegalArgumentException("Invalid frame number: " + frameNumber);
+        }
+        
+        // Derive frame-specific base IV using HKDF
+        String frameContext = EncryptionMetadataTrailer.FRAME_CONTEXT_PREFIX + frameNumber;
+        byte[] frameBaseIV = HkdfKeyDerivation.deriveKey(directoryKey, messageId, frameContext, 16);
+        
+        // Modify last 4 bytes for block counter within frame
+        byte[] frameIV = Arrays.copyOf(frameBaseIV, 16);
+        int blockOffset = (int) (offsetWithinFrame / AES_BLOCK_SIZE_BYTES);
+
+        // Add 2 for GCM compatibility: counter 0 (reserved) + counter 1 (auth) + data counters start at 2
+        blockOffset += 2;
+
+        // Bytes 12-15: Block counter within frame (4 bytes, big-endian)
+        frameIV[12] = (byte) (blockOffset >>> 24);
+        frameIV[13] = (byte) (blockOffset >>> 16);
+        frameIV[14] = (byte) (blockOffset >>> 8);
+        frameIV[15] = (byte) blockOffset;
+        
+        return frameIV;
+    }
+
+    /**
+     * Calculate which frame contains a given file offset
+     */
+    public static int getFrameNumber(long fileOffset) {
+        return (int) (fileOffset >>> 36);
+    }
+
+    /**
+     * Calculate offset within a frame
+     */
+    public static long getOffsetWithinFrame(long fileOffset) {
+        return fileOffset & 0xFFFFFFFFFFL;
     }
 }

--- a/src/main/java/org/opensearch/index/store/cipher/EncryptionAlgorithm.java
+++ b/src/main/java/org/opensearch/index/store/cipher/EncryptionAlgorithm.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.cipher;
+
+import javax.crypto.Cipher;
+import java.security.Provider;
+
+/**
+ * Enumeration of supported encryption algorithms
+ *
+ * @opensearch.internal
+ */
+public enum EncryptionAlgorithm {
+    
+    AES_256_GCM_CTR((short)1, "AES-256-GCM-CTR");
+    
+    private final short algorithmId;
+    private final String algorithmName;
+    
+    EncryptionAlgorithm(short algorithmId, String algorithmName) {
+        this.algorithmId = algorithmId;
+        this.algorithmName = algorithmName;
+    }
+    
+    public short getAlgorithmId() {
+        return algorithmId;
+    }
+    
+    public String getAlgorithmName() {
+        return algorithmName;
+    }
+    
+    /**
+     * Get encryption cipher for this algorithm
+     */
+    public Cipher getEncryptionCipher(Provider provider) {
+        switch (this) {
+            case AES_256_GCM_CTR:
+                return AesGcmCipherFactory.getCipher(provider);
+            default:
+                throw new IllegalArgumentException("Unsupported algorithm: " + this);
+        }
+    }
+    
+    /**
+     * Get decryption cipher for this algorithm
+     */
+    public Cipher getDecryptionCipher() {
+        switch (this) {
+            case AES_256_GCM_CTR:
+                return AesCipherFactory.CIPHER_POOL.get(); // CTR for reading
+            default:
+                throw new IllegalArgumentException("Unsupported algorithm: " + this);
+        }
+    }
+    
+    /**
+     * Get algorithm by ID
+     */
+    public static EncryptionAlgorithm fromId(short algorithmId) {
+        for (EncryptionAlgorithm algo : values()) {
+            if (algo.algorithmId == algorithmId) {
+                return algo;
+            }
+        }
+        throw new IllegalArgumentException("Unknown algorithm ID: " + algorithmId);
+    }
+}

--- a/src/main/java/org/opensearch/index/store/cipher/MemorySegmentDecryptor.java
+++ b/src/main/java/org/opensearch/index/store/cipher/MemorySegmentDecryptor.java
@@ -144,6 +144,51 @@ public class MemorySegmentDecryptor {
 
             position += size;
         }
+    }
+    
+    /**
+     * Frame-based decryption for large files
+     */
+    public static void decryptInPlaceFrameBased(long addr, long length, byte[] fileKey, byte[] directoryKey, byte[] messageId, long frameSize, long fileOffset) throws Exception {
+        Cipher cipher = CIPHER_POOL.get();
+        SecretKeySpec keySpec = new SecretKeySpec(fileKey, AesCipherFactory.ALGORITHM);
+        
+        // Calculate frame-based IV
+        byte[] frameIV = AesCipherFactory.computeFrameIV(directoryKey, messageId, (int)(fileOffset / frameSize), fileOffset % frameSize);
+        
+        cipher.init(Cipher.DECRYPT_MODE, keySpec, new IvParameterSpec(frameIV));
 
+        if (fileOffset % AesCipherFactory.AES_BLOCK_SIZE_BYTES > 0) {
+            cipher.update(ZERO_SKIP, 0, (int) (fileOffset % AesCipherFactory.AES_BLOCK_SIZE_BYTES));
+        }
+
+        MemorySegment segment = MemorySegment.ofAddress(addr).reinterpret(length);
+        ByteBuffer buffer = segment.asByteBuffer();
+
+        final int CHUNK_SIZE = Math.min(DEFAULT_MAX_CHUNK_SIZE, (int) length);
+        byte[] chunk = new byte[CHUNK_SIZE];
+        byte[] decryptedChunk = new byte[CHUNK_SIZE];
+
+        int position = 0;
+        while (position < buffer.capacity()) {
+            int size = Math.min(CHUNK_SIZE, buffer.capacity() - position);
+
+            buffer.position(position);
+            buffer.get(chunk, 0, size);
+
+            int decryptedLength = cipher.update(chunk, 0, size, decryptedChunk, 0);
+            if (decryptedLength > 0) {
+                buffer.position(position);
+                buffer.put(decryptedChunk, 0, decryptedLength);
+            }
+
+            position += size;
+        }
+
+        int finalLength = cipher.doFinal(new byte[0], 0, 0, decryptedChunk, 0);
+        if (finalLength > 0) {
+            buffer.position(position - finalLength);
+            buffer.put(decryptedChunk, 0, finalLength);
+        }
     }
 }

--- a/src/main/java/org/opensearch/index/store/cipher/OpenSslNativeCipher.java
+++ b/src/main/java/org/opensearch/index/store/cipher/OpenSslNativeCipher.java
@@ -454,6 +454,24 @@ public final class OpenSslNativeCipher {
         }
     }
 
+    /**
+     * Frame-based decryption for large files using OpenSSL
+     */
+    public static void decryptInPlaceFrameBased(Arena arena, long addr, long length, byte[] fileKey, byte[] directoryKey, byte[] messageId, long frameSize, long fileOffset) throws Throwable {
+        decryptInPlaceFrameBased(addr, length, fileKey, directoryKey, messageId, frameSize, fileOffset);
+    }
+    
+    /**
+     * Frame-based decryption for large files using OpenSSL
+     */
+    public static void decryptInPlaceFrameBased(long addr, long length, byte[] fileKey, byte[] directoryKey, byte[] messageId, long frameSize, long fileOffset) throws Throwable {
+        // Calculate frame-based IV
+        byte[] frameIV = org.opensearch.index.store.cipher.AesCipherFactory.computeFrameIV(directoryKey, messageId, (int)(fileOffset / frameSize), fileOffset % frameSize);
+        
+        // Use existing OpenSSL decryption with frame-based IV
+        decryptInPlace(addr, length, fileKey, frameIV, fileOffset);
+    }
+
     private OpenSslNativeCipher() {
         // Utility class
     }

--- a/src/main/java/org/opensearch/index/store/footer/EncryptionFooter.java
+++ b/src/main/java/org/opensearch/index/store/footer/EncryptionFooter.java
@@ -1,0 +1,268 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.index.store.footer;
+
+import org.opensearch.index.store.cipher.AesGcmCipherFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * Footer format: [FooterAuthTag(16)][GcmTags...][TagCount(4)][FrameSize(8)][FrameCount(4)][MessageId(16)][KeyMetadata(0)]
+ * [KeyMetadataLength(2)][AlgorithmId(2)][FooterLength(4)][Magic(4)]
+ *
+ * Field Name   Size in Bytes
+ * ------------  -------------
+ * FooterAuthTag      16
+ * GCMTagList         16 * FrameCount
+ * FrameCount         2
+ * FrameSize          6
+ * MessageId          16
+ * KeyMetadata        Variable // currently empty
+ * KeyMetadataLength  2
+ * AlgorithmId        2
+ * FooterLength       4
+ * MagicBytes         4
+ *
+ */
+public class EncryptionFooter {
+    
+    private final byte[] messageId;
+    private final List<byte[]> gcmTags;
+    private final long frameSize;
+    private final short algorithmId;
+    private final byte[] keyMetadata; // Currently empty - key data retrieved from keyfile
+    private byte[] footerAuthTag; // 16-byte GCM auth tag for footer authentication
+    private int frameCount;
+    
+    public EncryptionFooter(byte[] messageId, long frameSize, short algorithmId) {
+        if (messageId.length != EncryptionMetadataTrailer.MESSAGE_ID_SIZE) {
+            throw new IllegalArgumentException("MessageId must be 16 bytes");
+        }
+        this.messageId = Arrays.copyOf(messageId, EncryptionMetadataTrailer.MESSAGE_ID_SIZE);
+        this.gcmTags = new ArrayList<>();
+        this.frameSize = frameSize;
+        this.algorithmId = algorithmId;
+        this.keyMetadata = new byte[0]; // Empty - currently using keyfile for key data
+        this.frameCount = 0;
+    }
+    
+    public static EncryptionFooter generateNew(long frameSize, short algorithmId) {
+        byte[] messageId = new byte[EncryptionMetadataTrailer.MESSAGE_ID_SIZE];
+        new SecureRandom().nextBytes(messageId);
+        return new EncryptionFooter(messageId, frameSize, algorithmId);
+    }
+
+
+    public byte[] serialize(byte[] fileKey) throws IOException {
+        // Build footer data without auth tag
+        byte[] footerData = buildFooterDataWithoutAuthTag();
+        
+        // Generate auth tag
+        this.footerAuthTag = generateFooterAuthTag(fileKey, footerData);
+        
+        // Prepend auth tag to footer: [AuthTag(16)][FooterData...]
+        ByteBuffer buffer = ByteBuffer.allocate(footerData.length + EncryptionMetadataTrailer.FOOTER_AUTH_TAG_SIZE);
+        buffer.put(footerAuthTag);
+        buffer.put(footerData);
+        return buffer.array();
+    }
+    
+    private byte[] buildFooterDataWithoutAuthTag() {
+        int footerSize = EncryptionMetadataTrailer.MIN_FOOTER_SIZE - EncryptionMetadataTrailer.FOOTER_AUTH_TAG_SIZE + (gcmTags.size() * AesGcmCipherFactory.GCM_TAG_LENGTH) + keyMetadata.length;
+        ByteBuffer buffer = ByteBuffer.allocate(footerSize);
+        
+        // Write GCM tags
+        for (byte[] tag : gcmTags) {
+            buffer.put(tag);
+        }
+        
+        // Write tag count
+        buffer.putInt(gcmTags.size());
+        
+        // Write frame size
+        buffer.putLong(frameSize);
+        
+        // Write frame count
+        buffer.putInt(frameCount);
+        
+        // Write MessageId
+        buffer.put(messageId);
+        
+        // Write KeyMetadata (empty - using keyfile)
+        buffer.put(keyMetadata);
+        
+        // Write KeyMetadataLength
+        buffer.putShort((short) keyMetadata.length);
+        
+        // Write algorithm ID
+        buffer.putShort(algorithmId);
+        
+        // Write footer length
+        buffer.putInt(footerSize + EncryptionMetadataTrailer.FOOTER_AUTH_TAG_SIZE);
+        
+        // Write magic
+        buffer.put(EncryptionMetadataTrailer.MAGIC);
+        
+        return buffer.array();
+    }
+    
+    public static EncryptionFooter deserialize(byte[] fileBytes, byte[] fileKey) throws IOException {
+        if (fileBytes.length < EncryptionMetadataTrailer.MIN_FOOTER_SIZE) {
+            throw new IOException("Invalid footer size: " + fileBytes.length);
+        }
+        
+        // Extract auth tag from beginning
+        byte[] authTag = Arrays.copyOfRange(fileBytes, 0, EncryptionMetadataTrailer.FOOTER_AUTH_TAG_SIZE);
+        byte[] footerData = Arrays.copyOfRange(fileBytes, EncryptionMetadataTrailer.FOOTER_AUTH_TAG_SIZE, fileBytes.length);
+        
+        // Verify auth tag
+        if (!verifyFooterAuthTag(fileKey, footerData, authTag)) {
+            throw new IOException("Footer authentication failed");
+        }
+        
+        int pos = footerData.length;
+        
+        // Read magic
+        pos -= EncryptionMetadataTrailer.MAGIC.length;
+        byte[] magic = Arrays.copyOfRange(footerData, pos, pos + EncryptionMetadataTrailer.MAGIC.length);
+        if (!Arrays.equals(magic, EncryptionMetadataTrailer.MAGIC)) {
+            throw new IOException("Invalid footer magic");
+        }
+        
+        // Read footer length
+        pos -= EncryptionMetadataTrailer.FOOTER_LENGTH_SIZE;
+        int footerLength = ByteBuffer.wrap(footerData, pos, EncryptionMetadataTrailer.FOOTER_LENGTH_SIZE).getInt();
+        
+        // Read algorithm ID
+        pos -= EncryptionMetadataTrailer.ALGORITHM_ID_SIZE;
+        short algorithmId = ByteBuffer.wrap(footerData, pos, EncryptionMetadataTrailer.ALGORITHM_ID_SIZE).getShort();
+        
+        // Read KeyMetadataLength
+        pos -= EncryptionMetadataTrailer.KEY_METADATA_LENGTH_SIZE;
+        short keyMetadataLength = ByteBuffer.wrap(footerData, pos, EncryptionMetadataTrailer.KEY_METADATA_LENGTH_SIZE).getShort();
+        
+        // Read KeyMetadata (currently empty)
+        pos -= keyMetadataLength;
+        byte[] keyMetadata = Arrays.copyOfRange(footerData, pos, pos + keyMetadataLength);
+        
+        // Read MessageId
+        pos -= EncryptionMetadataTrailer.MESSAGE_ID_SIZE;
+        byte[] messageId = Arrays.copyOfRange(footerData, pos, pos + EncryptionMetadataTrailer.MESSAGE_ID_SIZE);
+        
+        // Read frame count
+        pos -= EncryptionMetadataTrailer.FRAME_COUNT_SIZE;
+        int frameCount = ByteBuffer.wrap(footerData, pos, EncryptionMetadataTrailer.FRAME_COUNT_SIZE).getInt();
+        
+        // Read frame size
+        pos -= EncryptionMetadataTrailer.FRAME_SIZE_SIZE;
+        long frameSize = ByteBuffer.wrap(footerData, pos, EncryptionMetadataTrailer.FRAME_SIZE_SIZE).getLong();
+        
+        // Read tag count
+        pos -= EncryptionMetadataTrailer.TAG_COUNT_SIZE;
+        int tagCount = ByteBuffer.wrap(footerData, pos, EncryptionMetadataTrailer.TAG_COUNT_SIZE).getInt();
+        
+        // Validate footer length
+        int expectedLength = EncryptionMetadataTrailer.MIN_FOOTER_SIZE + (tagCount * AesGcmCipherFactory.GCM_TAG_LENGTH) + keyMetadataLength;
+        if (footerLength != expectedLength) {
+            throw new IOException("Footer length mismatch: expected " + expectedLength + ", got " + footerLength);
+        }
+        
+        // Create footer and read GCM tags
+        EncryptionFooter footer = new EncryptionFooter(messageId, frameSize, algorithmId);
+        footer.frameCount = frameCount;
+        footer.footerAuthTag = authTag;
+        int tagStartPos = footerData.length - (footerLength - EncryptionMetadataTrailer.FOOTER_AUTH_TAG_SIZE);
+        
+        for (int i = 0; i < tagCount; i++) {
+            int tagPos = tagStartPos + (i * AesGcmCipherFactory.GCM_TAG_LENGTH);
+            byte[] tag = Arrays.copyOfRange(footerData, tagPos, tagPos + AesGcmCipherFactory.GCM_TAG_LENGTH);
+            footer.addGcmTag(tag);
+        }
+        
+        return footer;
+    }
+    
+    public static int calculateFooterLength(byte[] footerBytes) throws IOException {
+        if (footerBytes.length < EncryptionMetadataTrailer.MIN_FOOTER_SIZE) {
+            throw new IOException("Footer too small: " + footerBytes.length);
+        }
+        
+        // Read footer length from end: [FooterLength(4)][Magic(4)]
+        int pos = footerBytes.length - EncryptionMetadataTrailer.MAGIC.length - EncryptionMetadataTrailer.FOOTER_LENGTH_SIZE;
+        return ByteBuffer.wrap(footerBytes, pos, EncryptionMetadataTrailer.FOOTER_LENGTH_SIZE).getInt();
+    }
+    
+    public byte[] getMessageId() {
+        return Arrays.copyOf(messageId, EncryptionMetadataTrailer.MESSAGE_ID_SIZE);
+    }
+    
+    public void addGcmTag(byte[] tag) throws IOException {
+        if (tag.length != AesGcmCipherFactory.GCM_TAG_LENGTH) {
+            throw new IOException("Invalid GCM tag length: " + tag.length);
+        }
+        gcmTags.add(Arrays.copyOf(tag, tag.length));
+    }
+    
+    public long getFrameSize() {
+        return frameSize;
+    }
+    
+    public int getFrameCount() {
+        return frameCount;
+    }
+    
+    public void setFrameCount(int frameCount) {
+        this.frameCount = frameCount;
+    }
+    
+    public short getAlgorithmId() {
+        return algorithmId;
+    }
+    
+    public byte[] getKeyMetadata() {
+        return Arrays.copyOf(keyMetadata, keyMetadata.length);
+    }
+    
+    private static byte[] generateFooterAuthTag(byte[] fileKey, byte[] footerData) throws IOException {
+        try {
+            byte[] footerIV = new byte[12];  // GCM uses 12-byte IV
+            Arrays.fill(footerIV, 0, 8, (byte) 0xFF);  // 0xFFFFFFFFFFFFFFFF0000
+            
+            // Use default provider instead of null
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            GCMParameterSpec spec = new GCMParameterSpec(128, footerIV);
+            cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(fileKey, "AES"), spec);
+            
+            // Encrypt empty data to generate auth tag for footerData as AAD
+            cipher.updateAAD(footerData);
+            byte[] result = cipher.doFinal();  // Empty ciphertext + 16-byte tag
+            
+            // Extract the 16-byte GCM tag from the end
+            return Arrays.copyOfRange(result, result.length - 16, result.length);
+        } catch (Exception e) {
+            throw new IOException("Failed to generate footer auth tag", e);
+        }
+    }
+    
+    private static boolean verifyFooterAuthTag(byte[] fileKey, byte[] footerData, byte[] expectedTag) {
+        try {
+            byte[] computedTag = generateFooterAuthTag(fileKey, footerData);
+            return Arrays.equals(computedTag, expectedTag);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/index/store/footer/EncryptionMetadataTrailer.java
+++ b/src/main/java/org/opensearch/index/store/footer/EncryptionMetadataTrailer.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.index.store.footer;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Constants and utilities for encryption metadata footer format.
+ * 
+ * Footer format (read backwards from end of file):
+ * [FooterAuthTag][GCMTagList][FrameCount][FrameSize][MessageId][KeyMetadata][KeyMetadataLength][AlgorithmId][FooterLength][MagicBytes]
+ * 
+ * Features:
+ * - Frame-based encryption to overcome GCM 64GB limit
+ * - HKDF key derivation using MessageId
+ * - Footer authentication to prevent tampering
+ * - Algorithm agility for future evolution
+ * - Variable KeyMetadata for different key providers
+ * 
+ * @opensearch.internal
+ */
+public class EncryptionMetadataTrailer {
+
+    // Magic bytes at the very end for reliable footer detection
+    public static final String ENCRYPTION_MAGIC_STRING = "OSEF"; // OpenSearch Encrypted File
+    public static final byte[] MAGIC = ENCRYPTION_MAGIC_STRING.getBytes(StandardCharsets.UTF_8);
+    
+    // Field sizes in bytes
+    public static final int MESSAGE_ID_SIZE = 16;
+    public static final int TAG_COUNT_SIZE = 4;
+    public static final int FRAME_SIZE_SIZE = 8;
+    public static final int FRAME_COUNT_SIZE = 4;
+    public static final int KEY_METADATA_LENGTH_SIZE = 2;
+    public static final int ALGORITHM_ID_SIZE = 2;
+    public static final int FOOTER_LENGTH_SIZE = 4;
+    public static final int FOOTER_AUTH_TAG_SIZE = 16;
+    public static final int GCM_TAG_SIZE = 16;
+    
+    // Calculated sizes
+    public static final int FIXED_FOOTER_SIZE = MESSAGE_ID_SIZE + KEY_METADATA_LENGTH_SIZE + ALGORITHM_ID_SIZE + FOOTER_LENGTH_SIZE + MAGIC.length;
+    public static final int MIN_FOOTER_SIZE = FIXED_FOOTER_SIZE + TAG_COUNT_SIZE + FRAME_SIZE_SIZE + FRAME_COUNT_SIZE + FOOTER_AUTH_TAG_SIZE;
+    
+    // Frame constants for large file support
+    public static final long DEFAULT_FRAME_SIZE = 64L * 1024 * 1024 * 1024; // 64GB per frame
+    public static final int MAX_FRAMES_PER_FILE = Integer.MAX_VALUE;
+    public static final String FRAME_CONTEXT_PREFIX = "frame-";
+    
+    // Algorithm IDs for future extensibility
+    public static final int ALGORITHM_AES_256_GCM = 1;
+    
+    // Special IV for footer authentication (won't collide with frame IVs)
+    public static final byte[] FOOTER_AUTH_IV = new byte[]{
+        (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF,
+        (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF,
+        (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF,
+        (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF
+    };
+    
+    /**
+     * Calculate total footer size including variable parts
+     * @param frameCount number of frames in the file
+     * @param keyMetadataLength length of key metadata
+     * @return total footer size in bytes
+     */
+    public static int calculateFooterSize(int frameCount, int keyMetadataLength) {
+        return MIN_FOOTER_SIZE + (frameCount * GCM_TAG_SIZE) + keyMetadataLength;
+    }
+}

--- a/src/main/java/org/opensearch/index/store/hybrid/HybridCryptoDirectory.java
+++ b/src/main/java/org/opensearch/index/store/hybrid/HybridCryptoDirectory.java
@@ -18,7 +18,7 @@ import org.apache.lucene.store.IOContext.Context;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.LockFactory;
 import org.opensearch.common.util.io.IOUtils;
-import org.opensearch.index.store.iv.KeyIvResolver;
+import org.opensearch.index.store.key.KeyResolver;
 import org.opensearch.index.store.mmap.EagerDecryptedCryptoMMapDirectory;
 import org.opensearch.index.store.mmap.LazyDecryptedCryptoMMapDirectory;
 import org.opensearch.index.store.niofs.CryptoNIOFSDirectory;
@@ -40,11 +40,11 @@ public class HybridCryptoDirectory extends CryptoNIOFSDirectory {
         LazyDecryptedCryptoMMapDirectory delegate,
         EagerDecryptedCryptoMMapDirectory eagerDecryptedCryptoMMapDirectory1,
         Provider provider,
-        KeyIvResolver keyIvResolver,
+        KeyResolver keyResolver,
         Set<String> nioExtensions
     )
         throws IOException {
-        super(lockFactory, delegate.getDirectory(), provider, keyIvResolver);
+        super(lockFactory, delegate.getDirectory(), provider, keyResolver);
         this.lazyDecryptedCryptoMMapDirectoryDelegate = delegate;
         this.eagerDecryptedCryptoMMapDirectory = eagerDecryptedCryptoMMapDirectory1;
         this.specialExtensions = Set.of("kdd", "kdi", "kdm", "tip", "tim", "tmd", "cfs", "doc", "dvd", "nvd", "psm", "fdm");

--- a/src/main/java/org/opensearch/index/store/key/DefaultKeyResolver.java
+++ b/src/main/java/org/opensearch/index/store/key/DefaultKeyResolver.java
@@ -2,13 +2,11 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.opensearch.index.store.iv;
+package org.opensearch.index.store.key;
 
 import java.io.IOException;
 import java.security.Key;
 import java.security.Provider;
-import java.security.SecureRandom;
-import java.util.Base64;
 
 import javax.crypto.spec.SecretKeySpec;
 
@@ -16,91 +14,61 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
-import org.opensearch.common.Randomness;
 import org.opensearch.common.crypto.DataKeyPair;
 import org.opensearch.common.crypto.MasterKeyProvider;
-import org.opensearch.index.store.cipher.AesCipherFactory;
 
 /**
- * Default implementation of {@link KeyIvResolver} responsible for managing
- * the encryption key and initialization vector (IV) used in encrypting and decrypting
- * Lucene index files.
+ * Default implementation of {@link KeyResolver} responsible for managing
+ * the encryption key used in encrypting and decrypting Lucene index files.
  *
  * Metadata files:
  * - "keyfile" stores the encrypted data key
- * - "ivFile" stores the base64-encoded IV
+ * - IVs are derived using HKDF
  *
  * @opensearch.internal
  */
-public class DefaultKeyIvResolver implements KeyIvResolver {
+public class DefaultKeyResolver implements KeyResolver {
 
     private final Directory directory;
     private final MasterKeyProvider keyProvider;
 
     private Key dataKey;
-    private String iv;
 
-    private static final String IV_FILE = "ivFile";
     private static final String KEY_FILE = "keyfile";
 
     /**
-     * Constructs a new {@link DefaultKeyIvResolver} and ensures the key and IV are initialized.
+     * Constructs a new {@link DefaultKeyResolver} and ensures the key is initialized.
      *
      * @param directory the Lucene directory to read/write metadata files
      * @param provider the JCE provider used for cipher operations
      * @param keyProvider the master key provider used to encrypt/decrypt data keys
-     * @throws IOException if an I/O error occurs while reading or writing key/IV metadata
+     * @throws IOException if an I/O error occurs while reading or writing key metadata
      */
-    public DefaultKeyIvResolver(Directory directory, Provider provider, MasterKeyProvider keyProvider) throws IOException {
+    public DefaultKeyResolver(Directory directory, Provider provider, MasterKeyProvider keyProvider) throws IOException {
         this.directory = directory;
         this.keyProvider = keyProvider;
         initialize();
     }
 
     /**
-     * Attempts to load the IV and encrypted key from the directory.
+     * Attempts to load the encrypted key from the directory.
      * If not present, it generates and persists new values.
      */
     private void initialize() throws IOException {
         try {
-            iv = readStringFile(IV_FILE);
             dataKey = new SecretKeySpec(keyProvider.decryptKey(readByteArrayFile(KEY_FILE)), "AES");
         } catch (java.nio.file.NoSuchFileException e) {
-            initNewKeyAndIv();
+            initNewKey();
         }
     }
 
     /**
-     * Generates a new AES data key and IV (if not present), and writes them to metadata files.
+     * Generates a new AES data key and writes it to metadata file.
      */
-    private void initNewKeyAndIv() throws IOException {
+    private void initNewKey() throws IOException {
         DataKeyPair pair = keyProvider.generateDataPair();
         dataKey = new SecretKeySpec(pair.getRawKey(), "AES");
         writeByteArrayFile(KEY_FILE, pair.getEncryptedKey());
-
-        byte[] ivBytes = new byte[AesCipherFactory.IV_ARRAY_LENGTH];
-        SecureRandom random = Randomness.createSecure();
-        random.nextBytes(ivBytes);
-        iv = Base64.getEncoder().encodeToString(ivBytes);
-        writeStringFile(IV_FILE, iv);
-    }
-
-    /**
-     * Reads a string value from the specified file in the directory.
-     */
-    private String readStringFile(String fileName) throws IOException {
-        try (IndexInput in = directory.openInput(fileName, IOContext.READONCE)) {
-            return in.readString();
-        }
-    }
-
-    /**
-     * Writes a string value to the specified file in the directory.
-     */
-    private void writeStringFile(String fileName, String value) throws IOException {
-        try (IndexOutput out = directory.createOutput(fileName, IOContext.DEFAULT)) {
-            out.writeString(value);
-        }
     }
 
     /**
@@ -131,13 +99,5 @@ public class DefaultKeyIvResolver implements KeyIvResolver {
     @Override
     public Key getDataKey() {
         return dataKey;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public byte[] getIvBytes() {
-        return Base64.getDecoder().decode(iv);
     }
 }

--- a/src/main/java/org/opensearch/index/store/key/HkdfKeyDerivation.java
+++ b/src/main/java/org/opensearch/index/store/key/HkdfKeyDerivation.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.index.store.key;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * HKDF (HMAC-based Key Derivation Function) implementation for deriving keys from MessageId.
+ * Based on RFC 5869: https://tools.ietf.org/html/rfc5869
+ * 
+ * @opensearch.internal
+ */
+public class HkdfKeyDerivation {
+    
+    private static final String HMAC_ALGORITHM = "HmacSHA256";
+    private static final int HASH_LENGTH = 32; // SHA-256 output length
+    
+    /**
+     * Derive a key from Directory Key + MessageId using HKDF
+     * 
+     * @param directoryKey the master key from KeyIvResolver (32 bytes)
+     * @param messageId the unique file identifier (16 bytes from footer)
+     * @param context the context string for key derivation
+     * @param keyLength the desired output key length in bytes
+     * @return derived key bytes
+     */
+    public static byte[] deriveKey(byte[] directoryKey, byte[] messageId, String context, int keyLength) {
+        if (directoryKey == null || directoryKey.length != 32) {
+            throw new IllegalArgumentException("Directory key must be 32 bytes");
+        }
+        if (messageId == null || messageId.length != 16) {
+            throw new IllegalArgumentException("MessageId must be 16 bytes");
+        }
+        if (keyLength <= 0 || keyLength > 255 * HASH_LENGTH) {
+            throw new IllegalArgumentException("Invalid key length: " + keyLength);
+        }
+        
+        try {
+            // HKDF-Extract: PRK = HMAC-Hash(directoryKey, messageId)
+            // Use directory key as salt, messageId as input key material
+            byte[] prk = hmac(directoryKey, messageId);
+            
+            // HKDF-Expand: OKM = HMAC-Hash(PRK, info || counter)
+            byte[] info = context.getBytes(StandardCharsets.UTF_8);
+            return hkdfExpand(prk, info, keyLength);
+            
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new RuntimeException("HKDF key derivation failed", e);
+        }
+    }
+    
+    /**
+     * Convenience method for deriving AES-256 keys (32 bytes)
+     */
+    public static byte[] deriveAesKey(byte[] directoryKey, byte[] messageId, String context) {
+        return deriveKey(directoryKey, messageId, context, 32);
+    }
+    
+    private static byte[] hmac(byte[] key, byte[] data) throws NoSuchAlgorithmException, InvalidKeyException {
+        Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+        mac.init(new SecretKeySpec(key, HMAC_ALGORITHM));
+        return mac.doFinal(data);
+    }
+    
+    private static byte[] hkdfExpand(byte[] prk, byte[] info, int length) throws NoSuchAlgorithmException, InvalidKeyException {
+        int n = (length + HASH_LENGTH - 1) / HASH_LENGTH; // Ceiling division
+        byte[] okm = new byte[length];
+        byte[] t = new byte[0];
+        
+        for (int i = 1; i <= n; i++) {
+            Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+            mac.init(new SecretKeySpec(prk, HMAC_ALGORITHM));
+            mac.update(t);
+            mac.update(info);
+            mac.update((byte) i);
+            t = mac.doFinal();
+            
+            int copyLength = Math.min(HASH_LENGTH, length - (i - 1) * HASH_LENGTH);
+            System.arraycopy(t, 0, okm, (i - 1) * HASH_LENGTH, copyLength);
+        }
+        
+        return okm;
+    }
+}

--- a/src/main/java/org/opensearch/index/store/key/KeyResolver.java
+++ b/src/main/java/org/opensearch/index/store/key/KeyResolver.java
@@ -2,7 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.opensearch.index.store.iv;
+package org.opensearch.index.store.key;
 
 import java.security.Key;
 
@@ -15,7 +15,7 @@ import java.security.Key;
  *
  * @opensearch.internal
  */
-public interface KeyIvResolver {
+public interface KeyResolver {
 
     /**
      * Returns the symmetric encryption key used for cipher operations.
@@ -23,12 +23,4 @@ public interface KeyIvResolver {
      * @return the decrypted symmetric {@link Key}, typically AES
      */
     Key getDataKey();
-
-    /**
-     * Returns the raw initialization vector (IV) used with the cipher.
-     * The IV should typically be 12 or 16 bytes, depending on the encryption mode.
-     *
-     * @return the IV as a byte array
-     */
-    byte[] getIvBytes();
 }

--- a/src/main/java/org/opensearch/index/store/mmap/EagerDecryptedCryptoMMapDirectory.java
+++ b/src/main/java/org/opensearch/index/store/mmap/EagerDecryptedCryptoMMapDirectory.java
@@ -9,7 +9,6 @@ import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.security.Provider;
@@ -24,19 +23,85 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.MMapDirectory;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.index.store.cipher.OpenSslNativeCipher;
-import org.opensearch.index.store.iv.KeyIvResolver;
+import org.opensearch.index.store.key.HkdfKeyDerivation;
+import org.opensearch.index.store.key.KeyResolver;
+import org.opensearch.index.store.footer.EncryptionFooter;
+import org.opensearch.index.store.footer.EncryptionMetadataTrailer;
+import org.opensearch.index.store.cipher.EncryptionAlgorithm;
+import java.nio.ByteBuffer;
 
 @SuppressWarnings("preview")
 @SuppressForbidden(reason = "temporary bypass")
 public final class EagerDecryptedCryptoMMapDirectory extends MMapDirectory {
     private static final Logger LOGGER = LogManager.getLogger(EagerDecryptedCryptoMMapDirectory.class);
 
-    private final KeyIvResolver keyIvResolver;
+    private final KeyResolver keyResolver;
 
-    public EagerDecryptedCryptoMMapDirectory(Path path, Provider provider, KeyIvResolver keyIvResolver) throws IOException {
+    public EagerDecryptedCryptoMMapDirectory(Path path, Provider provider, KeyResolver keyResolver) throws IOException {
         super(path);
-        this.keyIvResolver = keyIvResolver;
+        this.keyResolver = keyResolver;
     }
+    
+    /**
+     * Footer information extracted from encrypted file
+     */
+    private static class FooterInfo {
+        final byte[] messageId;
+        final long frameSize;
+        final EncryptionAlgorithm algorithm;
+        final long contentLength; // File size excluding footer
+        
+        FooterInfo(byte[] messageId, long frameSize, EncryptionAlgorithm algorithm, long contentLength) {
+            this.messageId = messageId;
+            this.frameSize = frameSize;
+            this.algorithm = algorithm;
+            this.contentLength = contentLength;
+        }
+    }
+    
+    /**
+     * Read footer from FileChannel and return footer information
+     */
+    private FooterInfo readFooterInfo(FileChannel channel, byte[] directoryKey) throws IOException {
+        long fileSize = channel.size();
+        if (fileSize < EncryptionMetadataTrailer.MIN_FOOTER_SIZE) {
+            throw new IOException("File too small to contain encryption footer");
+        }
+        
+        // Read minimum footer to get actual length
+        ByteBuffer minBuffer = ByteBuffer.allocate(EncryptionMetadataTrailer.MIN_FOOTER_SIZE);
+        channel.read(minBuffer, fileSize - EncryptionMetadataTrailer.MIN_FOOTER_SIZE);
+        
+        int footerLength = EncryptionFooter.calculateFooterLength(minBuffer.array());
+        
+        // Read complete footer
+        ByteBuffer footerBuffer = ByteBuffer.allocate(footerLength);
+        int bytesRead = channel.read(footerBuffer, fileSize - footerLength);
+        
+        if (bytesRead != footerLength) {
+            throw new IOException("Failed to read complete footer");
+        }
+        
+        // Deserialize footer using directory key
+        EncryptionFooter footer = EncryptionFooter.deserialize(footerBuffer.array(), directoryKey);
+        
+        return new FooterInfo(
+            footer.getMessageId(),
+            footer.getFrameSize(),
+            EncryptionAlgorithm.fromId(footer.getAlgorithmId()),
+            fileSize - footerLength
+        );
+    }
+    
+//    /**
+//     * Check if file should be encrypted (excludes segments, si files, etc.)
+//     */
+//    private boolean isNonEncryptedFile(String fileName) {
+//        return fileName.contains("segments_") ||
+//               fileName.endsWith(".si") ||
+//               fileName.equals("keyfile") ||
+//               fileName.endsWith(".lock");
+//    }
 
     /**
      * Sets the preload predicate based on file extension list.
@@ -71,7 +136,12 @@ public final class EagerDecryptedCryptoMMapDirectory extends MMapDirectory {
         ensureCanRead(name);
 
         Path file = getDirectory().resolve(name);
-        long size = Files.size(file);
+        
+        // Skip footer processing for non-encrypted files
+        if (name.contains("segments_") || name.endsWith(".si")) {
+            return super.openInput(name, context);
+        }
+        
         boolean confined = context == IOContext.READONCE;
         Arena arena = confined ? Arena.ofConfined() : Arena.ofShared();
 
@@ -80,11 +150,15 @@ public final class EagerDecryptedCryptoMMapDirectory extends MMapDirectory {
         boolean success = false;
 
         try (var fc = FileChannel.open(file, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
-            final long fileSize = fc.size();
-            MemorySegment[] segments = mmapAndDecrypt(fc, fileSize, arena, chunkSizePower, name, context);
+            // Read footer information
+            byte[] directoryKey = keyResolver.getDataKey().getEncoded();
+            FooterInfo footerInfo = readFooterInfo(fc, directoryKey);
+            
+            // Map and decrypt only the content (excluding footer)
+            MemorySegment[] segments = mmapAndDecrypt(fc, footerInfo.contentLength, arena, chunkSizePower, name, context, footerInfo);
 
             final IndexInput in = MemorySegmentIndexInput
-                .newInstance("CryptoMemorySegmentIndexInput(path=\"" + file + "\")", arena, segments, size, chunkSizePower);
+                .newInstance("CryptoMemorySegmentIndexInput(path=\"" + file + "\")", arena, segments, footerInfo.contentLength, chunkSizePower);
             success = true;
             return in;
         } catch (Throwable ex) {
@@ -96,7 +170,7 @@ public final class EagerDecryptedCryptoMMapDirectory extends MMapDirectory {
         }
     }
 
-    private MemorySegment[] mmapAndDecrypt(FileChannel fc, long size, Arena arena, int chunkSizePower, String name, IOContext context)
+    private MemorySegment[] mmapAndDecrypt(FileChannel fc, long size, Arena arena, int chunkSizePower, String name, IOContext context, FooterInfo footerInfo)
         throws Throwable {
         final long chunkSize = 1L << chunkSizePower;
         final int numSegments = (int) ((size + chunkSize - 1) >>> chunkSizePower);
@@ -122,7 +196,7 @@ public final class EagerDecryptedCryptoMMapDirectory extends MMapDirectory {
                 LOGGER.warn("madvise MADV_WILLNEED failed for file {} with IOcontext {}", name, context, t);
             }
 
-            decryptSegment(arena, mmapSegment, offset);
+            decryptSegment(arena, mmapSegment, offset, footerInfo);
 
             segments[i] = mmapSegment;
             offset += segmentSize;
@@ -131,7 +205,7 @@ public final class EagerDecryptedCryptoMMapDirectory extends MMapDirectory {
         return segments;
     }
 
-    public void decryptSegment(Arena arena, MemorySegment segment, long segmentOffsetInFile) throws Throwable {
+    public void decryptSegment(Arena arena, MemorySegment segment, long segmentOffsetInFile, FooterInfo footerInfo) throws Throwable {
         final long size = segment.byteSize();
 
         final int twoMB = 1 << 21; // 2 MiB
@@ -139,22 +213,23 @@ public final class EagerDecryptedCryptoMMapDirectory extends MMapDirectory {
         final int eightMB = 1 << 23; // 8 MiB
         final int sixteenMB = 1 << 24; // 16 MiB
 
-        final byte[] key = this.keyIvResolver.getDataKey().getEncoded();
-        final byte[] iv = this.keyIvResolver.getIvBytes();
+        // Use frame-based decryption
+        final byte[] directoryKey = this.keyResolver.getDataKey().getEncoded();
+        final byte[] fileKey = HkdfKeyDerivation.deriveAesKey(directoryKey, footerInfo.messageId, "file-encryption");
 
         // Fast-path: no parallelism for ≤ 4 MiB
         if (size <= (4L << 20)) {
             long start = System.nanoTime();
 
-            OpenSslNativeCipher.decryptInPlace(arena, segment.address(), size, key, iv, segmentOffsetInFile);
+            OpenSslNativeCipher.decryptInPlaceFrameBased(arena, segment.address(), size, fileKey, directoryKey, footerInfo.messageId, footerInfo.frameSize, segmentOffsetInFile);
 
             long end = System.nanoTime();
             long durationMs = (end - start) / 1_000_000;
-            LOGGER.debug("Egar decryption of {} MiB at offset {} took {} ms", size / 1048576.0, segmentOffsetInFile, durationMs);
+            LOGGER.debug("Eager frame-based decryption of {} MiB at offset {} took {} ms", size / 1048576.0, segmentOffsetInFile, durationMs);
             return;
         }
 
-        // Use Openssl for large block decrytion.
+        // Use Openssl for large block decryption with frame support
         final int chunkSize;
         if (size <= (8L << 20)) {
             chunkSize = twoMB;
@@ -168,7 +243,7 @@ public final class EagerDecryptedCryptoMMapDirectory extends MMapDirectory {
 
         final int numChunks = (int) ((size + chunkSize - 1) / chunkSize);
 
-        // parallel decryptions.
+        // parallel decryptions with frame-based approach
         IntStream.range(0, numChunks).parallel().forEach(i -> {
             long offset = (long) i * chunkSize;
             long length = Math.min(chunkSize, size - offset);
@@ -176,9 +251,9 @@ public final class EagerDecryptedCryptoMMapDirectory extends MMapDirectory {
             long addr = segment.address() + offset;
 
             try {
-                OpenSslNativeCipher.decryptInPlace(addr, length, key, iv, fileOffset);
+                OpenSslNativeCipher.decryptInPlaceFrameBased(addr, length, fileKey, directoryKey, footerInfo.messageId, footerInfo.frameSize, fileOffset);
             } catch (Throwable t) {
-                throw new RuntimeException("Decryption failed at offset: " + fileOffset, t);
+                throw new RuntimeException("Frame-based decryption failed at offset: " + fileOffset, t);
             }
         });
     }

--- a/src/main/java/org/opensearch/index/store/mmap/LazyDecryptedMemorySegmentIndexInput.java
+++ b/src/main/java/org/opensearch/index/store/mmap/LazyDecryptedMemorySegmentIndexInput.java
@@ -24,6 +24,7 @@ import org.apache.lucene.util.ArrayUtil;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.index.store.cipher.MemorySegmentDecryptor;
 import org.opensearch.index.store.concurrency.AtomicBitSet;
+import org.opensearch.index.store.key.HkdfKeyDerivation;
 
 @SuppressForbidden(reason = "temporary bypass")
 @SuppressWarnings("preview")
@@ -42,8 +43,11 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
     final int chunkSizePower;
     final Arena arena;
     final MemorySegment[] segments;
-    final byte[] key;
-    final byte[] iv;
+    final byte[] fileKey;
+    final byte[] messageId;
+    final long frameSize;
+    final short algorithmId;
+    final byte[] directoryKey;
     final AtomicBitSet decryptedPages;
     final AtomicBitSet inProgressPages;
     final String resourceDescription;
@@ -59,9 +63,13 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
         MemorySegment[] segments,
         long resourceLength,
         int chunkSizePower,
-        byte[] key,
-        byte[] iv
+        byte[] messageId,
+        long frameSize,
+        short algorithmId,
+        byte[] directoryKey
     ) {
+        // Derive file-specific key from directory key and messageId
+        byte[] fileKey = HkdfKeyDerivation.deriveAesKey(directoryKey, messageId, "file-encryption");
 
         long totalPages = (resourceLength + PanamaNativeAccess.getPageSize() - 1) / PanamaNativeAccess.getPageSize();
         AtomicBitSet decryptedPages = new AtomicBitSet(totalPages);
@@ -76,8 +84,11 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                 segments[0],
                 resourceLength,
                 chunkSizePower,
-                key,
-                iv,
+                fileKey,
+                messageId,
+                frameSize,
+                algorithmId,
+                directoryKey,
                 decryptedPages,
                 inProgressPages,
                 0L
@@ -90,8 +101,11 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                 0,
                 resourceLength,
                 chunkSizePower,
-                key,
-                iv,
+                fileKey,
+                messageId,
+                frameSize,
+                algorithmId,
+                directoryKey,
                 decryptedPages,
                 inProgressPages,
                 0L
@@ -106,8 +120,11 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
         MemorySegment[] segments,
         long resourceLength,
         int chunkSizePower,
-        byte[] key,
-        byte[] iv,
+        byte[] fileKey,
+        byte[] messageId,
+        long frameSize,
+        short algorithmId,
+        byte[] directoryKey,
         AtomicBitSet decryptedPages,
         AtomicBitSet inProgressPages,
         long decryptionBaseOffset
@@ -119,8 +136,11 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
         this.chunkSizePower = chunkSizePower;
         this.chunkSizeMask = (1L << chunkSizePower) - 1L;
         this.curSegment = segments[0];
-        this.key = key;
-        this.iv = iv;
+        this.fileKey = fileKey;
+        this.messageId = messageId;
+        this.frameSize = frameSize;
+        this.algorithmId = algorithmId;
+        this.directoryKey = directoryKey;
         this.decryptedPages = decryptedPages;
         this.inProgressPages = inProgressPages;
         this.resourceDescription = resourceDescription;
@@ -251,6 +271,105 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
 
     }
 
+    private static void decryptAndProtectFrameBased(
+        String resourceDescription,
+        long resourceLength,
+        AtomicBitSet decryptedPages,
+        AtomicBitSet inProgressPages,
+        long addr,
+        long length,
+        long fileOffset,
+        byte[] fileKey,
+        byte[] directoryKey,
+        byte[] messageId,
+        long frameSize
+    ) throws IOException {
+
+        if (length == 0) {
+            return;
+        }
+
+        int osPageSize = PanamaNativeAccess.getPageSize();
+        long alignedAddr = addr & ~(osPageSize - 1);
+        long requestEnd = addr + length;
+        long alignedEnd = ((requestEnd + osPageSize - 1) & ~(osPageSize - 1));
+        long baseFileOffset = fileOffset - (addr - alignedAddr);
+
+        long currentPageAddr = alignedAddr;
+
+        int pageCount = 0;
+        long startTime = System.nanoTime();
+
+        while (currentPageAddr < alignedEnd) {
+            long pageFileOffset = baseFileOffset + (currentPageAddr - alignedAddr);
+            long pageFileKey = pageFileOffset & ~(osPageSize - 1);
+            long pageNum = pageFileKey / osPageSize;
+
+            // Skip if already decrypted
+            if (decryptedPages.get(pageNum)) {
+                currentPageAddr += osPageSize;
+                continue;
+            }
+
+            // Found a non decrypted page - start collecting contiguous batch
+            long batchStartAddr = currentPageAddr;
+            long batchStartFileOffset = pageFileOffset;
+            List<Long> batchPageNumbers = new ArrayList<>();
+
+            // Inner while loop: collect all contiguous unencrypted pages
+            while (currentPageAddr < alignedEnd) {
+                pageFileOffset = baseFileOffset + (currentPageAddr - alignedAddr);
+                pageFileKey = pageFileOffset & ~(osPageSize - 1);
+                pageNum = pageFileKey / osPageSize;
+
+                if (decryptedPages.get(pageNum))
+                    break;
+                if (inProgressPages.getAndSet(pageNum))
+                    break;
+
+                batchPageNumbers.add(pageNum);
+                currentPageAddr += osPageSize;
+            }
+
+            if (batchPageNumbers.isEmpty())
+                continue;
+            // Decrypt the entire batch at once
+            long batchSize = batchPageNumbers.size() * osPageSize;
+
+            try {
+                // Use frame-based decryption
+                MemorySegmentDecryptor.decryptInPlaceFrameBased(batchStartAddr, batchSize, fileKey, directoryKey, messageId, frameSize, batchStartFileOffset);
+
+                // Mark all pages as decrypted
+                for (Long page : batchPageNumbers) {
+                    decryptedPages.getAndSet(page);
+                }
+            } catch (Exception e) {
+                throw new IOException(e);
+            } finally {
+                // Release all claimed pages
+                for (Long page : batchPageNumbers) {
+                    inProgressPages.clear(page);
+                }
+            }
+
+            pageCount += batchPageNumbers.size();
+        }
+
+        long endTime = System.nanoTime();
+        long durationMicros = (endTime - startTime) / 1_000;
+
+        LOGGER
+            .debug(
+                "Lazy frame-based decryption {} of files (size: {} MB) slice length {} bytes: pages touched {}, took {} us",
+                resourceDescription,
+                resourceLength / 1_048_576.0,
+                length,
+                pageCount,
+                durationMicros
+            );
+    }
+    
     private static void decryptAndProtect(
         String resourceDescription,
         long resourceLength,
@@ -383,7 +502,7 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
             long addr = curSegment.address() + curPosition;
             long fileOffset = getDecryptionOffset();
 
-            decryptAndProtect(
+            decryptAndProtectFrameBased(
                 this.resourceDescription,
                 this.resourceLength,
                 this.decryptedPages,
@@ -391,8 +510,10 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                 addr,
                 1,
                 fileOffset,
-                this.key,
-                this.iv
+                this.fileKey,
+                this.directoryKey,
+                this.messageId,
+                this.frameSize
             );
 
             final byte v = curSegment.get(LAYOUT_BYTE, curPosition);
@@ -413,7 +534,7 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                 long addr = curSegment.address() + curPosition;
                 long fileOffset = getDecryptionOffset();
 
-                decryptAndProtect(
+                decryptAndProtectFrameBased(
                     this.resourceDescription,
                     this.resourceLength,
                     this.decryptedPages,
@@ -421,8 +542,10 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                     addr,
                     1,
                     fileOffset,
-                    this.key,
-                    this.iv
+                    this.fileKey,
+                    this.directoryKey,
+                    this.messageId,
+                    this.frameSize
                 );
 
                 final byte v = curSegment.get(LAYOUT_BYTE, curPosition);
@@ -447,7 +570,7 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
             long fileOffset = getDecryptionOffset();
 
             // Decrypt the entire region we're about to read
-            decryptAndProtect(
+            decryptAndProtectFrameBased(
                 this.resourceDescription,
                 this.resourceLength,
                 this.decryptedPages,
@@ -455,9 +578,10 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                 addr,
                 len,
                 fileOffset,
-                this.key,
-                this.iv
-
+                this.fileKey,
+                this.directoryKey,
+                this.messageId,
+                this.frameSize
             );
 
             MemorySegment.copy(curSegment, LAYOUT_BYTE, curPosition, b, offset, len);
@@ -479,7 +603,7 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
             while (len > curAvail) {
                 long addr = curSegment.address() + curPosition;
                 long fileOffset = startFileOffset + (originalLen - len); // Calculate relative offset
-                decryptAndProtect(
+                decryptAndProtectFrameBased(
                     this.resourceDescription,
                     this.resourceLength,
                     this.decryptedPages,
@@ -487,9 +611,10 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                     addr,
                     curAvail,
                     fileOffset,
-                    this.key,
-                    this.iv
-
+                    this.fileKey,
+                    this.directoryKey,
+                    this.messageId,
+                    this.frameSize
                 );
                 MemorySegment.copy(curSegment, LAYOUT_BYTE, curPosition, b, offset, (int) curAvail);
                 len -= curAvail;
@@ -505,7 +630,7 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
 
             long addr = curSegment.address() + curPosition;
             long fileOffset = startFileOffset + (originalLen - len);
-            decryptAndProtect(
+            decryptAndProtectFrameBased(
                 this.resourceDescription,
                 this.resourceLength,
                 this.decryptedPages,
@@ -513,9 +638,10 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                 addr,
                 len,
                 fileOffset,
-                this.key,
-                this.iv
-
+                this.fileKey,
+                this.directoryKey,
+                this.messageId,
+                this.frameSize
             );
             MemorySegment.copy(curSegment, LAYOUT_BYTE, curPosition, b, offset, len);
             curPosition += len;
@@ -536,7 +662,7 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
         if (currentSegmentRemaining > 0) {
             long addr = curSegment.address() + curPosition;
             long fileOffset = getDecryptionOffset(); // CHANGE: Use getDecryptionOffset()
-            decryptAndProtect(
+            decryptAndProtectFrameBased(
                 this.resourceDescription,
                 this.resourceLength,
                 this.decryptedPages,
@@ -544,8 +670,10 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                 addr,
                 currentSegmentRemaining,
                 fileOffset,
-                this.key,
-                this.iv
+                this.fileKey,
+                this.directoryKey,
+                this.messageId,
+                this.frameSize
             );
         }
 
@@ -555,7 +683,7 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
             long addr = nextSegment.address();
             // CHANGE: Calculate absolute file offset for next segment
             long fileOffset = decryptionBaseOffset + ((long) (curSegmentIndex + 1) << chunkSizePower);
-            decryptAndProtect(
+            decryptAndProtectFrameBased(
                 this.resourceDescription,
                 this.resourceLength,
                 this.decryptedPages,
@@ -563,8 +691,10 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                 addr,
                 nextSegment.byteSize(),
                 fileOffset,
-                this.key,
-                this.iv
+                this.fileKey,
+                this.directoryKey,
+                this.messageId,
+                this.frameSize
             );
         }
     }
@@ -577,7 +707,7 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
             long addr = curSegment.address() + curPosition;
             long fileOffset = getDecryptionOffset();
 
-            decryptAndProtect(
+            decryptAndProtectFrameBased(
                 this.resourceDescription,
                 this.resourceLength,
                 this.decryptedPages,
@@ -585,9 +715,10 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                 addr,
                 totalBytes,
                 fileOffset,
-                this.key,
-                this.iv
-
+                this.fileKey,
+                this.directoryKey,
+                this.messageId,
+                this.frameSize
             );
 
             MemorySegment.copy(curSegment, LAYOUT_LE_INT, curPosition, dst, offset, length);
@@ -610,7 +741,7 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
             long addr = curSegment.address() + curPosition;
             long fileOffset = getDecryptionOffset();
 
-            decryptAndProtect(
+            decryptAndProtectFrameBased(
                 this.resourceDescription,
                 this.resourceLength,
                 this.decryptedPages,
@@ -618,9 +749,10 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                 addr,
                 totalBytes,
                 fileOffset,
-                this.key,
-                this.iv
-
+                this.fileKey,
+                this.directoryKey,
+                this.messageId,
+                this.frameSize
             );
 
             MemorySegment.copy(curSegment, LAYOUT_LE_LONG, curPosition, dst, offset, length);
@@ -642,7 +774,7 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
             long addr = curSegment.address() + curPosition;
             long fileOffset = getDecryptionOffset();
 
-            decryptAndProtect(
+            decryptAndProtectFrameBased(
                 this.resourceDescription,
                 this.resourceLength,
                 this.decryptedPages,
@@ -650,9 +782,10 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                 addr,
                 totalBytes,
                 fileOffset,
-                this.key,
-                this.iv
-
+                this.fileKey,
+                this.directoryKey,
+                this.messageId,
+                this.frameSize
             );
 
             MemorySegment.copy(curSegment, LAYOUT_LE_FLOAT, curPosition, dst, offset, length);
@@ -673,7 +806,7 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
             long addr = curSegment.address() + curPosition;
             long fileOffset = getDecryptionOffset();
 
-            decryptAndProtect(
+            decryptAndProtectFrameBased(
                 this.resourceDescription,
                 this.resourceLength,
                 this.decryptedPages,
@@ -681,9 +814,10 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                 addr,
                 Short.BYTES,
                 fileOffset,
-                this.key,
-                this.iv
-
+                this.fileKey,
+                this.directoryKey,
+                this.messageId,
+                this.frameSize
             );
 
             final short v = curSegment.get(LAYOUT_LE_SHORT, curPosition);
@@ -703,7 +837,7 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
             long addr = curSegment.address() + curPosition;
             long fileOffset = getDecryptionOffset();
 
-            decryptAndProtect(
+            decryptAndProtectFrameBased(
                 this.resourceDescription,
                 this.resourceLength,
                 this.decryptedPages,
@@ -711,9 +845,10 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                 addr,
                 Integer.BYTES,
                 fileOffset,
-                this.key,
-                this.iv
-
+                this.fileKey,
+                this.directoryKey,
+                this.messageId,
+                this.frameSize
             );
 
             final int v = curSegment.get(LAYOUT_LE_INT, curPosition);
@@ -733,7 +868,7 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
             long addr = curSegment.address() + curPosition;
             long fileOffset = getDecryptionOffset();
 
-            decryptAndProtect(
+            decryptAndProtectFrameBased(
                 this.resourceDescription,
                 this.resourceLength,
                 this.decryptedPages,
@@ -741,9 +876,10 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                 addr,
                 Long.BYTES,
                 fileOffset,
-                this.key,
-                this.iv
-
+                this.fileKey,
+                this.directoryKey,
+                this.messageId,
+                this.frameSize
             );
 
             final long v = curSegment.get(LAYOUT_LE_LONG, curPosition);
@@ -790,18 +926,18 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
             // Calculate address and decrypt the single byte
             long addr = segments[si].address() + segmentOffset;
             long fileOffset = getDecryptionOffset(pos);
-            decryptAndProtect(
+            decryptAndProtectFrameBased(
                 this.resourceDescription,
                 this.resourceLength,
-
                 this.decryptedPages,
                 this.inProgressPages,
                 addr,
                 1,
                 fileOffset,
-                this.key,
-                this.iv
-
+                this.fileKey,
+                this.directoryKey,
+                this.messageId,
+                this.frameSize
             );
 
             return segments[si].get(LAYOUT_BYTE, segmentOffset);
@@ -837,7 +973,7 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
             // Calculate address and decrypt the 2 bytes for short
             long addr = segments[si].address() + segmentOffset;
             long fileOffset = getDecryptionOffset(pos);
-            decryptAndProtect(
+            decryptAndProtectFrameBased(
                 this.resourceDescription,
                 this.resourceLength,
                 this.decryptedPages,
@@ -845,8 +981,10 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                 addr,
                 2,
                 fileOffset,
-                this.key,
-                this.iv
+                this.fileKey,
+                this.directoryKey,
+                this.messageId,
+                this.frameSize
             );
 
             return segments[si].get(LAYOUT_LE_SHORT, segmentOffset);
@@ -870,7 +1008,7 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
             long addr = segments[si].address() + segmentOffset;
             long fileOffset = getDecryptionOffset(pos);
 
-            decryptAndProtect(
+            decryptAndProtectFrameBased(
                 this.resourceDescription,
                 this.resourceLength,
                 this.decryptedPages,
@@ -878,8 +1016,10 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                 addr,
                 Integer.BYTES,
                 fileOffset,
-                this.key,
-                this.iv
+                this.fileKey,
+                this.directoryKey,
+                this.messageId,
+                this.frameSize
             );
 
             return segments[si].get(LAYOUT_LE_INT, segmentOffset);
@@ -904,7 +1044,7 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
             long addr = segments[si].address() + segmentOffset;
             long fileOffset = getDecryptionOffset(pos);
 
-            decryptAndProtect(
+            decryptAndProtectFrameBased(
                 this.resourceDescription,
                 this.resourceLength,
                 this.decryptedPages,
@@ -912,8 +1052,10 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                 addr,
                 Long.BYTES,
                 fileOffset,
-                this.key,
-                this.iv
+                this.fileKey,
+                this.directoryKey,
+                this.messageId,
+                this.frameSize
             );
 
             return segments[si].get(LAYOUT_LE_LONG, segmentOffset);
@@ -1013,8 +1155,11 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                 slices[0].asSlice(segmentOffset, length),
                 length,
                 chunkSizePower,
-                key,
-                iv,
+                fileKey,
+                messageId,
+                frameSize,
+                algorithmId,
+                directoryKey,
                 this.decryptedPages,
                 this.inProgressPages,
                 sliceAbsoluteOffset  // must pass the absolute file offset
@@ -1027,8 +1172,11 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                 segmentOffset,  // this is the offset within the first segment
                 length,
                 chunkSizePower,
-                key,
-                iv,
+                fileKey,
+                messageId,
+                frameSize,
+                algorithmId,
+                directoryKey,
                 this.decryptedPages,
                 this.inProgressPages,
                 sliceAbsoluteOffset  // Pass the absolute file offset
@@ -1074,8 +1222,11 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
             MemorySegment segment,
             long length,
             int chunkSizePower,
-            byte[] key,
-            byte[] iv,
+            byte[] fileKey,
+            byte[] messageId,
+            long frameSize,
+            short algorithmId,
+            byte[] directoryKey,
             AtomicBitSet decryptedPages,
             AtomicBitSet inProgressPages,
             long decryptionBaseOffset
@@ -1086,8 +1237,11 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                 new MemorySegment[] { segment },
                 length,
                 chunkSizePower,
-                key,
-                iv,
+                fileKey,
+                messageId,
+                frameSize,
+                algorithmId,
+                directoryKey,
                 decryptedPages,
                 inProgressPages,
                 decryptionBaseOffset
@@ -1116,7 +1270,7 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
             try {
                 // For single segment, pos is the absolute file position
                 long addr = curSegment.address() + pos;
-                decryptAndProtect(
+                decryptAndProtectFrameBased(
                     resourceDescription,
                     resourceLength,
                     decryptedPages,
@@ -1124,8 +1278,10 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                     addr,
                     1,
                     getDecryptionOffset(pos),
-                    key,
-                    iv
+                    fileKey,
+                    directoryKey,
+                    messageId,
+                    frameSize
                 );
 
                 return curSegment.get(LAYOUT_BYTE, pos);
@@ -1141,7 +1297,7 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
             try {
                 // Decrypt 2 bytes for short
                 long addr = curSegment.address() + pos;
-                decryptAndProtect(
+                decryptAndProtectFrameBased(
                     resourceDescription,
                     resourceLength,
                     decryptedPages,
@@ -1149,8 +1305,10 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                     addr,
                     2,
                     getDecryptionOffset(pos),
-                    key,
-                    iv
+                    fileKey,
+                    directoryKey,
+                    messageId,
+                    frameSize
                 );
 
                 return curSegment.get(LAYOUT_LE_SHORT, pos);
@@ -1166,7 +1324,7 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
             try {
                 // Decrypt 4 bytes for int
                 long addr = curSegment.address() + pos;
-                decryptAndProtect(
+                decryptAndProtectFrameBased(
                     resourceDescription,
                     resourceLength,
                     decryptedPages,
@@ -1174,8 +1332,10 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                     addr,
                     4,
                     getDecryptionOffset(pos),
-                    key,
-                    iv
+                    fileKey,
+                    directoryKey,
+                    messageId,
+                    frameSize
                 );
 
                 return curSegment.get(LAYOUT_LE_INT, pos);
@@ -1193,7 +1353,7 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
             try {
                 // Decrypt 8 bytes for long
                 long addr = curSegment.address() + pos;
-                decryptAndProtect(
+                decryptAndProtectFrameBased(
                     resourceDescription,
                     resourceLength,
                     decryptedPages,
@@ -1201,8 +1361,10 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                     addr,
                     8,
                     getDecryptionOffset(pos),
-                    key,
-                    iv
+                    fileKey,
+                    directoryKey,
+                    messageId,
+                    frameSize
                 );
 
                 return curSegment.get(LAYOUT_LE_LONG, pos);
@@ -1231,8 +1393,11 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
             long offset,
             long length,
             int chunkSizePower,
-            byte[] key,
-            byte[] iv,
+            byte[] fileKey,
+            byte[] messageId,
+            long frameSize,
+            short algorithmId,
+            byte[] directoryKey,
             AtomicBitSet decryptedPages,
             AtomicBitSet inProgressPages,
             long decryptionBaseOffset
@@ -1243,8 +1408,11 @@ public class LazyDecryptedMemorySegmentIndexInput extends IndexInput implements 
                 segments,
                 length,
                 chunkSizePower,
-                key,
-                iv,
+                fileKey,
+                messageId,
+                frameSize,
+                algorithmId,
+                directoryKey,
                 decryptedPages,
                 inProgressPages,
                 decryptionBaseOffset

--- a/src/main/java/org/opensearch/index/store/niofs/CryptoBufferedIndexInput.java
+++ b/src/main/java/org/opensearch/index/store/niofs/CryptoBufferedIndexInput.java
@@ -25,7 +25,11 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.index.store.cipher.AesCipherFactory;
-import org.opensearch.index.store.iv.KeyIvResolver;
+import org.opensearch.index.store.cipher.EncryptionAlgorithm;
+import org.opensearch.index.store.footer.EncryptionFooter;
+import org.opensearch.index.store.footer.EncryptionMetadataTrailer;
+import org.opensearch.index.store.key.HkdfKeyDerivation;
+import org.opensearch.index.store.key.KeyResolver;
 
 /**
  * An IndexInput implementation that decrypts data for reading
@@ -41,22 +45,45 @@ final class CryptoBufferedIndexInput extends BufferedIndexInput {
     private final boolean isClone;
     private final long off;
     private final long end;
-    private final KeyIvResolver keyResolver;
+    private final KeyResolver keyResolver;
     private final SecretKeySpec keySpec;
+    private final byte[] directoryKey;
+    private final byte[] messageId;
+    private final int footerLength;
+    private final long frameSize;
+    private final EncryptionAlgorithm algorithm;
 
     private ByteBuffer tmpBuffer = EMPTY_BYTEBUFFER;
 
-    public CryptoBufferedIndexInput(String resourceDesc, FileChannel fc, IOContext context, KeyIvResolver keyResolver) throws IOException {
+    public CryptoBufferedIndexInput(String resourceDesc, FileChannel fc, IOContext context, KeyResolver keyResolver) throws IOException {
         super(resourceDesc, context);
         this.channel = fc;
         this.off = 0L;
         this.end = fc.size();
         this.keyResolver = keyResolver;
-        this.keySpec = new SecretKeySpec(keyResolver.getDataKey().getEncoded(), ALGORITHM);
         this.isClone = false;
+        
+        // Get directory key first
+        this.directoryKey = keyResolver.getDataKey().getEncoded();
+        
+        // Read footer with temporary key for authentication
+        EncryptionFooter footer = readFooterFromFile();
+        this.messageId = footer.getMessageId();
+        this.frameSize = footer.getFrameSize();
+        this.algorithm = EncryptionAlgorithm.fromId(footer.getAlgorithmId());
+        
+        // Derive file-specific key using messageId from footer
+        byte[] derivedKey = HkdfKeyDerivation.deriveAesKey(directoryKey, messageId, "file-encryption");
+        this.keySpec = new SecretKeySpec(derivedKey, ALGORITHM);
+        
+        // Calculate footer length
+        long fileSize = channel.size();
+        ByteBuffer buffer = ByteBuffer.allocate(EncryptionMetadataTrailer.MIN_FOOTER_SIZE);
+        channel.read(buffer, fileSize - EncryptionMetadataTrailer.MIN_FOOTER_SIZE);
+        this.footerLength = EncryptionFooter.calculateFooterLength(buffer.array());
     }
 
-    public CryptoBufferedIndexInput(String resourceDesc, FileChannel fc, long off, long length, int bufferSize, KeyIvResolver keyResolver)
+    public CryptoBufferedIndexInput(String resourceDesc, FileChannel fc, long off, long length, int bufferSize, KeyResolver keyResolver, SecretKeySpec keySpec, int footerLength, long frameSize, short algorithmId, byte[] directoryKey, byte[] messageId)
         throws IOException {
         super(resourceDesc, bufferSize);
         this.channel = fc;
@@ -64,7 +91,12 @@ final class CryptoBufferedIndexInput extends BufferedIndexInput {
         this.end = off + length;
         this.isClone = true;
         this.keyResolver = keyResolver;
-        this.keySpec = new SecretKeySpec(keyResolver.getDataKey().getEncoded(), ALGORITHM);
+        this.keySpec = keySpec;  // Reuse keySpec from main file
+        this.footerLength = footerLength;
+        this.frameSize = frameSize;
+        this.algorithm = EncryptionAlgorithm.fromId(algorithmId);
+        this.directoryKey = directoryKey;  // Passed from parent
+        this.messageId = messageId;  // Passed from parent
     }
 
     @Override
@@ -94,13 +126,24 @@ final class CryptoBufferedIndexInput extends BufferedIndexInput {
             off + offset,
             length,
             getBufferSize(),
-            keyResolver
+            keyResolver,
+            keySpec,  // Pass the already-derived keySpec
+            footerLength,
+            frameSize,
+            algorithm.getAlgorithmId(),
+            directoryKey,  // Pass directory key
+            messageId      // Pass message ID
         );
     }
 
     @Override
     public long length() {
-        return end - off;
+        // Exclude footer from logical file length (only for main file, not slices)
+        if (isClone) {
+            return end - off;  // Slices use exact length passed in
+        } else {
+            return end - off - footerLength;  // Main file excludes variable footer
+        }
     }
 
     @SuppressForbidden(reason = "FileChannel#read is efficient and used intentionally")
@@ -112,7 +155,15 @@ final class CryptoBufferedIndexInput extends BufferedIndexInput {
             tmpBuffer = ByteBuffer.allocate(CHUNK_SIZE);
         }
 
-        tmpBuffer.clear().limit(dst.remaining());
+        // Calculate frame boundaries to avoid reading across frames
+        int frameNumber = (int)(position / frameSize);
+        long offsetWithinFrame = position % frameSize;
+        long frameEnd = (frameNumber + 1) * frameSize;
+        
+        // Limit read to not cross frame boundary
+        int maxReadInFrame = (int) Math.min(dst.remaining(), frameEnd - position);
+
+        tmpBuffer.clear().limit(maxReadInFrame);
         int bytesRead = channel.read(tmpBuffer, position);
         if (bytesRead == -1) {
             return -1;
@@ -121,14 +172,16 @@ final class CryptoBufferedIndexInput extends BufferedIndexInput {
         tmpBuffer.flip();
 
         try {
-            Cipher cipher = AesCipherFactory.CIPHER_POOL.get();
-
-            byte[] ivCopy = AesCipherFactory.computeOffsetIVForAesGcmEncrypted(keyResolver.getIvBytes(), position);
-
-            cipher.init(Cipher.DECRYPT_MODE, this.keySpec, new IvParameterSpec(ivCopy));
-
-            if (position % AesCipherFactory.AES_BLOCK_SIZE_BYTES > 0) {
-                cipher.update(ZERO_SKIP, 0, (int) (position % AesCipherFactory.AES_BLOCK_SIZE_BYTES));
+            // Use frame-based decryption with algorithm-based cipher
+            Cipher cipher = algorithm.getDecryptionCipher();
+            
+            // Derive frame-specific IV
+            byte[] frameIV = AesCipherFactory.computeFrameIV(directoryKey, messageId, frameNumber, offsetWithinFrame);
+            
+            cipher.init(Cipher.DECRYPT_MODE, keySpec, new IvParameterSpec(frameIV));
+            
+            if (offsetWithinFrame % AesCipherFactory.AES_BLOCK_SIZE_BYTES > 0) {
+                cipher.update(ZERO_SKIP, 0, (int) (offsetWithinFrame % AesCipherFactory.AES_BLOCK_SIZE_BYTES));
             }
 
             return (end - position > bytesRead) ? cipher.update(tmpBuffer, dst) : cipher.doFinal(tmpBuffer, dst);
@@ -166,4 +219,33 @@ final class CryptoBufferedIndexInput extends BufferedIndexInput {
             throw new EOFException("seek past EOF: pos=" + pos + ", length=" + length());
         }
     }
+    
+    /**
+     * Read encryption footer from end of file
+     */
+    private EncryptionFooter readFooterFromFile() throws IOException {
+        long fileSize = channel.size();
+        if (fileSize < EncryptionMetadataTrailer.MIN_FOOTER_SIZE) {
+            throw new IOException("File too small to contain encryption footer");
+        }
+        
+        // First read minimum footer to get actual length
+        ByteBuffer minBuffer = ByteBuffer.allocate(EncryptionMetadataTrailer.MIN_FOOTER_SIZE);
+        channel.read(minBuffer, fileSize - EncryptionMetadataTrailer.MIN_FOOTER_SIZE);
+        
+        int footerLength = EncryptionFooter.calculateFooterLength(minBuffer.array());
+        
+        // Read complete footer
+        ByteBuffer footerBuffer = ByteBuffer.allocate(footerLength);
+        int bytesRead = channel.read(footerBuffer, fileSize - footerLength);
+        
+        if (bytesRead != footerLength) {
+            throw new IOException("Failed to read complete footer");
+        }
+        
+        // Use directory key for footer authentication (before file key derivation)
+        return EncryptionFooter.deserialize(footerBuffer.array(), directoryKey);
+    }
+    
+
 }

--- a/src/main/java/org/opensearch/index/store/niofs/CryptoNIOFSDirectory.java
+++ b/src/main/java/org/opensearch/index/store/niofs/CryptoNIOFSDirectory.java
@@ -6,6 +6,7 @@ package org.opensearch.index.store.niofs;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -19,7 +20,9 @@ import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.LockFactory;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.opensearch.common.util.io.IOUtils;
-import org.opensearch.index.store.iv.KeyIvResolver;
+import org.opensearch.index.store.footer.EncryptionFooter;
+import org.opensearch.index.store.footer.EncryptionMetadataTrailer;
+import org.opensearch.index.store.key.KeyResolver;
 
 /**
  * A NioFS directory implementation that encrypts files to be stored based on a
@@ -29,13 +32,14 @@ import org.opensearch.index.store.iv.KeyIvResolver;
  */
 public class CryptoNIOFSDirectory extends NIOFSDirectory {
     private final Provider provider;
-    public final KeyIvResolver keyIvResolver;
+    public final KeyResolver keyResolver;
     private final AtomicLong nextTempFileCounter = new AtomicLong();
+    private final int algorithmId = 1; // Default to AES_256_GCM_CTR
 
-    public CryptoNIOFSDirectory(LockFactory lockFactory, Path location, Provider provider, KeyIvResolver keyIvResolver) throws IOException {
+    public CryptoNIOFSDirectory(LockFactory lockFactory, Path location, Provider provider, KeyResolver keyResolver) throws IOException {
         super(location, lockFactory);
         this.provider = provider;
-        this.keyIvResolver = keyIvResolver;
+        this.keyResolver = keyResolver;
     }
 
     @Override
@@ -55,7 +59,7 @@ public class CryptoNIOFSDirectory extends NIOFSDirectory {
                 "CryptoBufferedIndexInput(path=\"" + path + "\")",
                 fc,
                 context,
-                this.keyIvResolver
+                this.keyResolver
             );
             success = true;
             return indexInput;
@@ -76,7 +80,7 @@ public class CryptoNIOFSDirectory extends NIOFSDirectory {
         Path path = directory.resolve(name);
         OutputStream fos = Files.newOutputStream(path, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW);
 
-        return new CryptoOutputStreamIndexOutput(name, path, fos, this.keyIvResolver.getDataKey(), keyIvResolver.getIvBytes(), provider);
+        return new CryptoOutputStreamIndexOutput(name, path, fos, this.keyResolver, provider, algorithmId);
     }
 
     @Override
@@ -90,7 +94,32 @@ public class CryptoNIOFSDirectory extends NIOFSDirectory {
         Path path = directory.resolve(name);
         OutputStream fos = Files.newOutputStream(path, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW);
 
-        return new CryptoOutputStreamIndexOutput(name, path, fos, this.keyIvResolver.getDataKey(), keyIvResolver.getIvBytes(), provider);
+        return new CryptoOutputStreamIndexOutput(name, path, fos, this.keyResolver, provider, algorithmId);
+    }
+
+    @Override
+    public long fileLength(String name) throws IOException {
+        if ((name.contains("segments_") || name.endsWith(".si")) ) {
+            return super.fileLength(name);  // Non-encrypted files
+        }
+        
+        // Encrypted files: calculate variable footer length
+        long fileSize = super.fileLength(name);
+        // Handle files that might be in process of being written
+        if (fileSize < EncryptionMetadataTrailer.MIN_FOOTER_SIZE) {
+            // File might be incomplete or very small
+            return Math.max(0, fileSize - EncryptionMetadataTrailer.MIN_FOOTER_SIZE);  // Assume minimum footer
+        }
+        
+        Path path = getDirectory().resolve(name);
+        try (FileChannel channel = FileChannel.open(path, StandardOpenOption.READ)) {
+            // Read minimum footer to get actual length
+            ByteBuffer buffer = ByteBuffer.allocate(EncryptionMetadataTrailer.MIN_FOOTER_SIZE);
+            channel.read(buffer, fileSize - EncryptionMetadataTrailer.MIN_FOOTER_SIZE);
+            
+            int footerLength = EncryptionFooter.calculateFooterLength(buffer.array());
+            return fileSize - footerLength;
+        }
     }
 
     @Override

--- a/src/main/java/org/opensearch/index/store/niofs/CryptoOutputStreamIndexOutput.java
+++ b/src/main/java/org/opensearch/index/store/niofs/CryptoOutputStreamIndexOutput.java
@@ -11,10 +11,17 @@ import java.nio.file.Path;
 
 import org.apache.lucene.store.OutputStreamIndexOutput;
 import org.opensearch.common.SuppressForbidden;
+import org.opensearch.index.store.cipher.AesCipherFactory;
 import org.opensearch.index.store.cipher.AesGcmCipherFactory;
+import org.opensearch.index.store.cipher.EncryptionAlgorithm;
+import org.opensearch.index.store.footer.EncryptionFooter;
+import org.opensearch.index.store.footer.EncryptionMetadataTrailer;
+import org.opensearch.index.store.key.HkdfKeyDerivation;
+import org.opensearch.index.store.key.KeyResolver;
 
 import javax.crypto.Cipher;
 import java.security.Key;
+import java.util.Arrays;
 
 /**
  * An IndexOutput implementation that encrypts data before writing using native
@@ -29,38 +36,55 @@ public final class CryptoOutputStreamIndexOutput extends OutputStreamIndexOutput
     private static final int BUFFER_SIZE = 65_536;
 
     /**
-     * Creates a new CryptoIndexOutput
+     * Creates a new CryptoIndexOutput with per-file key derivation
      *
      * @param name The name of the output
      * @param path The path to write to
      * @param os The output stream
-     * @param key The AES key
-     * @param iv The initialization vector (must be 16 bytes)
+     * @param keyResolver The key/IV resolver for directory keys
      * @param provider The JCE provider to use
      * @throws IOException If there is an I/O error
-     * @throws IllegalArgumentException If key or iv lengths are invalid
      */
-    public CryptoOutputStreamIndexOutput(String name, Path path, OutputStream os, Key key, byte[] iv, java.security.Provider provider) throws IOException {
-        super("FSIndexOutput(path=\"" + path + "\")", name, new EncryptedOutputStream(os, key, iv, provider), CHUNK_SIZE);
+    public CryptoOutputStreamIndexOutput(String name, Path path, OutputStream os, KeyResolver keyResolver, java.security.Provider provider, int algorithmId) throws IOException {
+        super("FSIndexOutput(path=\"" + path + "\")", name, new EncryptedOutputStream(os, keyResolver, provider, algorithmId), CHUNK_SIZE);
     }
 
     private static class EncryptedOutputStream extends FilterOutputStream {
 
-        private final Key key;
-        private final byte[] iv;
+        private final Key fileKey;
+        private final byte[] directoryKey;
         private final byte[] buffer;
-        private final Cipher cipher;
+        private final EncryptionFooter footer;
+        private final java.security.Provider provider;
+        private final long frameSize;
+        private final EncryptionAlgorithm algorithm;
+
+        // Frame tracking
+        private Cipher currentCipher;
+        private int currentFrameNumber = 0;
+        private long currentFrameOffset = 0;
         private int bufferPosition = 0;
         private long streamOffset = 0;
+        private int totalFrames = 0;
         private boolean isClosed = false;
 
-        EncryptedOutputStream(OutputStream os, Key key, byte[] iv, java.security.Provider provider) {
+        EncryptedOutputStream(OutputStream os, KeyResolver keyResolver, java.security.Provider provider, int algorithmId) {
             super(os);
-            this.key = key;
-            this.iv = iv;
+
+            this.frameSize = EncryptionMetadataTrailer.DEFAULT_FRAME_SIZE;
+
+            // Generate MessageId and derive file-specific key
+            this.footer = EncryptionFooter.generateNew(frameSize, (short)algorithmId);
+            this.directoryKey = keyResolver.getDataKey().getEncoded();
+            byte[] derivedKey = HkdfKeyDerivation.deriveAesKey(directoryKey, footer.getMessageId(), "file-encryption");
+            this.fileKey = new javax.crypto.spec.SecretKeySpec(derivedKey, "AES");
+
+            this.provider = provider;
+            this.algorithm = EncryptionAlgorithm.fromId((short) algorithmId);
             this.buffer = new byte[BUFFER_SIZE];
-            this.cipher = AesGcmCipherFactory.getCipher(provider);
-            AesGcmCipherFactory.initCipher(this.cipher, key, iv, Cipher.ENCRYPT_MODE, streamOffset);
+
+            // Initialize first frame cipher
+            initializeFrameCipher(0, 0);
         }
 
         @Override
@@ -105,12 +129,34 @@ public final class CryptoOutputStreamIndexOutput extends OutputStreamIndexOutput
         }
 
         private void processAndWrite(byte[] data, int offset, int length) throws IOException {
-            try {
-                byte[] encrypted = org.opensearch.index.store.cipher.AesGcmCipherFactory.encryptWithoutTag(streamOffset, cipher, slice(data, offset, length), length);
-                out.write(encrypted);
-                streamOffset += length;
-            } catch (Throwable t) {
-                throw new IOException("Encryption failed at offset " + streamOffset, t);
+            int remaining = length;
+            int dataOffset = offset;
+
+            while (remaining > 0) {
+                // Check if we need to start a new frame
+                int frameNumber = (int)(streamOffset / frameSize);
+                if (frameNumber != currentFrameNumber) {
+                    finalizeCurrentFrame();
+                    totalFrames = Math.max(totalFrames, frameNumber + 1);
+                    initializeFrameCipher(frameNumber, streamOffset % frameSize);
+                }
+
+                // Calculate how much we can write in current frame
+                long frameEnd = (frameNumber + 1) * frameSize;
+                int chunkSize = (int) Math.min(remaining, frameEnd - streamOffset);
+
+                try {
+                    byte[] encrypted = AesGcmCipherFactory.encryptWithoutTag(currentFrameOffset, currentCipher,
+                                                                        slice(data, dataOffset, chunkSize), chunkSize);
+                    out.write(encrypted);
+
+                    streamOffset += chunkSize;
+                    currentFrameOffset += chunkSize;
+                    remaining -= chunkSize;
+                    dataOffset += chunkSize;
+                } catch (Throwable t) {
+                    throw new IOException("Encryption failed at offset " + streamOffset, t);
+                }
             }
         }
 
@@ -132,13 +178,15 @@ public final class CryptoOutputStreamIndexOutput extends OutputStreamIndexOutput
                 flushBuffer();
                 // Lucene writes footer here.
                 // this will also flush the buffer.
-                // Finalize GCM and handle any remaining encrypted bytes
-                byte[] finalData = org.opensearch.index.store.cipher.AesGcmCipherFactory.finalizeAndGetTag(cipher);
-                // finalData contains [remaining_encrypted_bytes][16_byte_tag]
-                // Write any remaining encrypted bytes (excluding the tag)
-                if (finalData.length > AesGcmCipherFactory.GCM_TAG_LENGTH) {
-                    out.write(finalData, 0, finalData.length - AesGcmCipherFactory.GCM_TAG_LENGTH);
-                }
+                // Finalize current frame
+                finalizeCurrentFrame();
+
+                // Set final frame count in footer
+                footer.setFrameCount(totalFrames);
+
+                // Write footer with directory key for authentication
+                out.write(footer.serialize(this.directoryKey));
+
                 super.close();
             } catch (IOException e) {
                 exception = e;
@@ -152,7 +200,49 @@ public final class CryptoOutputStreamIndexOutput extends OutputStreamIndexOutput
 
         private void checkClosed() throws IOException {
             if (isClosed) {
-                throw new IOException("Outout stream is already closed, this is unusual");
+                throw new IOException("Output stream is already closed, this is unusual");
+            }
+        }
+
+        /**
+         * Initialize cipher for a new frame
+         */
+        private void initializeFrameCipher(int frameNumber, long offsetWithinFrame) {
+            this.currentFrameNumber = frameNumber;
+            this.currentFrameOffset = offsetWithinFrame;
+
+            // Derive frame-specific IV
+            byte[] frameIV = AesCipherFactory.computeFrameIV(directoryKey, footer.getMessageId(),
+                                                           frameNumber, offsetWithinFrame);
+
+            this.currentCipher = algorithm.getEncryptionCipher(provider);
+            AesGcmCipherFactory.initCipher(this.currentCipher, this.fileKey, frameIV,
+                                            Cipher.ENCRYPT_MODE, offsetWithinFrame);
+        }
+
+        /**
+         * Finalize current frame and collect GCM tag
+         */
+        private void finalizeCurrentFrame() throws IOException {
+            if (currentCipher != null) {
+                try {
+                    byte[] finalData = AesGcmCipherFactory.finalizeAndGetTag(currentCipher);
+                    // finalData contains [remaining_encrypted_bytes][16_byte_tag]
+
+                    if (finalData.length >= AesGcmCipherFactory.GCM_TAG_LENGTH) {
+                        // Write encrypted data (excluding tag)
+                        int encryptedLength = finalData.length - AesGcmCipherFactory.GCM_TAG_LENGTH;
+                        if (encryptedLength > 0) {
+                            out.write(finalData, 0, encryptedLength);
+                        }
+
+                        // Extract and store GCM tag
+                        byte[] gcmTag = Arrays.copyOfRange(finalData, encryptedLength, finalData.length);
+                        footer.addGcmTag(gcmTag);
+                    }
+                } catch (Throwable t) {
+                    throw new IOException("Failed to finalize frame " + currentFrameNumber, t);
+                }
             }
         }
     }

--- a/src/test/java/org/opensearch/index/store/CryptoDirectoryTests.java
+++ b/src/test/java/org/opensearch/index/store/CryptoDirectoryTests.java
@@ -26,7 +26,7 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.tests.mockfile.ExtrasFS;
 import org.opensearch.common.Randomness;
-import org.opensearch.index.store.iv.KeyIvResolver;
+import org.opensearch.index.store.key.KeyResolver;
 import org.opensearch.index.store.niofs.CryptoNIOFSDirectory;
 
 import static org.junit.Assert.assertEquals;
@@ -50,17 +50,16 @@ public class CryptoDirectoryTests extends OpenSearchBaseDirectoryTestCase {
         rnd.nextBytes(encryptedKey);
 
         // Create mock KeyIvResolver
-        KeyIvResolver keyIvResolver = mock(KeyIvResolver.class);
+        KeyResolver keyResolver = mock(KeyResolver.class);
         byte[] iv = new byte[16]; // 128-bit IV for AES/CTR
         rnd.nextBytes(iv);
 
-        when(keyIvResolver.getDataKey()).thenReturn(new SecretKeySpec(rawKey, "AES"));
-        when(keyIvResolver.getIvBytes()).thenReturn(iv);
+        when(keyResolver.getDataKey()).thenReturn(new SecretKeySpec(rawKey, "AES"));
 
         Provider provider = Security.getProvider("SunJCE");
         assertNotNull("Provider should not be null", provider);
 
-        return new CryptoNIOFSDirectory(FSLockFactory.getDefault(), file, provider, keyIvResolver);
+        return new CryptoNIOFSDirectory(FSLockFactory.getDefault(), file, provider, keyResolver);
     }
 
     @Override
@@ -84,7 +83,6 @@ public class CryptoDirectoryTests extends OpenSearchBaseDirectoryTestCase {
                 .stream(dir.listAll())
                 .filter(file -> !ExtrasFS.isExtra(file)) // remove any ExtrasFS stuff.
                 .filter(file -> !file.equals(KEY_FILE_NAME)) // remove keyfile.
-                .filter(file -> !file.equals("ivFile")) // remove ivFile.
                 .collect(Collectors.toSet());
 
             assertEquals(new HashSet<String>(names), files);

--- a/src/test/java/org/opensearch/index/store/mmap/LazyDecryptedRaceConditionTests.java
+++ b/src/test/java/org/opensearch/index/store/mmap/LazyDecryptedRaceConditionTests.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 import org.opensearch.common.SuppressForbidden;
+import org.opensearch.index.store.key.HkdfKeyDerivation;
 
 /**
  * The test focuses on the specific scenario where multiple
@@ -49,6 +50,10 @@ public class LazyDecryptedRaceConditionTests {
     private byte[] testKey;
     private byte[] testIv;
     private byte[] expectedPlaintextData;
+    private byte[] messageId;
+    private byte[] directoryKey;
+    private long frameSize;
+    private short algorithmId;
 
     @Before
     public void setUp() throws Exception {
@@ -60,6 +65,14 @@ public class LazyDecryptedRaceConditionTests {
         testIv = new byte[16];  // 128-bit IV
         Arrays.fill(testKey, (byte) 0x42);
         Arrays.fill(testIv, (byte) 0x24);
+        
+        // Frame-based parameters
+        messageId = new byte[16];
+        Arrays.fill(messageId, (byte) 0x33);
+        directoryKey = new byte[32];
+        Arrays.fill(directoryKey, (byte) 0x55);
+        frameSize = 64L * 1024 * 1024 * 1024; // 64GB
+        algorithmId = 1; // AES-256-GCM
 
         // STEP 1: Create known plaintext data
         byte[] plaintextData = new byte[DATA_SIZE];
@@ -81,15 +94,18 @@ public class LazyDecryptedRaceConditionTests {
     }
 
     /**
-     * Encrypt data using the same method as MemorySegmentDecryptor but in reverse.
-     * This matches the complex IV manipulation and block alignment.
+     * Encrypt data using frame-based approach to match new decryption
      */
     private byte[] encryptData(byte[] plaintext, byte[] key, byte[] iv) throws Exception {
+        // Use the derived file key for encryption (same as decryption)
+        byte[] fileKey = HkdfKeyDerivation.deriveAesKey(this.directoryKey, this.messageId, "file-encryption");
+        
         javax.crypto.Cipher cipher = org.opensearch.index.store.cipher.AesCipherFactory.CIPHER_POOL.get();
-        javax.crypto.spec.SecretKeySpec keySpec = new javax.crypto.spec.SecretKeySpec(key, "AES");
+        javax.crypto.spec.SecretKeySpec keySpec = new javax.crypto.spec.SecretKeySpec(fileKey, "AES");
 
-        byte[] ivCopy = org.opensearch.index.store.cipher.AesCipherFactory.computeOffsetIVForAesGcmEncrypted(iv, 0);
-        cipher.init(javax.crypto.Cipher.ENCRYPT_MODE, keySpec, new javax.crypto.spec.IvParameterSpec(ivCopy));
+        // Use frame-based IV calculation
+        byte[] frameIV = org.opensearch.index.store.cipher.AesCipherFactory.computeFrameIV(this.directoryKey, this.messageId, 0, 0);
+        cipher.init(javax.crypto.Cipher.ENCRYPT_MODE, keySpec, new javax.crypto.spec.IvParameterSpec(frameIV));
 
         return cipher.update(plaintext);
     }
@@ -107,7 +123,7 @@ public class LazyDecryptedRaceConditionTests {
     @Test(timeout = TEST_TIMEOUT_SECONDS * 1000)
     public void testEncryptedDataSetupWorks() throws Exception {
         LazyDecryptedMemorySegmentIndexInput input = LazyDecryptedMemorySegmentIndexInput
-            .newInstance("test-resource", arena, new MemorySegment[] { segment }, DATA_SIZE, CHUNK_SIZE_POWER, testKey, testIv);
+            .newInstance("test-resource", arena, new MemorySegment[] { segment }, DATA_SIZE, CHUNK_SIZE_POWER, messageId, frameSize, algorithmId, directoryKey);
 
         // Test that we can decrypt and get back the original plaintext
         input.seek(0);
@@ -128,7 +144,7 @@ public class LazyDecryptedRaceConditionTests {
     @Test(timeout = TEST_TIMEOUT_SECONDS * 1000)
     public void testConcurrentReadsSameLocation() throws Exception {
         LazyDecryptedMemorySegmentIndexInput input = LazyDecryptedMemorySegmentIndexInput
-            .newInstance("test-resource", arena, new MemorySegment[] { segment }, DATA_SIZE, CHUNK_SIZE_POWER, testKey, testIv);
+            .newInstance("test-resource", arena, new MemorySegment[] { segment }, DATA_SIZE, CHUNK_SIZE_POWER, messageId, frameSize, algorithmId, directoryKey);
 
         // Test reading from the same safe location using random access
         final long testOffset = 50;
@@ -198,7 +214,7 @@ public class LazyDecryptedRaceConditionTests {
     @Test(timeout = TEST_TIMEOUT_SECONDS * 1000)
     public void testConcurrentReadsMultipleLocations() throws Exception {
         LazyDecryptedMemorySegmentIndexInput input = LazyDecryptedMemorySegmentIndexInput
-            .newInstance("test-resource", arena, new MemorySegment[] { segment }, DATA_SIZE, CHUNK_SIZE_POWER, testKey, testIv);
+            .newInstance("test-resource", arena, new MemorySegment[] { segment }, DATA_SIZE, CHUNK_SIZE_POWER, messageId, frameSize, algorithmId, directoryKey);
 
         final int numOperations = 3; // Reduced operations for safety
         final CountDownLatch startLatch = new CountDownLatch(1);
@@ -251,7 +267,7 @@ public class LazyDecryptedRaceConditionTests {
     @Test(timeout = TEST_TIMEOUT_SECONDS * 1000)
     public void testConcurrentBlockReads() throws Exception {
         LazyDecryptedMemorySegmentIndexInput input = LazyDecryptedMemorySegmentIndexInput
-            .newInstance("test-resource", arena, new MemorySegment[] { segment }, DATA_SIZE, CHUNK_SIZE_POWER, testKey, testIv);
+            .newInstance("test-resource", arena, new MemorySegment[] { segment }, DATA_SIZE, CHUNK_SIZE_POWER, messageId, frameSize, algorithmId, directoryKey);
 
         final int blockSize = 8; // Very small block size
         final long testOffset = 10; // Safe offset
@@ -303,7 +319,7 @@ public class LazyDecryptedRaceConditionTests {
     @Test(timeout = TEST_TIMEOUT_SECONDS * 1000)
     public void testHighContentionRaceCondition() throws Exception {
         LazyDecryptedMemorySegmentIndexInput input = LazyDecryptedMemorySegmentIndexInput
-            .newInstance("test-resource", arena, new MemorySegment[] { segment }, DATA_SIZE, CHUNK_SIZE_POWER, testKey, testIv);
+            .newInstance("test-resource", arena, new MemorySegment[] { segment }, DATA_SIZE, CHUNK_SIZE_POWER, messageId, frameSize, algorithmId, directoryKey);
 
         // Use just a few very safe offsets to maximize contention
         final long[] testOffsets = { 0, 5, 10, 15, 20 };


### PR DESCRIPTION
Description

This PR implements changes required for the IV implementation strategy.

Previously, the data key was generated by KMS at the directory level and stored in keyFile, while the IV was randomly generated using SecureRandom and stored in ivFile. All files within the same directory shared these values.

The new changes include:

-  Generating a 16-byte messageId for each file
- Adding support for deriving new data keys from the directory data key using HKDF algorithm and message-id
- Generating new base-IV for each frame

To address counter exhaustion and prevent counter reuse within files, introduced frames to handle large data. When a counter approaches exhaustion, the current frame closes and a new one opens.

Key improvements:

- Separate tag storage for each frame
- Generation of 16-byte SecureRandom messageID per file for deriving the file encryption key
- Different contexts for encryption key and frame IV generation
- File-specific metadata stored in the file footer
- GCM algorithm tags stored in footer for validation
- Separated encrypted data storage in a file for CTR cipher decryption compatibility

The footer contains:

- Algorithm ID for flexible decryption implementation
- GCM tags for each frame
- Frame count and tag count variables
- Footer length for efficient file access
- Magic bytes (`OSEF` - OpenSearch Encrypted File) for verification

Footer Structure:
```
Format: [FooterAuthTag(16)][GcmTags...][TagCount(4)][FrameSize(8)][FrameCount(4)][MessageId(16)][KeyMetadata(0)][KeyMetadataLength(2)][AlgorithmId(2)][FooterLength(4)][Magic(4)]
```
```
Field Name         Size (Bytes)
----------------  -------------
FooterAuthTag      16
GCMTagList         16 * FrameCount
FrameCount         2
FrameSize          6
MessageId          16
KeyMetadata        Variable (currently empty)
KeyMetadataLength  2
AlgorithmId        2
FooterLength       4
MagicBytes         4
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->
https://github.com/opensearch-project/opensearch-storage-encryption/issues/14

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
