### PR TITLE
Remove platform classifier for native-io_uring dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     api "io.netty:netty-transport-native-unix-common:4.2.5.Final"
     api "io.netty:netty-transport-classes-io_uring:4.2.5.Final"
     api "io.netty:netty-common:4.2.5.Final"
-    api "io.netty:netty-transport-native-io_uring:4.2.5.Final:linux-x86_64"
+    api "io.netty:netty-transport-native-io_uring:4.2.5.Final"
 }
 
 


### PR DESCRIPTION
### Description
Remove platform classifier for native-io_uring dependency to support ARM64/aarch64 machines.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [NA] New functionality includes testing.
- [NA] New functionality has been documented.
- [NA] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [NA] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
