### PR TITLE
Update docs on durability semantics after close is called

### DIFF
--- a/src/main/java/org/opensearch/index/store/directio/BufferIOWithCaching.java
+++ b/src/main/java/org/opensearch/index/store/directio/BufferIOWithCaching.java
@@ -353,16 +353,29 @@ public final class BufferIOWithCaching extends OutputStreamIndexOutput {
 
                 encryptionMetadataCache.putFooter(normalizedPath, footer);
 
+                // close() only flushes to the OS (kernel page cache). It does NOT guarantee
+                // * durability on disk (no fsync here). Lucene will provide the durability boundary by calling
+                // * Directory.sync(files), which issues fsync/force(true) on the files that are part of the
+                // * commit. After sync() returns, the data is crash-safe.
                 super.close();
 
                 // Cache the final partial block if present (avoids disk I/O for immediate reads)
                 cacheFinalPartialBlock();
 
                 // signal the kernel to flush the file cacehe
-                // we don't call flush aggresevley to avoid cpu pressure.
+                // but we don't call flush aggresevley in small files
+                // since most of the page cache would be still dirty as lucene might
+                // have not yet fsycned them yet via Directory.sync and DONTNEED is ineffective.
                 if (streamOffset > 32L * 1024 * 1024) {
                     String absolutePath = path.toAbsolutePath().toString();
-                    // Drop cache BEFORE deletion while file handle is still valid
+                    // **** This doesn't effect durability ***
+                    // - DONTNEED is a cache "hint" only. It never discards DIRTY pages. For dirty pages,
+                    // the kernel first schedules/writebacks the data and drops the pages only after
+                    // the write completes. Clean pages may be dropped immediately.
+                    // - Therefore, using DONTNEED does not jeopardize durability: a later fsync
+                    // (via Lucene's Directory.sync(files)) will still ensure persistence. If any
+                    // writeback is outstanding, fsync/force(true) will wait for it to finish before
+                    // returning, preserving the durability contract.
                     Thread.startVirtualThread(() -> PanamaNativeAccess.dropFileCache(absolutePath));
                 }
 


### PR DESCRIPTION
### Description
Update docs on durability semantics after close is called

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
