### PR TITLE
Make SunJCE as default and the only supported provider

### DIFF
--- a/src/main/java/org/opensearch/index/store/CryptoDirectoryFactory.java
+++ b/src/main/java/org/opensearch/index/store/CryptoDirectoryFactory.java
@@ -99,17 +99,9 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
     public static final String CRYPTO_SETTING = "index.store.crypto";
 
     /**
-     * Specifies a crypto provider to be used for encryption. The default value
-     * is SunJCE.
+     * Default crypto provider name.
      */
-    public static final Setting<Provider> INDEX_CRYPTO_PROVIDER_SETTING = new Setting<>("index.store.crypto.provider", "SunJCE", (s) -> {
-        Provider p = Security.getProvider(s);
-        if (p == null) {
-            throw new SettingsException("unrecognized [index.store.crypto.provider] \"" + s + "\"");
-        } else {
-            return p;
-        }
-    }, Property.IndexScope, Property.InternalIndex);
+    public static final String DEFAULT_CRYPTO_PROVIDER = "SunJCE";
 
     /**
      * Specifies the Key management plugin type to be used. The desired CryptoKeyProviderPlugin
@@ -241,7 +233,7 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
      */
     protected Directory newFSDirectory(Path location, LockFactory lockFactory, IndexSettings indexSettings, int shardId)
         throws IOException {
-        final Provider provider = indexSettings.getValue(INDEX_CRYPTO_PROVIDER_SETTING);
+        final Provider provider = Security.getProvider(DEFAULT_CRYPTO_PROVIDER);
 
         // Use index-level key resolver - store keys at index level
 

--- a/src/main/java/org/opensearch/index/store/CryptoDirectoryPlugin.java
+++ b/src/main/java/org/opensearch/index/store/CryptoDirectoryPlugin.java
@@ -75,7 +75,6 @@ public class CryptoDirectoryPlugin extends Plugin implements IndexStorePlugin, E
         return Arrays
             .asList(
                 CryptoDirectoryFactory.INDEX_KEY_PROVIDER_SETTING,
-                CryptoDirectoryFactory.INDEX_CRYPTO_PROVIDER_SETTING,
                 CryptoDirectoryFactory.INDEX_KMS_ARN_SETTING,
                 CryptoDirectoryFactory.INDEX_KMS_ENC_CTX_SETTING,
                 CryptoDirectoryFactory.NODE_KEY_REFRESH_INTERVAL_SETTING,

--- a/src/main/java/org/opensearch/index/store/CryptoEngineFactory.java
+++ b/src/main/java/org/opensearch/index/store/CryptoEngineFactory.java
@@ -7,6 +7,7 @@ package org.opensearch.index.store;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.security.Provider;
+import java.security.Security;
 
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
@@ -67,7 +68,7 @@ public class CryptoEngineFactory implements EngineFactory {
         Path indexDirectory = translogPath.getParent().getParent(); // Go up two levels: translog -> shard -> index
 
         // Get the same settings that CryptoDirectoryFactory uses
-        Provider provider = config.getIndexSettings().getValue(CryptoDirectoryFactory.INDEX_CRYPTO_PROVIDER_SETTING);
+        Provider provider = Security.getProvider(CryptoDirectoryFactory.DEFAULT_CRYPTO_PROVIDER);
         MasterKeyProvider keyProvider = getKeyProvider(config);
 
         // Create directory for index-level keys (same as CryptoDirectoryFactory)

--- a/src/main/java/org/opensearch/index/store/cipher/AesCipherFactory.java
+++ b/src/main/java/org/opensearch/index/store/cipher/AesCipherFactory.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
 
+import org.opensearch.index.store.CryptoDirectoryFactory;
 import org.opensearch.index.store.footer.EncryptionMetadataTrailer;
 import org.opensearch.index.store.key.HkdfKeyDerivation;
 
@@ -58,12 +59,14 @@ public class AesCipherFactory {
     }
 
     /**
-     * Thread-local cipher pool for AES/CTR/NoPadding operations using SunJCE provider.
+     * Thread-local cipher pool for AES/CTR/NoPadding operations.
      * Each thread gets its own cipher instance to avoid synchronization overhead.
      */
     public static final ThreadLocal<Cipher> CIPHER_POOL = ThreadLocal.withInitial(() -> {
         try {
-            return Cipher.getInstance("AES/CTR/NoPadding", "SunJCE");
+            // todo we can make provider comfigirable but for now with AES/CTR, SunJCE works best
+            // in terms of performance.
+            return Cipher.getInstance("AES/CTR/NoPadding", CryptoDirectoryFactory.DEFAULT_CRYPTO_PROVIDER);
         } catch (NoSuchAlgorithmException | NoSuchProviderException | NoSuchPaddingException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
### Description
Make SunJCE as default and the only supported provider

SunJCE with AES/CTR has been found to be most performant for us. We will stick with it as the only default . Our code base currently is very tied to AES/CTR + SunJCE being hardcoded at various place. So having a setting was destructive.  later if someone needs a new provider, they can introduce a new setting, but will have to make a bunch of compatibilty changes.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
