### PR TITLE
Added Register key and unregister key API.

### DIFF
--- a/src/main/java/org/opensearch/index/store/rest/RestRegisterCryptoAction.java
+++ b/src/main/java/org/opensearch/index/store/rest/RestRegisterCryptoAction.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.rest;
+
+import static java.util.Collections.singletonList;
+import static org.opensearch.rest.RestRequest.Method.POST;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.transport.client.node.NodeClient;
+
+public class RestRegisterCryptoAction extends BaseRestHandler {
+
+    private static final String ACTION_NAME = "register_key_action";
+    private static final String ROUTE_PATH = "/_plugin/opensearch-storage-encryption/_register_key";
+
+    @Override
+    public String getName() {
+        return ACTION_NAME;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return singletonList(new Route(POST, ROUTE_PATH));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        throw new UnsupportedOperationException("Register key operation is not implemented");
+    }
+}

--- a/src/main/java/org/opensearch/index/store/rest/RestUnregisterCryptoAction.java
+++ b/src/main/java/org/opensearch/index/store/rest/RestUnregisterCryptoAction.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.rest;
+
+import static java.util.Collections.singletonList;
+import static org.opensearch.rest.RestRequest.Method.POST;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.transport.client.node.NodeClient;
+
+public class RestUnregisterCryptoAction extends BaseRestHandler {
+
+    private static final String ACTION_NAME = "unregister_key_action";
+    private static final String ROUTE_PATH = "/_plugin/opensearch-storage-encryption/_unregister_key";
+
+    @Override
+    public String getName() {
+        return ACTION_NAME;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return singletonList(new Route(POST, ROUTE_PATH));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        throw new UnsupportedOperationException("Unregister key operation is not implemented");
+    }
+}

--- a/src/test/java/org/opensearch/index/store/rest/RestRegisterCryptoActionTests.java
+++ b/src/test/java/org/opensearch/index/store/rest/RestRegisterCryptoActionTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.opensearch.rest.RestRequest.Method.POST;
+
+import org.junit.Before;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.client.node.NodeClient;
+
+public class RestRegisterCryptoActionTests extends OpenSearchTestCase {
+
+    private RestRegisterCryptoAction action;
+    private RestRequest request;
+    private NodeClient client;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        action = new RestRegisterCryptoAction();
+        request = mock(RestRequest.class);
+        client = mock(NodeClient.class);
+    }
+
+    public void testGetName() {
+        assertEquals("register_key_action", action.getName());
+    }
+
+    public void testRoutes() {
+        assertEquals(1, action.routes().size());
+        assertEquals(POST, action.routes().get(0).getMethod());
+        assertEquals("/_plugin/opensearch-storage-encryption/_register_key", action.routes().get(0).getPath());
+    }
+
+    public void testPrepareRequestThrowsUnsupportedOperationException() {
+        expectThrows(UnsupportedOperationException.class, () -> action.prepareRequest(request, client));
+    }
+}

--- a/src/test/java/org/opensearch/index/store/rest/RestUnregisterCryptoActionTests.java
+++ b/src/test/java/org/opensearch/index/store/rest/RestUnregisterCryptoActionTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.opensearch.rest.RestRequest.Method.POST;
+
+import org.junit.Before;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.client.node.NodeClient;
+
+public class RestUnregisterCryptoActionTests extends OpenSearchTestCase {
+
+    private RestUnregisterCryptoAction action;
+    private RestRequest request;
+    private NodeClient client;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        action = new RestUnregisterCryptoAction();
+        request = mock(RestRequest.class);
+        client = mock(NodeClient.class);
+    }
+
+    public void testGetName() {
+        assertEquals("unregister_key_action", action.getName());
+    }
+
+    public void testRoutes() {
+        assertEquals(1, action.routes().size());
+        assertEquals(POST, action.routes().get(0).getMethod());
+        assertEquals("/_plugin/opensearch-storage-encryption/_unregister_key", action.routes().get(0).getPath());
+    }
+
+    public void testPrepareRequestThrowsUnsupportedOperationException() {
+        expectThrows(UnsupportedOperationException.class, () -> action.prepareRequest(request, client));
+    }
+}


### PR DESCRIPTION
### Description
Added register key and unregister key API flow, its throwing unsupported_operation_exception as of now.

`curl -X POST "http://localhost:9200/_plugin/opensearch-storage-encryption/_register_key"   -H "Content-Type: application/json"
{"error":{"root_cause":[{"type":"unsupported_operation_exception","reason":"Register key operation is not implemented"}],"type":"unsupported_operation_exception","reason":"Register key operation is not implemented"},"status":500}`

`curl -X POST "http://localhost:9200/_plugin/opensearch-storage-encryption/_unregister_key"   -H "Content-Type: application/json"
{"error":{"root_cause":[{"type":"unsupported_operation_exception","reason":"Unregister key operation is not implemented"}],"type":"unsupported_operation_exception","reason":"Unregister key operation is not implemented"},"status":500}`

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [Y] New functionality includes testing.
- [Y] New functionality has been documented.
- [ Y] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [Y] Commits are signed per the DCO using `--signoff`.
- [] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
