### PR TITLE
Fix race condition in RefCountedMemorySegment.close()

### DIFF
--- a/src/main/java/org/opensearch/index/store/block/RefCountedMemorySegment.java
+++ b/src/main/java/org/opensearch/index/store/block/RefCountedMemorySegment.java
@@ -31,6 +31,7 @@ import org.opensearch.index.store.metrics.ErrorType;
  * </ol>
  *
  */
+@SuppressWarnings("preview")
 public final class RefCountedMemorySegment implements BlockCacheValue<RefCountedMemorySegment> {
 
     private static final Logger LOGGER = LogManager.getLogger(RefCountedMemorySegment.class);


### PR DESCRIPTION
### Description

Reorder operations in close() to decrement refcount before bumping generation. This ensures concurrent tryPin() calls fail-fast on refcount=0, preventing a race where a thread could successfully pin a segment that's being closed (stale data access). 


(the race) 

Thread A checks generation (not stale)
Thread B calls close(), bumps generation
Thread A calls tryPin() and succeeds on stale data
With the new order, tryPin fails-fast on refcount=0.



### Related Issues
Resolves  https://github.com/opensearch-project/opensearch-storage-encryption/pull/80#discussion_r2524269772

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
