### PR TITLE
Pool sizer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,38 +89,37 @@ test {
         showStandardStreams = true
     }
     systemProperty 'tests.security.manager', 'false'
-    systemProperty 'opensearch.storage.warmup.percentage', '0'
-    systemProperty 'opensearch.storage.pool.size.bytes', '268435456' // 256MB for tests
+    systemProperty 'node.store.pool_size_mb', '64'
+    systemProperty 'node.store.pool_warmup_percentage', '0'
     jvmArgs += [
         '--enable-native-access=ALL-UNNAMED',
-        '-XX:MaxDirectMemorySize=512m'
+        '-XX:MaxDirectMemorySize=1g'
     ]
 }
 
 tasks.named('internalClusterTest').configure {
     systemProperty 'tests.security.manager', 'false'
     systemProperty 'java.security.policy', 'test.policy'
-    systemProperty 'opensearch.storage.warmup.percentage', '0'
-    systemProperty 'opensearch.storage.pool.size.bytes', '268435456'
     testLogging {
         events "passed", "skipped", "failed"
         showStandardStreams = true
     }
     jvmArgs += [
         '--enable-native-access=ALL-UNNAMED',
-        '-XX:MaxDirectMemorySize=512m'
+        '-XX:MaxDirectMemorySize=1g'
     ]
 }
 
+
 tasks.named('yamlRestTest').configure {
-    systemProperty 'opensearch.storage.warmup.percentage', '0'
-    systemProperty 'opensearch.storage.pool.size.bytes', '134217728'
+    systemProperty 'node.store.pool_size_mb', '64'
+    systemProperty 'node.store.pool_warmup_percentage', '0'
 }
 
 testClusters.yamlRestTest {
-    systemProperty 'opensearch.storage.warmup.percentage', '0'
-    systemProperty 'opensearch.storage.pool.size.bytes', '134217728'
-    jvmArgs '-XX:MaxDirectMemorySize=512m'
+    setting 'node.store.pool_size_mb', '64'
+    setting 'node.store.pool_warmup_percentage', '0'
+    jvmArgs '-XX:MaxDirectMemorySize=1g'
 }
 
 compileJava {

--- a/src/internalClusterTest/java/org/opensearch/index/store/niofs/CryptoDirectoryIntegTestCases.java
+++ b/src/internalClusterTest/java/org/opensearch/index/store/niofs/CryptoDirectoryIntegTestCases.java
@@ -5,6 +5,8 @@
 package org.opensearch.index.store.niofs;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -28,6 +30,16 @@ public class CryptoDirectoryIntegTestCases extends OpenSearchIntegTestCase {
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return Arrays
             .asList(CryptoDirectoryPlugin.class, MockCryptoKeyProviderPlugin.class, MockCryptoPlugin.class, ReindexModulePlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings
+            .builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put("node.store.pool_size_mb", 64)
+            .put("node.store.pool_warmup_percentage", 0.0)
+            .build();
     }
 
     @Override

--- a/src/main/java/org/opensearch/index/store/CryptoDirectoryPlugin.java
+++ b/src/main/java/org/opensearch/index/store/CryptoDirectoryPlugin.java
@@ -27,6 +27,7 @@ import org.opensearch.index.engine.EngineFactory;
 import org.opensearch.index.shard.IndexEventListener;
 import org.opensearch.index.store.iv.IndexKeyResolverRegistry;
 import org.opensearch.index.store.iv.NodeLevelKeyCache;
+import org.opensearch.index.store.pool.PoolSizeCalculator;
 import org.opensearch.indices.cluster.IndicesClusterStateService.AllocatedIndices.IndexRemovalReason;
 import org.opensearch.plugins.EnginePlugin;
 import org.opensearch.plugins.IndexStorePlugin;
@@ -58,7 +59,10 @@ public class CryptoDirectoryPlugin extends Plugin implements IndexStorePlugin, E
             .asList(
                 CryptoDirectoryFactory.INDEX_KMS_TYPE_SETTING,
                 CryptoDirectoryFactory.INDEX_CRYPTO_PROVIDER_SETTING,
-                CryptoDirectoryFactory.NODE_DATA_KEY_TTL_SECONDS_SETTING
+                CryptoDirectoryFactory.NODE_DATA_KEY_TTL_SECONDS_SETTING,
+                PoolSizeCalculator.NODE_POOL_SIZE_PERCENTAGE_SETTING,
+                PoolSizeCalculator.NODE_POOL_SIZE_MB_SETTING,
+                PoolSizeCalculator.NODE_POOL_WARMUP_PERCENTAGE_SETTING
             );
     }
 
@@ -96,7 +100,7 @@ public class CryptoDirectoryPlugin extends Plugin implements IndexStorePlugin, E
         IndexNameExpressionResolver expressionResolver,
         Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
-        CryptoDirectoryFactory.initializeSharedPool();
+        CryptoDirectoryFactory.initializeSharedPool(environment.settings());
         NodeLevelKeyCache.initialize(environment.settings());
 
         return Collections.emptyList();

--- a/src/main/java/org/opensearch/index/store/PanamaNativeAccess.java
+++ b/src/main/java/org/opensearch/index/store/PanamaNativeAccess.java
@@ -17,7 +17,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.common.SuppressForbidden;
 
 /**
- * Utility class for accessing native POSIX functions via Panama Foreign Function & Memory API.
+ * Utility class for accessing native POSIX functions via Panama Foreign Function  Memory API.
  */
 @SuppressForbidden(reason = "Uses Panama FFI for native function access")
 @SuppressWarnings("preview")

--- a/src/main/java/org/opensearch/index/store/block_cache/BlockCacheBuilder.java
+++ b/src/main/java/org/opensearch/index/store/block_cache/BlockCacheBuilder.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.block_cache;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.SuppressForbidden;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+
+/**
+ * Builder for creating block caches with proper lifecycle management.
+ */
+@SuppressForbidden(reason = "use ThreadPoolExecutor with silent failures, failures may not need to panic threads")
+public final class BlockCacheBuilder {
+
+    private static final Logger LOGGER = LogManager.getLogger(BlockCacheBuilder.class);
+
+    private BlockCacheBuilder() {}
+
+    /**
+     * Creates a block cache with the specified capacity and removal handling.
+     *
+     * @param <T> the type of cached block values
+     * @param <V> the type returned by the block loader
+     * @param initialCapacity initial capacity hint for the cache
+     * @param maxBlocks maximum number of blocks to cache
+     * @return configured CaffeineBlockCache instance
+     */
+    public static <T extends AutoCloseable, V> CaffeineBlockCache<T, V> build(int initialCapacity, long maxBlocks) {
+        @SuppressWarnings("resource")
+        ThreadPoolExecutor removalExec = new ThreadPoolExecutor(4, 8, 60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), r -> {
+            Thread t = new Thread(r, "block-cache-maint");
+            t.setDaemon(true);
+            return t;
+        });
+
+        Cache<BlockCacheKey, BlockCacheValue<T>> cache = Caffeine
+            .newBuilder()
+            .initialCapacity(initialCapacity)
+            .recordStats()
+            .maximumSize(maxBlocks)
+            .removalListener((BlockCacheKey key, BlockCacheValue<T> value, RemovalCause cause) -> {
+                if (value != null) {
+                    removalExec.execute(() -> {
+                        try {
+                            value.close();
+                        } catch (Throwable t) {
+                            LOGGER.warn("Failed to close cached value during removal {}", key, t);
+                        }
+                    });
+                }
+            })
+            .build();
+
+        // Loader is null here because this creates a shared cache instance.
+        // Per-directory caches will wrap this cache with their own loaders
+        // that provide directory-specific decryption keys.
+        return new CaffeineBlockCache<>(cache, null, maxBlocks);
+    }
+}

--- a/src/main/java/org/opensearch/index/store/directio/DirectIoConfigs.java
+++ b/src/main/java/org/opensearch/index/store/directio/DirectIoConfigs.java
@@ -10,26 +10,6 @@ public class DirectIoConfigs {
     public static final int DIRECT_IO_ALIGNMENT = Math.max(512, getPageSizeSafe());
     public static final int DIRECT_IO_WRITE_BUFFER_SIZE_POWER = 18;
 
-    /**
-     * Total size of the reserved memory pool in bytes.
-     * Can be overridden via system property: opensearch.storage.pool.size.bytes
-     * Default: 32GB
-     */
-    public static final long RESEVERED_POOL_SIZE_IN_BYTES = Long
-        .parseLong(System.getProperty("opensearch.storage.pool.size.bytes", String.valueOf(32L * 1024 * 1024 * 1024)));
-
-    /**
-     * Percentage of memory pool to pre-allocate during warm-up (0.0 to 1.0).
-     * In Java 21, Arena.allocate() requires direct memory to be allocated upfront.
-     * we warm-up pre-allocates memory segments to avoid allocation overhead during I/O operations,
-     * but can cause OutOfMemoryError in memory-constrained environments like tests.
-     *
-     * Can be overridden via system property: opensearch.storage.warmup.percentage
-     * Default: 0.2 (20% warm-up)
-     * Tests typically set this to 0 to avoid direct buffer memory exhaustion.
-     */
-    public static final double WARM_UP_PERCENTAGE = Double.parseDouble(System.getProperty("opensearch.storage.warmup.percentage", "0.2"));
-
     public static final int CACHE_BLOCK_SIZE_POWER = 13;
     public static final int CACHE_BLOCK_SIZE = 1 << CACHE_BLOCK_SIZE_POWER;
     public static final long CACHE_BLOCK_MASK = CACHE_BLOCK_SIZE - 1;

--- a/src/main/java/org/opensearch/index/store/pool/EphemeralMemorySegmentPool.java
+++ b/src/main/java/org/opensearch/index/store/pool/EphemeralMemorySegmentPool.java
@@ -8,74 +8,83 @@ import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.index.store.block.RefCountedMemorySegment;
 
 @SuppressWarnings("preview")
 @SuppressForbidden(reason = "allocates standalone arenas per segment")
 public class EphemeralMemorySegmentPool implements Pool<RefCountedMemorySegment>, AutoCloseable {
-    private final Arena arena;
+
+    private static final Logger LOGGER = LogManager.getLogger(EphemeralMemorySegmentPool.class);
     private final int segmentSize;
 
     public EphemeralMemorySegmentPool(int segmentSize) {
         this.segmentSize = segmentSize;
-        this.arena = Arena.ofShared();
     }
 
     @Override
     public RefCountedMemorySegment acquire() {
-        MemorySegment segment = arena.allocate(segmentSize);
-        RefCountedMemorySegment refSegment = new RefCountedMemorySegment(segment, segmentSize, this::release);
-        return refSegment;
+        // Each segment gets its own confined arena
+        final Arena arena = Arena.ofShared();
+        final MemorySegment segment = arena.allocate(segmentSize);
+
+        // Return a refcounted wrapper that closes this arena upon release
+        return new RefCountedMemorySegment(segment, segmentSize, _ -> {
+            try {
+                arena.close(); // Frees native memory immediately
+            } catch (Exception e) {
+                LOGGER.warn("Failed to close ephemeral arena", e);
+            }
+        });
     }
 
     @Override
     public void release(RefCountedMemorySegment refSegment) {
-        close();
+        // no-op, as release is handled in RefCountedMemorySegment’s callback
     }
 
     @Override
-    public void close() {
-        arena.close();
-    }
-
-    @Override
-    public RefCountedMemorySegment tryAcquire(long timeout, TimeUnit unit) throws InterruptedException {
+    public RefCountedMemorySegment tryAcquire(long timeout, TimeUnit unit) {
         return acquire();
     }
 
     @Override
-    public long totalMemory() {
-        throw new UnsupportedOperationException("Unimplemented method 'totalMemory'");
+    public void close() {
+        // no global arenas, nothing to close
     }
 
     @Override
     public String poolStats() {
-        return String.format("EphemeralPool[size=%d]", segmentSize);
+        return "EphemeralMemorySegmentPool[1 arena per segment, size=" + segmentSize + "]";
+    }
+
+    @Override
+    public long totalMemory() {
+        return 0;
     }
 
     @Override
     public long availableMemory() {
-        throw new UnsupportedOperationException("Unimplemented method 'availableMemory'");
+        return 0;
     }
 
     @Override
     public int pooledSegmentSize() {
-        throw new UnsupportedOperationException("Unimplemented method 'pooledSegmentSize'");
+        return segmentSize;
     }
 
     @Override
     public boolean isUnderPressure() {
-        throw new UnsupportedOperationException("Unimplemented method 'isUnderPressure'");
+        return false;
     }
 
     @Override
-    public void warmUp(long numBlocks) {
-        throw new UnsupportedOperationException("Unimplemented method 'warmUp'");
-    }
+    public void warmUp(long numBlocks) {}
 
     @Override
     public boolean isClosed() {
-        throw new UnsupportedOperationException("Unimplemented method isClosed");
+        return false;
     }
 }

--- a/src/main/java/org/opensearch/index/store/pool/PoolSizeCalculator.java
+++ b/src/main/java/org/opensearch/index/store/pool/PoolSizeCalculator.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.pool;
+
+import java.util.Locale;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Setting.Property;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.monitor.os.OsProbe;
+
+/**
+ * Utility class for calculating memory pool sizes based on node configuration and available memory.
+ */
+public final class PoolSizeCalculator {
+
+    private static final Logger LOGGER = LogManager.getLogger(PoolSizeCalculator.class);
+
+    /** Default fallback used when memory calculation fails. */
+    private static final long DEFAULT_POOL_SIZE_BYTES = 4L * 1024 * 1024 * 1024;
+
+    /** Minimum pool size (1 GB) to ensure adequate memory allocation. */
+    private static final long MIN_POOL_SIZE_BYTES = 1024L * 1024 * 1024;
+
+    private static final long GB_TO_BYTES = 1024L * 1024L * 1024L;
+    private static final long MB_TO_BYTES = 1024L * 1024L;
+
+    /**
+     * Percentage of estimated off-heap memory to reserve for the pool.
+     */
+    public static final Setting<Double> NODE_POOL_SIZE_PERCENTAGE_SETTING = Setting
+        .doubleSetting("node.store.pool_size_percentage", 0.30, 0.0, 1.0, Property.NodeScope);
+
+    /** Explicit pool size override (in MB). Default: -1 (auto-calculate). Minimum: 64 MB. */
+    public static final Setting<Long> NODE_POOL_SIZE_MB_SETTING = Setting
+        .longSetting(
+            "node.store.pool_size_mb",
+            -1L,  // -1 means "auto"
+            -1L,
+            Long.MAX_VALUE,
+            v -> {
+                if (v != -1L && v < 64L) {
+                    throw new IllegalArgumentException("node.store.pool_size_mb must be -1 (auto) or at least 64 MB, got: " + v);
+                }
+            },
+            Property.NodeScope
+        );
+
+    /** Percentage of pool to pre-allocate during warm-up (0.0–1.0). */
+    public static final Setting<Double> NODE_POOL_WARMUP_PERCENTAGE_SETTING = Setting
+        .doubleSetting("node.store.pool_warmup_percentage", 0.2, 0.0, 1.0, Property.NodeScope);
+
+    public static long calculatePoolSize(Settings settings) {
+        long explicitMb = NODE_POOL_SIZE_MB_SETTING.get(settings);
+        if (explicitMb != -1L) {
+            long bytes = explicitMb * MB_TO_BYTES;
+            LOGGER
+                .info(
+                    "Using explicit pool size: {} MB ({}) GB",
+                    explicitMb,
+                    String.format(Locale.ROOT, "%.1f", bytes / (double) GB_TO_BYTES)
+                );
+            return bytes;
+        }
+
+        double pct = NODE_POOL_SIZE_PERCENTAGE_SETTING.get(settings);
+        long maxHeap = Runtime.getRuntime().maxMemory();
+
+        try {
+            long totalPhysical = OsProbe.getInstance().getTotalPhysicalMemorySize();
+            long offHeap = Math.max(0, totalPhysical - maxHeap);
+            long calc = (long) (offHeap * pct);
+            calc = Math.max(MIN_POOL_SIZE_BYTES, calc);
+            calc = Math.min(offHeap, calc);
+            if (calc == 0)
+                calc = DEFAULT_POOL_SIZE_BYTES;
+
+            LOGGER
+                .info(
+                    String
+                        .format(
+                            Locale.ROOT,
+                            "Calculated pool size: %s (%.1f GB) [total=%.1f GB, heap=%.1f GB, offheap=%.1f GB, pct=%.2f]",
+                            toString(calc),
+                            calc / (double) GB_TO_BYTES,
+                            totalPhysical / (double) GB_TO_BYTES,
+                            maxHeap / (double) GB_TO_BYTES,
+                            offHeap / (double) GB_TO_BYTES,
+                            pct
+                        )
+                );
+            return calc;
+
+        } catch (Exception e) {
+            boolean isTest = Boolean.getBoolean("tests.enabled") || "local".equalsIgnoreCase(System.getenv("STAGE"));
+
+            if (isTest) {
+                throw new IllegalStateException("Failed to detect total physical memory in test mode", e);
+            }
+
+            LOGGER.warn("Failed to detect total physical memory; using default {}", toString(DEFAULT_POOL_SIZE_BYTES), e);
+            return DEFAULT_POOL_SIZE_BYTES;
+        }
+    }
+
+    private static String toString(long bytes) {
+        return String.format(Locale.ROOT, "%,d bytes", bytes);
+    }
+
+    private PoolSizeCalculator() {}
+}


### PR DESCRIPTION
### Description
[Describe what this change achieves]

This PR introduces a config to set the primary pool size for our buffer pool.  The default uses 30% of the available off heap memory. The primary when full can expand by another same amount i.e by maximum of 60% of offheap memory leaving behind 40% for page cache. 

This also sets cache size as 80% of the pool size. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
