### PR TITLE
Set cache size to lesser than pool size

### DIFF
--- a/src/internalClusterTest/java/org/opensearch/index/store/CacheInvalidationIntegTests.java
+++ b/src/internalClusterTest/java/org/opensearch/index/store/CacheInvalidationIntegTests.java
@@ -39,7 +39,7 @@ public class CacheInvalidationIntegTests extends OpenSearchIntegTestCase {
             .put(super.nodeSettings(nodeOrdinal))
             .put("node.store.crypto.pool_size_percentage", 0.05)
             .put("node.store.crypto.warmup_percentage", 0.0)
-            .put("node.store.crypto.pool_to_cache_ratio", 1.25)
+            .put("node.store.crypto.cache_to_pool_ratio", 0.8)
             .put("node.store.crypto.key_refresh_interval_secs", 30)
             .build();
     }

--- a/src/internalClusterTest/java/org/opensearch/index/store/ConcurrencyIntegTests.java
+++ b/src/internalClusterTest/java/org/opensearch/index/store/ConcurrencyIntegTests.java
@@ -49,7 +49,7 @@ public class ConcurrencyIntegTests extends OpenSearchIntegTestCase {
             .put(super.nodeSettings(nodeOrdinal))
             .put("node.store.crypto.pool_size_percentage", 0.05) // 5% for tests
             .put("node.store.crypto.warmup_percentage", 0.0) // No warmup
-            .put("node.store.crypto.pool_to_cache_ratio", 1.25)
+            .put("node.store.crypto.cache_to_pool_ratio", 0.8)
             .put("node.store.crypto.key_refresh_interval_secs", 30) // Short for testing
             .build();
     }
@@ -281,7 +281,7 @@ public class ConcurrencyIntegTests extends OpenSearchIntegTestCase {
             .builder()
             .put(nodeSettings(0))
             .put("node.store.crypto.pool_size_percentage", 0.001) // Very small pool
-            .put("node.store.crypto.pool_to_cache_ratio", 2.0)
+            .put("node.store.crypto.cache_to_pool_ratio", 0.5)
             .build();
 
         internalCluster().startNode(smallPoolSettings);

--- a/src/internalClusterTest/java/org/opensearch/index/store/IndexTemplateIntegTests.java
+++ b/src/internalClusterTest/java/org/opensearch/index/store/IndexTemplateIntegTests.java
@@ -39,7 +39,7 @@ public class IndexTemplateIntegTests extends OpenSearchIntegTestCase {
             .put(super.nodeSettings(nodeOrdinal))
             .put("node.store.crypto.pool_size_percentage", 0.05)
             .put("node.store.crypto.warmup_percentage", 0.0)
-            .put("node.store.crypto.pool_to_cache_ratio", 1.25)
+            .put("node.store.crypto.cache_to_pool_ratio", 0.8)
             .put("node.store.crypto.key_refresh_interval_secs", 30)
             .build();
     }

--- a/src/internalClusterTest/java/org/opensearch/index/store/ShardMigrationIntegTests.java
+++ b/src/internalClusterTest/java/org/opensearch/index/store/ShardMigrationIntegTests.java
@@ -49,7 +49,7 @@ public class ShardMigrationIntegTests extends OpenSearchIntegTestCase {
             .put(super.nodeSettings(nodeOrdinal))
             .put("node.store.crypto.pool_size_percentage", 0.05) // 5% for tests
             .put("node.store.crypto.warmup_percentage", 0.0) // No warmup
-            .put("node.store.crypto.pool_to_cache_ratio", 1.25)
+            .put("node.store.crypto.cache_to_pool_ratio", 0.8)
             .put("node.store.crypto.key_refresh_interval_secs", 30) // Short for testing
             .build();
     }

--- a/src/internalClusterTest/java/org/opensearch/index/store/SnapshotRestoreIntegTests.java
+++ b/src/internalClusterTest/java/org/opensearch/index/store/SnapshotRestoreIntegTests.java
@@ -43,7 +43,7 @@ public class SnapshotRestoreIntegTests extends OpenSearchIntegTestCase {
             .put(super.nodeSettings(nodeOrdinal))
             .put("node.store.crypto.pool_size_percentage", 0.05)
             .put("node.store.crypto.warmup_percentage", 0.0)
-            .put("node.store.crypto.pool_to_cache_ratio", 1.25)
+            .put("node.store.crypto.cache_to_pool_ratio", 0.8)
             .put("node.store.crypto.key_refresh_interval_secs", 30)
             .build();
     }

--- a/src/internalClusterTest/java/org/opensearch/index/store/niofs/CryptoDirectoryIntegTestCases.java
+++ b/src/internalClusterTest/java/org/opensearch/index/store/niofs/CryptoDirectoryIntegTestCases.java
@@ -37,7 +37,7 @@ public class CryptoDirectoryIntegTestCases extends OpenSearchIntegTestCase {
             .put(super.nodeSettings(nodeOrdinal))
             .put("node.store.crypto.pool_size_percentage", 0.05)  // 5% of off-heap for tests (smaller pool)
             .put("node.store.crypto.warmup_percentage", 0.0)      // No warmup to avoid pre-allocating memory
-            .put("node.store.crypto.pool_to_cache_ratio", 1.25)
+            .put("node.store.crypto.cache_to_pool_ratio", 0.8)
             .build();
     }
 

--- a/src/main/java/org/opensearch/index/store/CryptoDirectoryPlugin.java
+++ b/src/main/java/org/opensearch/index/store/CryptoDirectoryPlugin.java
@@ -13,8 +13,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Setting;
@@ -51,9 +49,6 @@ import org.opensearch.watcher.ResourceWatcherService;
  * A plugin that enables index level encryption and decryption.
  */
 public class CryptoDirectoryPlugin extends Plugin implements IndexStorePlugin, EnginePlugin, TelemetryAwarePlugin {
-
-    private static final Logger LOGGER = LogManager.getLogger(CryptoDirectoryPlugin.class);
-
     private PoolBuilder.PoolResources sharedPoolResources;
     private NodeEnvironment nodeEnvironment;
 
@@ -77,7 +72,7 @@ public class CryptoDirectoryPlugin extends Plugin implements IndexStorePlugin, E
                 CryptoDirectoryFactory.INDEX_KMS_ENC_CTX_SETTING,
                 CryptoDirectoryFactory.NODE_KEY_REFRESH_INTERVAL_SECS_SETTING,
                 PoolSizeCalculator.NODE_POOL_SIZE_PERCENTAGE_SETTING,
-                PoolSizeCalculator.NODE_POOL_TO_CACHE_RATIO_SETTING,
+                PoolSizeCalculator.NODE_CACHE_TO_POOL_RATIO_SETTING,
                 PoolSizeCalculator.NODE_WARMUP_PERCENTAGE_SETTING
             );
     }
@@ -175,5 +170,4 @@ public class CryptoDirectoryPlugin extends Plugin implements IndexStorePlugin, E
             });
         }
     }
-
 }

--- a/src/main/java/org/opensearch/index/store/pool/PoolBuilder.java
+++ b/src/main/java/org/opensearch/index/store/pool/PoolBuilder.java
@@ -15,7 +15,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.index.store.block.RefCountedMemorySegment;
 import org.opensearch.index.store.block_cache.BlockCache;
 import org.opensearch.index.store.block_cache.BlockCacheBuilder;
-import org.opensearch.index.store.pool.PoolBuilder.PoolResources;
 
 /**
  * Builder for creating shared pool and cache resources with proper lifecycle management.
@@ -168,7 +167,7 @@ public final class PoolBuilder {
         reservedPoolSizeInBytes = (reservedPoolSizeInBytes / CACHE_BLOCK_SIZE) * CACHE_BLOCK_SIZE;
         long maxBlocks = reservedPoolSizeInBytes / CACHE_BLOCK_SIZE;
 
-        double poolToCacheRatio = PoolSizeCalculator.NODE_POOL_TO_CACHE_RATIO_SETTING.get(settings);
+        double cacheToPoolRatio = PoolSizeCalculator.NODE_CACHE_TO_POOL_RATIO_SETTING.get(settings);
         double warmupPercentage = PoolSizeCalculator.NODE_WARMUP_PERCENTAGE_SETTING.get(settings);
 
         Pool<RefCountedMemorySegment> segmentPool = new MemorySegmentPool(reservedPoolSizeInBytes, CACHE_BLOCK_SIZE);
@@ -180,8 +179,8 @@ public final class PoolBuilder {
                 maxBlocks
             );
 
-        // Calculate cache size: cache = pool / ratio
-        long maxCacheBlocks = (long) (maxBlocks / poolToCacheRatio);
+        // Calculate cache size: cache = pool * ratio
+        long maxCacheBlocks = (long) (maxBlocks * cacheToPoolRatio);
         long warmupBlocks = (long) (maxCacheBlocks * warmupPercentage);
         segmentPool.warmUp(warmupBlocks);
         LOGGER.info("Warmed up {} blocks ({}% of {} cache blocks)", warmupBlocks, warmupPercentage * 100, maxCacheBlocks);

--- a/src/main/java/org/opensearch/index/store/pool/PoolSizeCalculator.java
+++ b/src/main/java/org/opensearch/index/store/pool/PoolSizeCalculator.java
@@ -30,10 +30,12 @@ public final class PoolSizeCalculator {
         .doubleSetting("node.store.crypto.pool_size_percentage", 0.3, 0.0, 1.0, Property.NodeScope);
 
     /**
-     * Ratio of pool size to cache size.
+     * Ratio of cache size to pool size.
+     * cache_size = pool_size * ratio
+     * Default 0.75 means cache is 75% of pool size (enables constant recycling with 25% buffer).
      */
-    public static final Setting<Double> NODE_POOL_TO_CACHE_RATIO_SETTING = Setting
-        .doubleSetting("node.store.crypto.pool_to_cache_ratio", 1.5, 1.0, 10.0, Property.NodeScope);
+    public static final Setting<Double> NODE_CACHE_TO_POOL_RATIO_SETTING = Setting
+        .doubleSetting("node.store.crypto.cache_to_pool_ratio", 0.75, 0.1, 1.0, Property.NodeScope);
 
     /**
      * Percentage of cache blocks to warmup at initialization.


### PR DESCRIPTION
### Description
With cache size < pool size, cache evictions create a natural buffer that prevents the pool from hitting its maximum limit. This guarantees blocks are always available for allocation without waiting for cache pressure to free resources.

later we will build a cache resizer which looks at memory pressure and adjust the size of cache.  
### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
