### PR TITLE
Index setting changes in index.store.crypto, added settings for index level key

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,12 @@ repositories {
     maven { url "https://artifacts.opensearch.org/snapshots/lucene/" }
 }
 
+configurations.all {
+    resolutionStrategy {
+        force 'com.google.errorprone:error_prone_annotations:2.41.0'
+    }
+}
+
 dependencies {
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
     runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"

--- a/src/internalClusterTest/java/org/opensearch/index/store/niofs/CryptoDirectoryIntegTestCases.java
+++ b/src/internalClusterTest/java/org/opensearch/index/store/niofs/CryptoDirectoryIntegTestCases.java
@@ -47,7 +47,8 @@ public class CryptoDirectoryIntegTestCases extends OpenSearchIntegTestCase {
             .builder()
             .put(super.indexSettings())
             .put("index.store.type", "cryptofs")
-            .put("index.store.crypto.kms.type", "dummy")
+            .put("index.store.crypto.key_provider", "dummy")
+            .put("index.store.crypto.kms.key_arn", "dummyArn")
             .build();
     }
 

--- a/src/main/java/org/opensearch/index/store/CryptoDirectoryPlugin.java
+++ b/src/main/java/org/opensearch/index/store/CryptoDirectoryPlugin.java
@@ -60,8 +60,10 @@ public class CryptoDirectoryPlugin extends Plugin implements IndexStorePlugin, E
     public List<Setting<?>> getSettings() {
         return Arrays
             .asList(
-                CryptoDirectoryFactory.INDEX_KMS_TYPE_SETTING,
+                CryptoDirectoryFactory.INDEX_KEY_PROVIDER_SETTING,
                 CryptoDirectoryFactory.INDEX_CRYPTO_PROVIDER_SETTING,
+                CryptoDirectoryFactory.INDEX_KMS_ARN_SETTING,
+                CryptoDirectoryFactory.INDEX_KMS_ENC_CTX_SETTING,
                 CryptoDirectoryFactory.NODE_KEY_REFRESH_INTERVAL_SECS_SETTING,
                 PoolSizeCalculator.NODE_POOL_SIZE_PERCENTAGE_SETTING,
                 PoolSizeCalculator.NODE_POOL_TO_CACHE_RATIO_SETTING,

--- a/src/yamlRestTest/resources/rest-api-spec/test/20_encrypted_index_crud.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/20_encrypted_index_crud.yml
@@ -13,7 +13,8 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
+            index.store.crypto.kms.key_arn: "dummyArn"
 
   - match: { acknowledged: true }
 
@@ -23,7 +24,7 @@
         index: test-crypto-crud
 
   - match: { test-crypto-crud.settings.index.store.type: "cryptofs" }
-  - match: { test-crypto-crud.settings.index.store.crypto.kms.type: "dummy" }
+  - match: { test-crypto-crud.settings.index.store.crypto.key_provider: "dummy" }
 
   # Index a document
   - do:
@@ -152,7 +153,8 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
+            index.store.crypto.kms.key_arn: "dummyArn"
 
   # Index complex document with nested objects and arrays
   - do:
@@ -228,7 +230,8 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
+            index.store.crypto.kms.key_arn: "dummyArn"
 
   # Index documents
   - do:

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_bulk_operations.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_bulk_operations.yml
@@ -13,7 +13,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
 
   # Bulk index multiple documents
   - do:
@@ -145,7 +145,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
 
   # First bulk: create documents
   - do:
@@ -232,7 +232,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
             refresh_interval: -1
 
   # Index 50 documents in one bulk request

--- a/src/yamlRestTest/resources/rest-api-spec/test/40_snapshot_restore.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/40_snapshot_restore.yml
@@ -24,7 +24,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
 
   - do:
       bulk:
@@ -130,7 +130,7 @@
         index: test-crypto-snapshot
 
   - match: { test-crypto-snapshot.settings.index.store.type: "cryptofs" }
-  - match: { test-crypto-snapshot.settings.index.store.crypto.kms.type: "dummy" }
+  - match: { test-crypto-snapshot.settings.index.store.crypto.key_provider: "dummy" }
 
   # Verify we can write to restored index
   - do:
@@ -189,7 +189,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
 
   - do:
       indices.create:
@@ -199,7 +199,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
 
   - do:
       indices.create:
@@ -209,7 +209,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
 
   # Index data into each
   - do:
@@ -321,7 +321,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
 
   - do:
       bulk:
@@ -389,7 +389,7 @@
         index: restored-crypto-index
 
   - match: { restored-crypto-index.settings.index.store.type: "cryptofs" }
-  - match: { restored-crypto-index.settings.index.store.crypto.kms.type: "dummy" }
+  - match: { restored-crypto-index.settings.index.store.crypto.key_provider: "dummy" }
 
   # Cleanup
   - do:
@@ -433,7 +433,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
 
   # Index initial data
   - do:
@@ -579,7 +579,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
 
   - do:
       indices.create:
@@ -589,7 +589,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
 
   - do:
       indices.create:
@@ -599,7 +599,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
 
   # Populate each index
   - do:
@@ -756,7 +756,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
           mappings:
             properties:
               title:

--- a/src/yamlRestTest/resources/rest-api-spec/test/50_translog_operations.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/50_translog_operations.yml
@@ -13,7 +13,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
 
   # Index documents without refresh (stays in translog)
   - do:
@@ -102,7 +102,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
 
   # Index some documents and flush
   - do:
@@ -224,7 +224,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
             index.translog.durability: "request"
 
   # Verify settings
@@ -322,7 +322,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
             index.translog.flush_threshold_size: "1mb"
 
   # Index documents to trigger multiple flushes
@@ -423,7 +423,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
             refresh_interval: -1
 
   # Bulk index many documents without refresh
@@ -532,7 +532,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
 
   # Get initial translog stats
   - do:
@@ -609,7 +609,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
 
   # Simulate concurrent writes with bulk
   - do:

--- a/src/yamlRestTest/resources/rest-api-spec/test/60_cache_stress_tests.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/60_cache_stress_tests.yml
@@ -13,7 +13,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
 
   # Index a very large document (150KB) spanning ~19 cache blocks (8KB each)
   - do:
@@ -69,7 +69,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
 
   # Index multiple 25KB documents to fill cache and trigger eviction
   # Each document spans 3-4 cache blocks (8KB each)
@@ -139,7 +139,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
 
   # Bulk index 10 medium documents (10KB each)
   # Tests sequential access and read-ahead behavior
@@ -219,7 +219,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
 
   # Index documents with varying sizes
   - do:
@@ -302,7 +302,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
 
   # Index large documents with varied content
   - do:
@@ -379,7 +379,7 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.store.type: "cryptofs"
-            index.store.crypto.kms.type: "dummy"
+            index.store.crypto.key_provider: "dummy"
 
   # Index a large document
   - do:


### PR DESCRIPTION
### Description
This PR refactors the key management configuration system to be more generic and extensible, while adding specific support for AWS KMS key providers. The changes prepare the plugin to support multiple key provider types beyond just KMS, addressing the need for users who want to bring their own raw keys.

## Changes Made

• **Renamed setting**: `INDEX_KMS_TYPE_SETTING` → `INDEX_KEY_TYPE_SETTING`
  - Changed key type setting: `index.store.kms.type` → `index.store.crypto.key_type`
  - Makes setting generic for multiple key provider types

• **Added AWS KMS specific settings**:
  - `INDEX_KMS_ARN_SETTING`: `index.store.crypto.kms.key_arn`
  - `INDEX_KMS_ENC_CTX_SETTING`: `index.store.crypto.kms.encryption_context`



## Benefits

- Supports multiple key provider types (not just KMS)
- KMS encryption context provides additional authenticated data
- Prepares for raw key support and other cloud providers

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
