### PR TITLE
record otel metric for stats and error flow

### DIFF
--- a/src/test/java/org/opensearch/index/store/key/DefaultKeyResolverTests.java
+++ b/src/test/java/org/opensearch/index/store/key/DefaultKeyResolverTests.java
@@ -33,6 +33,8 @@ import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.crypto.DataKeyPair;
 import org.opensearch.common.crypto.MasterKeyProvider;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.index.store.metrics.CryptoMetricsService;
+import org.opensearch.telemetry.metrics.MetricsRegistry;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.client.AdminClient;
 import org.opensearch.transport.client.Client;
@@ -61,6 +63,9 @@ public class DefaultKeyResolverTests extends OpenSearchTestCase {
         directory = new NIOFSDirectory(tempDir, FSLockFactory.getDefault());
         provider = Security.getProvider("SunJCE");
         assertNotNull("SunJCE provider should be available", provider);
+
+        // Initialize CryptoMetricsService
+        CryptoMetricsService.initialize(mock(MetricsRegistry.class));
 
         // Initialize NodeLevelKeyCache with mock Client and ClusterService
         MasterKeyHealthMonitor.reset();


### PR DESCRIPTION
### Description
Added metric to track
1. cache pool stats
2. memoy pool stats
3. KMS error metric

### Related Issues
This is too improve moniotring.

### Check List
- [Y] New functionality includes testing.
- [Y] New functionality has been documented.
- [NA] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [Y] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
