### PR TITLE
Bug fixes in refcounted memory segments (use generation number instead of retirement flags)

### DIFF
--- a/src/main/java/org/opensearch/index/store/CryptoDirectoryFactory.java
+++ b/src/main/java/org/opensearch/index/store/CryptoDirectoryFactory.java
@@ -61,14 +61,35 @@ import com.github.benmanes.caffeine.cache.RemovalCause;
 
 @SuppressForbidden(reason = "temporary")
 /**
- * Factory for an encrypted filesystem directory
+ * Factory for creating encrypted filesystem directories with support for various storage types.
+ *
+ * Supports:
+ * - NIOFS: NIO-based encrypted file system
+ * - HYBRIDFS: Hybrid directory with Direct I/O and block caching
+ * - MMAPFS: Not supported (throws AssertionError)
+ *
+ * The factory maintains node-level shared resources (pool and cache) for efficient
+ * memory utilization across all encrypted directories.
  */
 public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
 
     private static final Logger LOGGER = LogManager.getLogger(CryptoDirectoryFactory.class);
 
-    private static volatile Pool<MemorySegmentPool.SegmentHandle> sharedSegmentPool;
+    /**
+     * Shared pool of RefCountedMemorySegments for Direct I/O operations.
+     * Initialized once per node and shared across all CryptoDirectIODirectory instances.
+     */
+    private static volatile Pool<RefCountedMemorySegment> sharedSegmentPool;
+
+    /**
+     * Shared block cache for decrypted data blocks.
+     * Initialized once per node and shared across all CryptoDirectIODirectory instances.
+     */
     private static volatile BlockCache<RefCountedMemorySegment> sharedBlockCache;
+
+    /**
+     * Lock for thread-safe initialization of shared resources.
+     */
     private static final Object initLock = new Object();
 
     /**
@@ -79,18 +100,21 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
     }
 
     /**
-     *  Specifies a crypto provider to be used for encryption. The default value is SunJCE.
+     * Specifies a crypto provider to be used for encryption. The default value
+     * is SunJCE.
      */
     public static final Setting<Provider> INDEX_CRYPTO_PROVIDER_SETTING = new Setting<>("index.store.crypto.provider", "SunJCE", (s) -> {
         Provider p = Security.getProvider(s);
         if (p == null) {
             throw new SettingsException("unrecognized [index.store.crypto.provider] \"" + s + "\"");
-        } else
+        } else {
             return p;
+        }
     }, Property.IndexScope, Property.InternalIndex);
 
     /**
-     *  Specifies the Key management plugin type to be used. The desired KMS plugin should be installed.
+     * Specifies the Key management plugin type to be used. The desired KMS
+     * plugin should be installed.
      */
     public static final Setting<String> INDEX_KMS_TYPE_SETTING = new Setting<>("index.store.kms.type", "", Function.identity(), (s) -> {
         if (s == null || s.isEmpty()) {
@@ -135,6 +159,7 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
 
     /**
      * {@inheritDoc}
+     *
      * @param indexSettings the index settings
      * @param path the shard file path
      */
@@ -147,12 +172,13 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
     }
 
     /**
-     * {@inheritDoc}
+     * Creates an encrypted directory based on the configured store type.
+     *
      * @param location the directory location
-     * @param lockFactory the lockfactory for this FS directory
-     * @param indexSettings the read index settings 
-     * @return the concrete implementation of the directory based on index setttings.
-     * @throws IOException
+     * @param lockFactory the lock factory for this directory
+     * @param indexSettings the index settings
+     * @return the concrete implementation of the encrypted directory based on store type
+     * @throws IOException if directory creation fails
      */
     protected Directory newFSDirectory(Path location, LockFactory lockFactory, IndexSettings indexSettings) throws IOException {
         final Provider provider = indexSettings.getValue(INDEX_CRYPTO_PROVIDER_SETTING);
@@ -173,7 +199,7 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
 
         switch (type) {
             case HYBRIDFS -> {
-                LOGGER.debug("Using HYBRIDFS directory");
+                LOGGER.debug("Using HYBRIDFS directory with Direct I/O and block caching");
 
                 CryptoDirectIODirectory cryptoDirectIODirectory = createCryptoDirectIODirectory(
                     location,
@@ -187,7 +213,7 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
                 throw new AssertionError("MMAPFS not supported with index level encryption");
             }
             case SIMPLEFS, NIOFS -> {
-                LOGGER.debug("Using NIOFS directory");
+                LOGGER.debug("Using NIOFS directory for encrypted storage");
                 return new CryptoNIOFSDirectory(lockFactory, location, provider, keyIvResolver);
             }
             default -> throw new AssertionError("unexpected built-in store type [" + type + "]");
@@ -203,54 +229,51 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
     ) throws IOException {
         /*
         * ================================
-        * Shared Block Cache with RefCountedMemorySegment
+        * Shared Block Cache Architecture
         * ================================
         *
-        * This shared Caffeine cache stores decrypted MemorySegment blocks for direct I/O access,
-        * using reference counting to ensure safe reuse across multiple readers and directories.
+        * This method creates a CryptoDirectIODirectory that uses node-level shared resources
+        * (pool and cache) for efficient memory utilization and high cache hit rates.
         *
-        * Cache Type:
-        * ------------
-        * - Key:   BlockCacheKey (typically includes file path, offset, etc.)
-        * - Value: BlockCacheValue<RefCountedMemorySegment>
+        * Shared Resources:
+        * -----------------
+        * - sharedSegmentPool: Pool of RefCountedMemorySegments (initialized in initializeSharedPool)
+        * - sharedBlockCache: Caffeine cache storing decrypted blocks (initialized in initializeSharedPool)
+        *
+        * Per-Directory Resources:
+        * ------------------------
+        * - BlockLoader: Directory-specific loader using this directory's keyIvResolver for decryption
+        * - Cache Wrapper: Wraps the shared cache with directory-specific loader
+        * - ReadAhead Worker: Asynchronous prefetching for sequential reads
         *
         * Memory Lifecycle:
-        * ------------------
-        * - Each cached block is a RefCountedMemorySegment, which wraps a MemorySegment
-        *   and manages its lifetime via reference counting.
+        * -----------------
+        * 1. Cache miss: Loader reads encrypted data, decrypts it, stores in RefCountedMemorySegment
+        * 2. Initial refCount=1 (cache's reference)
+        * 3. Reader pins: refCount incremented via tryPin()
+        * 4. Reader unpins: refCount decremented via decRef()
+        * 5. Cache eviction: retired=true set (prevents new pins), then decRef() called
+        * 6. refCount=0: Segment returned to pool for reuse
         *
-        * - On load, we increment the reference count via `incRef()` for each use
-        *   (i.e., each IndexInput clone or slice).
-        *
-        * - On close, `decRef()` is called. When the count hits zero, the underlying
-        *   MemorySegment is released via a `SegmentReleaser` (typically returning
-        *   the segment to a pool or freeing it).
-        *
-        * Global Sharing:
-        * ---------------
-        * - The cache is now shared across all CryptoDirectIODirectory instances per node,
-        *   improving memory efficiency and cache hit rates across different indexes.
-        * - Cache size matches the pool size to ensure optimal memory utilization.
-        *
-        * Threading:
-        * -----------
-        * - Caffeine eviction is single-threaded by default (runs in caller thread via `Runnable::run`),
-        *   which avoids offloading release to background threads that may hold on to native memory.
-        * 
+        * Two-Phase Eviction (prevents stale reads):
+        * -------------------------------------------
+        * - evictionListener: Sets retired=true (marks stale for BlockSlotTinyCache)
+        * - removalListener: Calls decRef() (releases cache's reference)
         */
 
-        // Create a per-directory loader that knows about this specific keyIvResolver
-        BlockLoader<MemorySegmentPool.SegmentHandle> loader = new CryptoDirectIOBlockLoader(sharedSegmentPool, keyIvResolver);
+        // Create a per-directory loader that uses this directory's keyIvResolver for decryption
+        BlockLoader<RefCountedMemorySegment> loader = new CryptoDirectIOBlockLoader(sharedSegmentPool, keyIvResolver);
 
-        // Create a directory-specific cache that wraps the shared cache with this directory's loader
+        // Wrap the shared cache with directory-specific loader
         long maxBlocks = RESEVERED_POOL_SIZE_IN_BYTES / CACHE_BLOCK_SIZE;
         BlockCache<RefCountedMemorySegment> directoryCache = new CaffeineBlockCache<>(
-            ((CaffeineBlockCache<RefCountedMemorySegment, MemorySegmentPool.SegmentHandle>) sharedBlockCache).getCache(),
+            ((CaffeineBlockCache<RefCountedMemorySegment, RefCountedMemorySegment>) sharedBlockCache).getCache(),
             loader,
             sharedSegmentPool,
             maxBlocks
         );
 
+        // Create read-ahead worker for asynchronous prefetching
         int threads = Math.max(4, Runtime.getRuntime().availableProcessors() / 4);
         Worker readaheadWorker = new QueuingWorker(READ_AHEAD_QUEUE_SIZE, threads, directoryCache);
 
@@ -269,6 +292,20 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
     /**
      * Initialize the shared MemorySegmentPool and BlockCache once per node.
      * This method is called from CryptoDirectoryPlugin.createComponents().
+     *
+     * Thread Safety:
+     * - Uses double-checked locking for initialization
+     * - Safe to call multiple times (idempotent)
+     *
+     * Cache Removal Strategy:
+     * - Uses removalListener to handle all removal causes (SIZE, EXPLICIT, REPLACED, etc.)
+     * - Calls value.close() which atomically: (1) sets retired=true, (2) calls decRef()
+     * - When refCount reaches 0, segment is returned to pool for reuse
+     *
+     * Note on evictionListener vs removalListener:
+     * - evictionListener only fires for SIZE-based evictions
+     * - removalListener fires for ALL removals (including explicit invalidation)
+     * - We use removalListener to ensure retired flag is set for all removal paths
      */
     public static void initializeSharedPool() {
         if (sharedSegmentPool == null || sharedBlockCache == null) {
@@ -276,7 +313,7 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
                 if (sharedSegmentPool == null || sharedBlockCache == null) {
                     long maxBlocks = RESEVERED_POOL_SIZE_IN_BYTES / CACHE_BLOCK_SIZE;
 
-                    // Initialize shared pool
+                    // Initialize shared memory pool with warmup
                     sharedSegmentPool = new MemorySegmentPool(RESEVERED_POOL_SIZE_IN_BYTES, CACHE_BLOCK_SIZE);
                     LOGGER
                         .info(
@@ -292,26 +329,16 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
                         Thread t = new Thread(r, "block-cache-maint");
                         t.setDaemon(true);
                         return t;
-                    },
-                        new ThreadPoolExecutor.CallerRunsPolicy() // useless since we have an unbounded queue.
-                    );
+                    });
 
+                    // Initialize shared cache with removal listener
                     Cache<BlockCacheKey, BlockCacheValue<RefCountedMemorySegment>> cache = Caffeine
                         .newBuilder()
                         .initialCapacity(CACHE_INITIAL_SIZE)
                         .recordStats()
                         .maximumSize(maxBlocks)
-                        .evictionListener((BlockCacheKey key, BlockCacheValue<RefCountedMemorySegment> value, RemovalCause cause) -> {
-                            if (value != null && cause == RemovalCause.SIZE) {
-                                try {
-                                    value.close();
-                                } catch (Throwable t) {
-                                    LOGGER.warn("Failed to close a cached value during eviction ", t);
-                                }
-                            }
-                        })
-                        .removalListener((key, value, cause) -> {
-                            if (value != null && cause != RemovalCause.SIZE) {
+                        .removalListener((BlockCacheKey key, BlockCacheValue<RefCountedMemorySegment> value, RemovalCause cause) -> {
+                            if (value != null) {
                                 removalExec.execute(() -> {
                                     try {
                                         value.close();
@@ -333,6 +360,9 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
         }
     }
 
+    /**
+     * Publishes pool statistics to the logger for monitoring and debugging.
+     */
     private static void publishPoolStats() {
         try {
             LOGGER.info("{}", sharedSegmentPool.poolStats());
@@ -341,6 +371,10 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
         }
     }
 
+    /**
+     * Starts a background daemon thread that periodically logs pool statistics.
+     * Logs every 5 minutes to help monitor memory usage and pool health.
+     */
     private static void startTelemetry() {
         Thread loggerThread = new Thread(() -> {
             while (true) {

--- a/src/main/java/org/opensearch/index/store/block/RefCountedMemorySegment.java
+++ b/src/main/java/org/opensearch/index/store/block/RefCountedMemorySegment.java
@@ -7,162 +7,222 @@ package org.opensearch.index.store.block;
 import java.lang.foreign.MemorySegment;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
-import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.index.store.block_cache.BlockCacheValue;
 
-@SuppressWarnings("preview")
 /**
- * A wrapper around a  {@link MemorySegment} that implements reference counting and cache semantics.
- * This allows shared use of the segment (e.g. across multiple readers) while ensuring
+ * A reference-counted wrapper around a {@link MemorySegment} that implements {@link BlockCacheValue}.
+ *
+ * <h2>Purpose</h2>
+ * Enables safe sharing of native memory segments across multiple concurrent readers while ensuring
  * the underlying resource is released exactly once when no longer in use.
  *
- * The segment is released via a {@link BlockReleaser} callback when its reference count
- * drops to zero. Includes cache-specific retirement state for safe eviction.
+ * <h2>Reference Counting Lifecycle</h2>
+ * <ol>
+ *   <li><b>Creation:</b> refCount starts at 1 (represents cache's ownership)</li>
+ *   <li><b>Pin:</b> Reader calls {@link #tryPin()} → refCount incremented (if not retired)</li>
+ *   <li><b>Use:</b> Reader accesses {@link #segment()} while pinned</li>
+ *   <li><b>Unpin:</b> Reader calls {@link #unpin()} → refCount decremented</li>
+ *   <li><b>Release:</b> When refCount reaches 0, {@link BlockReleaser} callback returns segment to pool</li>
+ * </ol>
+ *
  */
 public final class RefCountedMemorySegment implements BlockCacheValue<RefCountedMemorySegment> {
 
-    /** Underlying memory segment holding the actual data. */
+    private static final Logger LOGGER = LogManager.getLogger(RefCountedMemorySegment.class);
+
+    /** Underlying native memory segment holding the decrypted block data. */
     private final MemorySegment segment;
 
-    /** Logical length of the segment; used when returning a sliced view. */
+    private final MemorySegment slicedSegment;
+
+    /** Logical length of valid data in the segment (may be less than segment capacity). */
     private final int length;
 
     /**
-     * Reference counter for the segment. Starts at 1 to represent ownership by
-     * the creator (or cache). Clients increment the counter via {@link #incRef()}
-     * and decrement it via {@link #decRef()}. When the counter reaches zero,
-     * the segment is released.
-     *
-     * Note: We use AtomicInteger for safe updates in concurrent access scenarios.
+     * VarHandle for atomic operations on the refCount field.
+     * Used for CAS, increment, and decrement operations.
      */
-    private final AtomicInteger refCount = new AtomicInteger(1);
-
-    /**
-     * Callback to release the memory segment when the reference count reaches zero.
-     * Typically this is responsible for returning the segment to a pool or closing it.
-     */
-    private final BlockReleaser<MemorySegment> onFullyReleased;
-
-    /**
-     * VarHandle for atomic access to the retired field
-     */
-    private static final VarHandle RETIRED;
+    private static final VarHandle REFCOUNT;
     static {
         try {
-            RETIRED = MethodHandles.lookup().findVarHandle(RefCountedMemorySegment.class, "retired", boolean.class);
+            REFCOUNT = MethodHandles.lookup().findVarHandle(RefCountedMemorySegment.class, "refCount", int.class);
         } catch (IllegalAccessException | NoSuchFieldException e) {
             throw new Error(e);
         }
     }
 
     /**
-     * Cache retirement state - when true, no new pins are allowed
+     * Reference counter tracking active users of this segment.
+     * - Starts at 1 (cache's initial reference)
+     * - Incremented by {@link #tryPin()} when readers acquire the segment
+     * - Decremented by {@link #decRef()} when released
+     * - When reaches 0, segment is returned to pool via {@link #onFullyReleased}
+     *
+     * Uses volatile int with VarHandle for atomic operations, saving 16 bytes per segment
+     * compared to AtomicInteger while maintaining same performance.
      */
-    private volatile boolean retired = false;
+    private volatile int refCount = 1;
 
     /**
-     * Creates a new reference-counted memory segment.
-     *
-     * @param segment the actual memory segment being tracked
-     * @param length the logical length of the data in the segment
-     * @param onFullyReleased a callback to invoke when the segment is no longer in use
+     * Callback invoked when reference count reaches zero.
+     * Typically returns the segment to a memory pool for reuse.
      */
-    public RefCountedMemorySegment(MemorySegment segment, int length, BlockReleaser<MemorySegment> onFullyReleased) {
+    private final BlockReleaser<RefCountedMemorySegment> onFullyReleased;
+
+    /**
+     * VarHandle for atomic operations on the generation field.
+     * Used for atomic increment in close() while allowing plain volatile reads in getGeneration().
+     */
+    private static final VarHandle GENERATION;
+    static {
+        try {
+            GENERATION = MethodHandles.lookup().findVarHandle(RefCountedMemorySegment.class, "generation", int.class);
+        } catch (IllegalAccessException | NoSuchFieldException e) {
+            throw new Error(e);
+        }
+    }
+
+    /**
+     * Generation counter incremented on each eviction (close) cycle.
+     * Used by BlockSlotTinyCache to detect stale cached references.
+     *
+     * Incremented when:
+     * - close() is called (segment evicted from cache)
+     *
+     * NOT incremented when:
+     * - reset() is called (segment reused from pool)
+     *
+     * This allows generation-based staleness detection without a separate retired flag.
+     * Once close() increments generation, all cached references with the old generation
+     * become invalid, preventing use of stale or recycled memory.
+     *
+     * Uses plain volatile for ultra-fast reads (hot path in BlockSlotTinyCache).
+     * VarHandle used only for atomic increment in close() (cold path).
+     */
+    private volatile int generation = 0;
+
+    /**
+     * Creates a reference-counted memory segment.
+     *
+     * @param segment the native memory segment to wrap
+     * @param length the logical length of valid data (0 to segment.byteSize())
+     * @param onFullyReleased callback invoked when refCount reaches 0 (typically returns to pool)
+     * @throws IllegalArgumentException if segment or callback is null
+     */
+    public RefCountedMemorySegment(MemorySegment segment, int length, BlockReleaser<RefCountedMemorySegment> onFullyReleased) {
         if (segment == null || onFullyReleased == null) {
             throw new IllegalArgumentException("segment and onFullyReleased must not be null");
         }
         this.segment = segment;
         this.length = length;
         this.onFullyReleased = onFullyReleased;
+
+        this.slicedSegment = (length < segment.byteSize()) ? segment.asSlice(0, length) : segment;
     }
 
     /**
-     * Increments the reference count.
-     * Should be called whenever a new consumer starts using the segment.
+     * Increments the reference count (internal use - prefer {@link #tryPin()} for external callers).
      *
-     * @throws IllegalStateException if the segment has already been released
+     * <p><b>WARNING:</b> This bypasses retirement checks. Use only when you already hold a valid reference
+     * (e.g., creating a clone/slice of an IndexInput).
+     *
+     * @throws IllegalStateException if attempting to increment a fully released segment (refCount was 0)
      */
     public void incRef() {
-        int count = refCount.incrementAndGet();
+        int count = (int) REFCOUNT.getAndAdd(this, 1) + 1;
         if (count <= 1) {
             throw new IllegalStateException("Attempted to revive a released segment (refCount=" + count + ")");
         }
     }
 
     /**
-     * Decrements the reference count.
-     * If the reference count reaches zero, the underlying segment is released via the callback.
+     * Decrements the reference count (internal use - prefer {@link #unpin()} for external callers).
+     * When refCount reaches 0, invokes {@link #onFullyReleased} to return segment to pool.
      *
-     * @throws IllegalStateException if refCount underflows (i.e., decremented below zero)
+     * @throws IllegalStateException if refCount underflows (more decrements than increments)
      */
+    @Override
     public void decRef() {
-        int prev = refCount.getAndDecrement();
+        int prev = (int) REFCOUNT.getAndAdd(this, -1);
         if (prev == 1) {
-            // This thread decremented the last ref, so it's responsible for releasing
-            onFullyReleased.release(segment);
+            // Last reference dropped - return segment to pool
+            onFullyReleased.release(this);
         } else if (prev <= 0) {
             throw new IllegalStateException("decRef underflow (refCount=" + (prev - 1) + ')');
         }
     }
 
     /**
-     * Returns the current ref count.
-     * This is mainly for diagnostics or metrics.
+     * Returns the current reference count (for diagnostics/metrics only).
+     *
+     * @return the current refCount value (1 = cache only, >1 = cache + active readers)
      */
-    public AtomicInteger getRefCount() {
-        return refCount;
+    public int getRefCount() {
+        return refCount; // Direct volatile read
     }
 
     /**
-     * Returns a sliced view of the segment from offset 0 to `length`.
-     * This avoids exposing unused memory region (e.g. for partially filled buffers).
+     * Returns a sliced view of the underlying memory segment containing only valid data.
+     * The returned segment has bounds [0, length), hiding any unused capacity.
+     *
+     * <p><b>IMPORTANT:</b> Only call this while holding a valid pin (after successful {@link #tryPin()}).
+     *
+     * @return sliced MemorySegment from offset 0 to {@link #length}
      */
+
     public MemorySegment segment() {
-        return segment.asSlice(0, length);
+        return slicedSegment;
     }
 
     /**
-     * Returns the logical length of the data inside the segment.
+     * {@inheritDoc}
      */
     @Override
     public int length() {
         return length;
     }
 
-    // === BlockCacheValue Implementation ===
-
     /**
-     * Attempts to pin this segment for use, incrementing the reference count.
-     * Uses CAS loops for thread-safe pinning.
-     * 
-     * @return true if successfully pinned, false if retired or already released
+     * Attempts to acquire a pin (increment refCount) for safe access to this segment.
+     * Uses CAS loops for thread-safe concurrent pinning.
+     *
+     * <p><b>Usage Pattern:</b>
+     * <pre>{@code
+     * RefCountedMemorySegment seg = cache.get(key);
+     * if (seg.tryPin()) {
+     *     try {
+     *         // Safe to use seg.segment() here
+     *     } finally {
+     *         seg.unpin();
+     *     }
+     * }
+     * }</pre>
+     *
+     * @return true if successfully pinned (caller must call {@link #unpin()}), false if retired/released
      */
     @Override
     public boolean tryPin() {
-        try {
-            while (!this.retired) {
-                int r = refCount.get();
-                if (r == 0) {
-                    return false; // already released
-                }
-
-                if (refCount.compareAndSet(r, r + 1)) {
-                    return true; // successfully pinned
-                }
-
-                Thread.onSpinWait();
-            }
-
-            return false; // retired while we were spinning
-        } catch (IllegalStateException e) {
-            // Race condition occurred - segment was released during pinning attempt
-            return false;
+        int r = (int) REFCOUNT.getVolatile(this);
+        while (r > 0) {
+            if (REFCOUNT.compareAndSet(this, r, r + 1))
+                return true;
+            r = (int) REFCOUNT.getVolatile(this);
+            Thread.onSpinWait();
         }
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("tryPin failed: refCount=0");
+        }
+        return false;
     }
 
     /**
-     * Releases a previously acquired pin by decrementing the reference count.
+     * Releases a previously acquired pin.
+     * Every successful {@link #tryPin()} MUST be paired with exactly one {@code unpin()}.
+     *
+     * <p>Delegates to {@link #decRef()}.
      */
     @Override
     public void unpin() {
@@ -170,30 +230,65 @@ public final class RefCountedMemorySegment implements BlockCacheValue<RefCounted
     }
 
     /**
-     * Closes this cache value, marking it as retired and dropping the cache's reference.
-     * Called exactly once by the cache's removal listener.
+     * Resets this segment to a fresh state for reuse from the pool.
+     * Must be called when a segment is reacquired from the free list.
+     *
+     * <p><b>IMPORTANT:</b> This method is NOT thread-safe and should only be called
+     * by the pool while holding its lock, before the segment is handed out.
+     *
+     * <p>Resets:
+     * <ul>
+     *   <li>refCount to 1 (represents new cache/owner reference)</li>
+     * </ul>
+     *
+     * <p>Does NOT increment generation - that happens in close() when evicted.
      */
-    @Override
-    public void close() {
-        if ((boolean) RETIRED.compareAndSet(this, false, true)) {
-            // Drop the cache's ownership reference. If no readers are pinned, this will free now.
-            decRef();
-        }
+    public void reset() {
+        refCount = 1; // safe under pool lock
     }
 
     /**
-     * Returns this segment instance for cache value access.
+     * Returns the current generation number.
+     * Used by BlockSlotTinyCache to detect segment reuse.
+     *
+     * <p>Ultra-fast volatile read optimized for hot path.
+     * Direct field access allows JIT to inline completely.
+     *
+     * @return current generation counter value
+     */
+    public int getGeneration() {
+        return generation; // Direct volatile read - fastest possible
+    }
+
+    /**
+     * Closes this cache value by invalidating it and dropping the cache's reference.
+     *
+     * <p><b>IMPORTANT:</b> This method must be called exactly once per cache entry lifecycle.
+     * Caffeine guarantees removalListener is called exactly once, so this is safe.
+     * Multiple calls would cause refCount underflow.
+     *
+     * <p>This method:
+     * <ol>
+     *   <li>Increments generation (invalidates all cached references in BlockSlotTinyCache)</li>
+     *   <li>Calls decRef() (drops cache's reference)</li>
+     * </ol>
+     *
+     * <p>Once generation is incremented, any cached entries with the old
+     * generation will fail the generation check and reload from the main cache.
+     */
+    @Override
+    public void close() {
+        generation++;
+        decRef();
+    }
+
+    /**
+     * Returns this instance (self-referential for BlockCacheValue contract).
+     *
+     * @return this RefCountedMemorySegment
      */
     @Override
     public RefCountedMemorySegment value() {
         return this;
-    }
-
-    /**
-     * Returns true if this value has been retired from the cache.
-     */
-    @Override
-    public boolean isRetired() {
-        return this.retired;
     }
 }

--- a/src/main/java/org/opensearch/index/store/block_cache/BlockCacheValue.java
+++ b/src/main/java/org/opensearch/index/store/block_cache/BlockCacheValue.java
@@ -10,66 +10,79 @@ package org.opensearch.index.store.block_cache;
  *
  * <h2>Lifecycle Contract</h2>
  * <ul>
- *   <li><b>Pin before use:</b> Call {@link #isRetired()} before accessing {@link #value()}.
- *       If it returns {@code true}, you must eventually call {@link #unpin()} (potentially in a {@code finally}).</li>
- *   <li><b>Retirement:</b> When the cache removes this entry, it will call {@link #close()} exactly once.
- *       Implementations must mark the value as <i>retired</i> so that new {@link #isRetired()} attempts fail,
- *       and then drop the cache’s reference. The underlying resource is freed only when the refcount reaches zero.</li>
- *   <li><b>No unpinned access:</b> Callers must never read from {@link #value()} without a successful {@link #isRetired()}.</li>
+ *   <li><b>Pin before use:</b> Call {@link #tryPin()} before accessing {@link #value()}.
+ *       If it returns {@code true}, you <em>must</em> eventually call {@link #unpin()}
+ *       (typically in a {@code finally} block).</li>
+ *   <li><b>Retirement:</b> When the cache removes this entry, it will call {@link #close()} exactly once
+ *       and then drop the cache’s reference. The underlying resource is freed only when the reference
+ *       count reaches zero (i.e., after the last {@link #unpin()}).</li>
+ *   <li><b>No unpinned access:</b> Callers must only read from {@link #value()} while holding a pin
+ *       acquired via {@link #tryPin()}. If {@link #tryPin()} returns {@code false} or after
+ *       {@link #close()} has been called, the value must not be accessed.</li>
  * </ul>
  *
  * <h2>Thread-safety</h2>
- * All methods are expected to be thread-safe. {@link #isRetired()} and {@link #unpin()} must be safe under concurrency.
+ * Implementations must be safe for concurrent {@link #tryPin()}, {@link #unpin()}, and a single
+ * {@link #close()} call. Access to {@link #value()} must be safe for concurrent readers that each
+ * hold a pin. Implementations should ensure {@link #tryPin()} fails (returns {@code false})
+ * once the value has been retired.
  *
- * @param <T> The wrapped resource type (e.g., RefCountedMemorySegment)
+ * @param <T> The wrapped resource type (e.g., a read-only view like RefCountedMemorySegment)
  */
 public interface BlockCacheValue<T> extends AutoCloseable {
 
     /**
      * Attempts to increment the pin/reference count for this value.
-     * <p>
-     * Succeeds only if the value is not {@linkplain #isRetired() retired} and not already fully released.
      *
-     * @return {@code true} if the caller acquired a pin and may access {@link #value()}, {@code false} otherwise
+     * @return {@code true} if the caller acquired a pin and may access {@link #value()},
+     *         {@code false} if the value is retired or otherwise unavailable
      */
     boolean tryPin();
 
     /**
      * Releases a previously acquired pin.
      * <p>
-     * Every successful {@link #isRetired()} must be paired with exactly one {@code unpin()}.
+     * Every successful {@link #tryPin()} call must be paired with exactly one {@code unpin()}.
      * When the last pin is released (including the cache’s own hold after {@link #close()}),
      * the underlying resource should be freed.
      */
     void unpin();
 
     /**
-     * @return the wrapped resource for read-only use while pinned.
-     *         Calling code must have a valid pin (see {@link #isRetired()} / {@link #unpin()}).
+     * Returns the wrapped resource for read-only use while pinned.
+     * <p>
+     * Callers must only use the returned value while they hold a pin acquired via {@link #tryPin()}.
      */
     T value();
 
     /**
-     * @return logical size of this value in bytes (e.g., block length).
+     * @return logical size of this value in bytes (e.g., block length). This is expected to be stable
+     *         for the lifetime of the cache entry.
      */
     int length();
 
     /**
-     * @return {@code true} if this value has been retired by the cache (removed/invalidated/evicted)
-     *         and will not accept new pins; existing pins may still be active until released.
-     */
-    boolean isRetired();
-
-    /**
-     * Retires this value from the cache and drops the cache’s reference.
+     * Retires this value from the cache and drops the cache's reference.
      * <p>
-     * <b>Called exactly once</b> by the cache (e.g., via removalListener). Implementations must:
+     * <b>Called exactly once</b> by the cache (e.g., via a removal listener). Implementations must:
      * <ol>
-     *   <li>Mark the value as retired so future {@link #isRetired()} fail.</li>
-     *   <li>Drop the cache’s hold on the refcount.</li>
-     *   <li>Only free the underlying resource when the refcount reaches zero.</li>
+     *   <li>Mark the value as retired so that subsequent {@link #tryPin()} attempts fail.</li>
+     *   <li>Drop the cache's reference (the underlying resource is freed only when the total
+     *       reference count reaches zero).</li>
      * </ol>
+     * Implementations should not throw checked exceptions.
      */
     @Override
     void close();
+
+    /**
+     * Drops a reference to this value without retirement semantics.
+     * <p>
+     * Use this when releasing ownership of a value that was never inserted into the cache
+     * (e.g., duplicate loads in bulk operations). Unlike {@link #close()}, this does not
+     * increment the generation counter or mark the value as retired.
+     * <p>
+     * When the reference count reaches zero, the underlying resource is freed/returned to pool.
+     */
+    void decRef();
 }

--- a/src/main/java/org/opensearch/index/store/block_loader/CryptoDirectIOBlockLoader.java
+++ b/src/main/java/org/opensearch/index/store/block_loader/CryptoDirectIOBlockLoader.java
@@ -20,25 +20,24 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.index.store.block.RefCountedMemorySegment;
 import org.opensearch.index.store.cipher.MemorySegmentDecryptor;
 import org.opensearch.index.store.iv.KeyIvResolver;
-import org.opensearch.index.store.pool.MemorySegmentPool;
 import org.opensearch.index.store.pool.Pool;
 
-@SuppressWarnings("preview")
-public class CryptoDirectIOBlockLoader implements BlockLoader<MemorySegmentPool.SegmentHandle> {
+public class CryptoDirectIOBlockLoader implements BlockLoader<RefCountedMemorySegment> {
     private static final Logger LOGGER = LogManager.getLogger(CryptoDirectIOBlockLoader.class);
 
-    private final Pool<MemorySegmentPool.SegmentHandle> segmentPool;
+    private final Pool<RefCountedMemorySegment> segmentPool;
     private final KeyIvResolver keyIvResolver;
 
-    public CryptoDirectIOBlockLoader(Pool<MemorySegmentPool.SegmentHandle> segmentPool, KeyIvResolver keyIvResolver) {
+    public CryptoDirectIOBlockLoader(Pool<RefCountedMemorySegment> segmentPool, KeyIvResolver keyIvResolver) {
         this.segmentPool = segmentPool;
         this.keyIvResolver = keyIvResolver;
     }
 
     @Override
-    public MemorySegmentPool.SegmentHandle[] load(Path filePath, long startOffset, long blockCount) throws Exception {
+    public RefCountedMemorySegment[] load(Path filePath, long startOffset, long blockCount) throws Exception {
         if (!Files.exists(filePath)) {
             throw new NoSuchFileException(filePath.toString());
         }
@@ -51,7 +50,7 @@ public class CryptoDirectIOBlockLoader implements BlockLoader<MemorySegmentPool.
             throw new IllegalArgumentException("blockCount must be positive: " + blockCount);
         }
 
-        MemorySegmentPool.SegmentHandle[] result = new MemorySegmentPool.SegmentHandle[(int) blockCount];
+        RefCountedMemorySegment[] result = new RefCountedMemorySegment[(int) blockCount];
         long readLength = blockCount << CACHE_BLOCK_SIZE_POWER;
 
         try (
@@ -81,7 +80,7 @@ public class CryptoDirectIOBlockLoader implements BlockLoader<MemorySegmentPool.
 
             try {
                 while (blockIndex < blockCount && bytesCopied < bytesRead) {
-                    MemorySegmentPool.SegmentHandle handle = segmentPool.tryAcquire(10, TimeUnit.MILLISECONDS);
+                    RefCountedMemorySegment handle = segmentPool.tryAcquire(10, TimeUnit.MILLISECONDS);
                     if (handle == null) {
                         throw new RuntimeException("Failed to acquire a block");
                     }
@@ -114,10 +113,10 @@ public class CryptoDirectIOBlockLoader implements BlockLoader<MemorySegmentPool.
         }
     }
 
-    private void releaseHandles(MemorySegmentPool.SegmentHandle[] handles, int upTo) {
+    private void releaseHandles(RefCountedMemorySegment[] handles, int upTo) {
         for (int i = 0; i < upTo; i++) {
             if (handles[i] != null) {
-                handles[i].release();  // Release back to correct tier
+                handles[i].decRef();
             }
         }
     }

--- a/src/main/java/org/opensearch/index/store/directio/BlockSlotTinyCache.java
+++ b/src/main/java/org/opensearch/index/store/directio/BlockSlotTinyCache.java
@@ -4,8 +4,6 @@
  */
 package org.opensearch.index.store.directio;
 
-import static org.opensearch.index.store.directio.DirectIoConfigs.CACHE_BLOCK_SIZE_POWER;
-
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -13,13 +11,37 @@ import org.opensearch.index.store.block.RefCountedMemorySegment;
 import org.opensearch.index.store.block_cache.BlockCache;
 import org.opensearch.index.store.block_cache.BlockCacheValue;
 import org.opensearch.index.store.block_cache.FileBlockCacheKey;
+import static org.opensearch.index.store.directio.DirectIoConfigs.CACHE_BLOCK_SIZE_POWER;
 
+/**
+ * Fast L1 cache for recently accessed blocks.
+ * Sits in front of the main Caffeine cache to reduce cache lookup overhead.
+ *
+ * <h2>Generation-based Staleness Detection</h2>
+ * Each cached entry stores a generation number snapshot from the underlying
+ * RefCountedMemorySegment. The generation counter is incremented when a segment
+ * is evicted from the main cache (via close()), invalidating all L1 cache references.
+ *
+ * This prevents returning stale data in two scenarios:
+ *
+ * <h3>Scenario 1: Eviction without reuse</h3>
+ * 1. File A's block cached in L1 → RefCountedMemorySegment@X (gen=5)
+ * 2. Main cache evicts → close() increments gen to 6
+ * 3. L1 checks: cached gen(5) ≠ current gen(6) → reload from main cache
+ *
+ * <h3>Scenario 2: Eviction with pool reuse</h3>
+ * 1. File A's block cached in L1 → RefCountedMemorySegment@X (gen=5)
+ * 2. Main cache evicts → close() increments gen to 6, segment returned to pool
+ * 3. Pool reuses segment for File B → RefCountedMemorySegment@X (gen=6, new data)
+ * 4. Reader requests File A → L1 checks: cached gen(5) ≠ current gen(6) → reload
+ *
+ */
 public final class BlockSlotTinyCache {
 
     private static final int SLOT_COUNT = 32;
     private static final int SLOT_MASK = SLOT_COUNT - 1;
 
-    private record Slot(long blockIdx, BlockCacheValue<RefCountedMemorySegment> val) {
+    private record Slot(long blockIdx, BlockCacheValue<RefCountedMemorySegment> val, int generation) {
     }
 
     private final BlockCache<RefCountedMemorySegment> cache;
@@ -31,6 +53,7 @@ public final class BlockSlotTinyCache {
 
     private long lastBlockIdx = -1;
     private BlockCacheValue<RefCountedMemorySegment> lastVal;
+    private int lastGeneration = -1;
 
     BlockSlotTinyCache(BlockCache<RefCountedMemorySegment> cache, Path path, long fileLength) {
         this.cache = cache;
@@ -43,10 +66,11 @@ public final class BlockSlotTinyCache {
         final long blockIdx = blockOff >>> CACHE_BLOCK_SIZE_POWER;
 
         // Fast path: last accessed (avoid slot calculation if possible)
-        if (blockIdx == lastBlockIdx) {
-            BlockCacheValue<RefCountedMemorySegment> val = lastVal;
-            if (val != null && !val.isRetired()) {
-                return val;
+
+        if (blockIdx == lastBlockIdx && lastVal != null) {
+            RefCountedMemorySegment seg = lastVal.value();
+            if (seg.getGeneration() == lastGeneration) {
+                return lastVal;
             }
         }
 
@@ -56,11 +80,17 @@ public final class BlockSlotTinyCache {
         Slot slot = slots[slotIdx];
         if (slot != null && slot.blockIdx == blockIdx) {
             BlockCacheValue<RefCountedMemorySegment> val = slot.val;
-            if (val != null && !val.isRetired()) {
-                // Cache both slot and last reference atomically
-                lastBlockIdx = blockIdx;
-                lastVal = val;
-                return val;
+            if (val != null) {
+                // Check generation to detect segment eviction or reuse
+                int currentGen = val.value().getGeneration();
+                if (currentGen == slot.generation) {
+                    // Cache both slot and last reference atomically
+                    lastBlockIdx = blockIdx;
+                    lastVal = val;
+                    lastGeneration = currentGen;
+                    return val;
+                }
+                // Generation mismatch - segment was evicted/recycled, fall through to reload
             }
         }
 
@@ -76,62 +106,20 @@ public final class BlockSlotTinyCache {
             val = cache.getOrLoad(key);
         }
 
-        // Single update point - create new slot record
-        slots[slotIdx] = new Slot(blockIdx, val);
+        // Single update point - create new slot record with current generation
+        int generation = val.value().getGeneration();
+        slots[slotIdx] = new Slot(blockIdx, val, generation);
         lastBlockIdx = blockIdx;
         lastVal = val;
+        lastGeneration = generation;
 
         return val;
-    }
-
-    public RefCountedMemorySegment acquireRefCounted(long blockOff) throws IOException {
-        final long blockIdx = blockOff >>> CACHE_BLOCK_SIZE_POWER;
-
-        // Fast path: last accessed (avoid slot calculation if possible)
-        if (blockIdx == lastBlockIdx) {
-            BlockCacheValue<RefCountedMemorySegment> val = lastVal;
-            if (val != null && !val.isRetired()) {
-                return val.value();
-            }
-        }
-
-        final int slotIdx = (int) (blockIdx & SLOT_MASK);
-
-        // Slot lookup - single memory access, better cache locality
-        Slot slot = slots[slotIdx];
-        if (slot != null && slot.blockIdx == blockIdx) {
-            BlockCacheValue<RefCountedMemorySegment> val = slot.val;
-            if (val != null && !val.isRetired()) {
-                // Cache both slot and last reference atomically
-                lastBlockIdx = blockIdx;
-                lastVal = val;
-                return val.value();
-            }
-        }
-
-        // Cache miss path - reuse pre-allocated key if possible
-        FileBlockCacheKey key = slotKeys[slotIdx];
-        if (key == null || key.fileOffset() != blockOff) {
-            key = new FileBlockCacheKey(path, blockOff);
-            slotKeys[slotIdx] = key; // Cache for future use
-        }
-        BlockCacheValue<RefCountedMemorySegment> val = cache.get(key);
-
-        if (val == null) {
-            val = cache.getOrLoad(key);
-        }
-
-        // Single update point - create new slot record
-        slots[slotIdx] = new Slot(blockIdx, val);
-        lastBlockIdx = blockIdx;
-        lastVal = val;
-
-        return val.value();
     }
 
     public void clear() {
         lastBlockIdx = -1;
         lastVal = null;
+        lastGeneration = -1;
         for (int i = 0; i < SLOT_COUNT; i++) {
             slots[i] = null;
             slotKeys[i] = null; // Clear cached keys

--- a/src/main/java/org/opensearch/index/store/directio/CryptoDirectIODirectory.java
+++ b/src/main/java/org/opensearch/index/store/directio/CryptoDirectIODirectory.java
@@ -28,7 +28,6 @@ import org.opensearch.index.store.block_cache.BlockCache;
 import org.opensearch.index.store.block_cache.FileBlockCacheKey;
 import org.opensearch.index.store.block_loader.BlockLoader;
 import org.opensearch.index.store.iv.KeyIvResolver;
-import org.opensearch.index.store.pool.MemorySegmentPool;
 import org.opensearch.index.store.pool.Pool;
 import org.opensearch.index.store.read_ahead.ReadaheadContext;
 import org.opensearch.index.store.read_ahead.ReadaheadManager;
@@ -40,7 +39,7 @@ public final class CryptoDirectIODirectory extends FSDirectory {
     private static final Logger LOGGER = LogManager.getLogger(CryptoDirectIODirectory.class);
     private final AtomicLong nextTempFileCounter = new AtomicLong();
 
-    private final Pool<MemorySegmentPool.SegmentHandle> memorySegmentPool;
+    private final Pool<RefCountedMemorySegment> memorySegmentPool;
     private final BlockCache<RefCountedMemorySegment> blockCache;
     private final Worker readAheadworker;
     private final KeyIvResolver keyIvResolver;
@@ -50,9 +49,9 @@ public final class CryptoDirectIODirectory extends FSDirectory {
         LockFactory lockFactory,
         Provider provider,
         KeyIvResolver keyIvResolver,
-        Pool<MemorySegmentPool.SegmentHandle> memorySegmentPool,
+        Pool<RefCountedMemorySegment> memorySegmentPool,
         BlockCache<RefCountedMemorySegment> blockCache,
-        BlockLoader<MemorySegmentPool.SegmentHandle> blockLoader,
+        BlockLoader<RefCountedMemorySegment> blockLoader,
         Worker worker
     )
         throws IOException {

--- a/src/main/java/org/opensearch/index/store/pool/MemorySegmentPool.java
+++ b/src/main/java/org/opensearch/index/store/pool/MemorySegmentPool.java
@@ -4,23 +4,26 @@
  */
 package org.opensearch.index.store.pool;
 
-import java.lang.foreign.MemorySegment;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.common.SuppressForbidden;
+import org.opensearch.index.store.block.RefCountedMemorySegment;
 
 /**
  * Exception hierarchy for memory pool exhaustion
  */
+
 class PoolExhaustedException extends RuntimeException {
+
     public PoolExhaustedException(String message) {
         super(message);
     }
 }
 
 class PrimaryPoolExhaustedException extends PoolExhaustedException {
+
     public PrimaryPoolExhaustedException() {
         super("Primary pool exhausted: no free segments available");
     }
@@ -33,6 +36,7 @@ class SecondaryPoolExhaustedException extends PoolExhaustedException {
 }
 
 class SecondaryPoolUnavailableException extends PoolExhaustedException {
+
     public SecondaryPoolUnavailableException(String reason) {
         super("Secondary pool unavailable: " + reason);
     }
@@ -44,9 +48,8 @@ class NoOffHeapMemoryException extends PoolExhaustedException {
     }
 }
 
-@SuppressWarnings("preview")
 @SuppressForbidden(reason = "temporary")
-public class MemorySegmentPool implements Pool<MemorySegmentPool.SegmentHandle>, AutoCloseable {
+public class MemorySegmentPool implements Pool<RefCountedMemorySegment>, AutoCloseable {
     private static final Logger LOGGER = LogManager.getLogger(MemorySegmentPool.class);
     private final Object secondaryLock = new Object();
 
@@ -60,35 +63,22 @@ public class MemorySegmentPool implements Pool<MemorySegmentPool.SegmentHandle>,
         this.secondaryPool = null; // Initialize only when needed
     }
 
-    /**
-     * Handle that carries the segment and its owning pool.
-     */
-    public record SegmentHandle(MemorySegment segment, Pool<MemorySegment> origin) implements AutoCloseable {
-        public void release() {
-            origin.release(segment);
-        }
-
-        @Override
-        public void close() {
-            release();
-        }
-    }
-
     @Override
-    public SegmentHandle acquire() throws InterruptedException {
+    public RefCountedMemorySegment acquire() throws InterruptedException {
         // Try primary pool first
         try {
-            return new SegmentHandle(primaryPool.acquire(), primaryPool);
+            return primaryPool.acquire();
         } catch (PrimaryPoolExhaustedException e) {
             // Fallback to secondary pool
             try {
                 tryAcquireFromSecondary();
-                return new SegmentHandle(secondaryPool.acquire(), secondaryPool);
+                return secondaryPool.acquire();
+
             } catch (SecondaryPoolExhaustedException | SecondaryPoolUnavailableException se) {
                 // Final fallback to ephemeral pool
                 try {
                     EphemeralMemorySegmentPool ephemeral = new EphemeralMemorySegmentPool(primaryPool.pooledSegmentSize());
-                    return new SegmentHandle(ephemeral.acquire(), ephemeral);
+                    return ephemeral.acquire();
                 } catch (Exception ee) {
                     throw new NoOffHeapMemoryException();
                 }
@@ -97,27 +87,8 @@ public class MemorySegmentPool implements Pool<MemorySegmentPool.SegmentHandle>,
     }
 
     @Override
-    public SegmentHandle tryAcquire(long timeout, TimeUnit unit) throws InterruptedException {
-        // Try primary pool first
-        try {
-            MemorySegment seg = primaryPool.tryAcquire(timeout, unit);
-            return new SegmentHandle(seg, primaryPool);
-        } catch (PrimaryPoolExhaustedException e) {
-            // Fallback to secondary pool
-            try {
-                tryAcquireFromSecondary();
-                MemorySegment seg = secondaryPool.tryAcquire(timeout, unit);
-                return new SegmentHandle(seg, secondaryPool);
-            } catch (SecondaryPoolExhaustedException | SecondaryPoolUnavailableException se) {
-                // Final fallback to ephemeral pool
-                try {
-                    EphemeralMemorySegmentPool ephemeral = new EphemeralMemorySegmentPool(primaryPool.pooledSegmentSize());
-                    return new SegmentHandle(ephemeral.acquire(), ephemeral);
-                } catch (Exception ee) {
-                    throw new NoOffHeapMemoryException();
-                }
-            }
-        }
+    public RefCountedMemorySegment tryAcquire(long timeout, TimeUnit unit) throws InterruptedException {
+        return acquire();
     }
 
     private void tryAcquireFromSecondary() throws SecondaryPoolUnavailableException {
@@ -125,16 +96,11 @@ public class MemorySegmentPool implements Pool<MemorySegmentPool.SegmentHandle>,
             synchronized (secondaryLock) {
                 if (secondaryPool == null || secondaryPool.isClosed()) {
                     try {
-                        if (secondaryPool != null && secondaryPool.isClosed()) {
-                            LOGGER.info("Renewing closed secondary pool");
-                            secondaryPool.renew();
-                        } else {
-                            LOGGER.info("Creating secondary pool on demand");
-                            long secondaryMemory = primaryPool.totalMemory() / 2;
-                            secondaryPool = new SecondaryMemorySegmentPool(secondaryMemory, primaryPool.pooledSegmentSize());
-                        }
+                        LOGGER.info("Creating fresh secondary pool");
+                        long secondaryMemory = primaryPool.totalMemory() / 2;
+                        secondaryPool = new SecondaryMemorySegmentPool(secondaryMemory, primaryPool.pooledSegmentSize());
                     } catch (Exception e) {
-                        String reason = "Failed to create/renew secondary pool: " + e.getMessage();
+                        String reason = "Failed to create secondary pool: " + e.getMessage();
                         LOGGER.error(reason, e);
                         throw new SecondaryPoolUnavailableException(reason);
                     }
@@ -144,20 +110,28 @@ public class MemorySegmentPool implements Pool<MemorySegmentPool.SegmentHandle>,
     }
 
     @Override
-    public void release(SegmentHandle handle) {
-        if (handle != null) {
-            handle.release();
-        }
+    public void release(RefCountedMemorySegment refSegment) {
+        // No-op: segments auto-release to their source pool via callback when refCount hits 0
+        // Each segment's callback points to its specific pool (primary/secondary/ephemeral)
+        // Users should call decRef() directly instead of pool.release()
     }
 
     @Override
     public long totalMemory() {
-        return primaryPool.totalMemory() + secondaryPool.totalMemory();
+        long total = primaryPool.totalMemory();
+        if (secondaryPool != null) {
+            total += secondaryPool.totalMemory();
+        }
+        return total;
     }
 
     @Override
     public long availableMemory() {
-        return primaryPool.availableMemory() + secondaryPool.availableMemory();
+        long available = primaryPool.availableMemory();
+        if (secondaryPool != null) {
+            available += secondaryPool.availableMemory();
+        }
+        return available;
     }
 
     @Override


### PR DESCRIPTION
### Description
[Describe what this change achieves]

Previously, to identify a segment in local cache as stale, we used an atomic boolean flag ```retired``` which was marked as ```true``` when the segment referring the block was released. This however had race when a segment was released and reused immediately and the  local cache continue to use a stale entry. This was caught as a corruption during test runs.  We now introduce a generation number for each segment and bump the generation number atomically on every release. Any local access to cache checks for its last known generation number and current and only use the reference if they haven't changed. 

Secondy, remove the indirection between MemorySegmentHandles 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
