### PR TITLE
Add plugin enable/disable mode and fix integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,32 @@
 # opensearch-storage-encryption
 
 An Opensearch plugin for supporting "fast" On fly Index-Level-Encryption. Security with high Performance is of highest 
-prority. 
+priority. 
 
+## Plugin Modes
+
+The crypto directory plugin can operate in two modes:
+
+### 1. **Disabled Mode (Default)**
+- Plugin is loaded but all encryption functionality is inactive
+- No performance overhead from encryption operations
+- This is the **default state** - no configuration needed
+
+### 2. **Enabled Mode**
+- Plugin performs encryption/decryption operations
+- All crypto directory features are active
+- Encrypted indices can be created and accessed
+- To enable, add to `opensearch.yml`:
+  ```yaml
+  plugins.crypto.enabled: true
+  ```
+
+**⚠️ Important Notes:**
+- The enabled setting requires node restart to change
+- Plugin is **disabled by default** - you must explicitly enable it for encryption
+- Existing encrypted indices become inaccessible when plugin is disabled
+- Setting should be consistent across all cluster nodes for best results
+- Cannot create new encrypted indices when disabled (`cryptofs` store type unavailable)
 
 # Architecture
 
@@ -55,4 +79,3 @@ For example:
 ## Key announcement  
 
 29/7/2025: The plugin development is still in progress and is expected to land fully in Opensearch 3.3 release.
-

--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,7 @@ tasks.named('yamlRestTest').configure {
 }
 
 testClusters.yamlRestTest {
+    setting 'plugins.crypto.enabled', 'true'
     setting 'node.store.crypto.pool_size_percentage', '0.0'
     setting 'node.store.crypto.warmup_percentage', '0.0'
 }

--- a/src/internalClusterTest/java/org/opensearch/index/store/CacheInvalidationIntegTests.java
+++ b/src/internalClusterTest/java/org/opensearch/index/store/CacheInvalidationIntegTests.java
@@ -37,6 +37,7 @@ public class CacheInvalidationIntegTests extends OpenSearchIntegTestCase {
         return Settings
             .builder()
             .put(super.nodeSettings(nodeOrdinal))
+            .put("plugins.crypto.enabled", true)
             .put("node.store.crypto.pool_size_percentage", 0.05)
             .put("node.store.crypto.warmup_percentage", 0.0)
             .put("node.store.crypto.cache_to_pool_ratio", 0.8)

--- a/src/internalClusterTest/java/org/opensearch/index/store/ConcurrencyIntegTests.java
+++ b/src/internalClusterTest/java/org/opensearch/index/store/ConcurrencyIntegTests.java
@@ -47,6 +47,7 @@ public class ConcurrencyIntegTests extends OpenSearchIntegTestCase {
         return Settings
             .builder()
             .put(super.nodeSettings(nodeOrdinal))
+            .put("plugins.crypto.enabled", true)
             .put("node.store.crypto.pool_size_percentage", 0.05) // 5% for tests
             .put("node.store.crypto.warmup_percentage", 0.0) // No warmup
             .put("node.store.crypto.cache_to_pool_ratio", 0.8)

--- a/src/internalClusterTest/java/org/opensearch/index/store/ShardMigrationIntegTests.java
+++ b/src/internalClusterTest/java/org/opensearch/index/store/ShardMigrationIntegTests.java
@@ -47,6 +47,7 @@ public class ShardMigrationIntegTests extends OpenSearchIntegTestCase {
         return Settings
             .builder()
             .put(super.nodeSettings(nodeOrdinal))
+            .put("plugins.crypto.enabled", true)
             .put("node.store.crypto.pool_size_percentage", 0.05) // 5% for tests
             .put("node.store.crypto.warmup_percentage", 0.0) // No warmup
             .put("node.store.crypto.cache_to_pool_ratio", 0.8)

--- a/src/internalClusterTest/java/org/opensearch/index/store/SnapshotRestoreIntegTests.java
+++ b/src/internalClusterTest/java/org/opensearch/index/store/SnapshotRestoreIntegTests.java
@@ -41,6 +41,7 @@ public class SnapshotRestoreIntegTests extends OpenSearchIntegTestCase {
         return Settings
             .builder()
             .put(super.nodeSettings(nodeOrdinal))
+            .put("plugins.crypto.enabled", true)
             .put("node.store.crypto.pool_size_percentage", 0.05)
             .put("node.store.crypto.warmup_percentage", 0.0)
             .put("node.store.crypto.cache_to_pool_ratio", 0.8)

--- a/src/internalClusterTest/java/org/opensearch/index/store/niofs/CryptoDirectoryIntegTestCases.java
+++ b/src/internalClusterTest/java/org/opensearch/index/store/niofs/CryptoDirectoryIntegTestCases.java
@@ -35,6 +35,7 @@ public class CryptoDirectoryIntegTestCases extends OpenSearchIntegTestCase {
         return Settings
             .builder()
             .put(super.nodeSettings(nodeOrdinal))
+            .put("plugins.crypto.enabled", true)
             .put("node.store.crypto.pool_size_percentage", 0.05)  // 5% of off-heap for tests (smaller pool)
             .put("node.store.crypto.warmup_percentage", 0.0)      // No warmup to avoid pre-allocating memory
             .put("node.store.crypto.cache_to_pool_ratio", 0.8)

--- a/src/main/java/org/opensearch/index/store/CryptoDirectoryPlugin.java
+++ b/src/main/java/org/opensearch/index/store/CryptoDirectoryPlugin.java
@@ -13,6 +13,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
@@ -58,13 +60,49 @@ import org.opensearch.watcher.ResourceWatcherService;
  * A plugin that enables index level encryption and decryption.
  */
 public class CryptoDirectoryPlugin extends Plugin implements IndexStorePlugin, EnginePlugin, TelemetryAwarePlugin, ActionPlugin {
-    private NodeEnvironment nodeEnvironment;
+    private static final Logger log = LogManager.getLogger(CryptoDirectoryPlugin.class);
 
     /**
-     * The default constructor.
+     * Setting key for enabling the crypto plugin.
      */
-    public CryptoDirectoryPlugin() {
+    public static final String CRYPTO_PLUGIN_ENABLED = "plugins.crypto.enabled";
+
+    /**
+     * Setting for controlling whether the crypto plugin is enabled.
+     */
+    public static final Setting<Boolean> CRYPTO_PLUGIN_ENABLED_SETTING = Setting
+        .boolSetting(CRYPTO_PLUGIN_ENABLED, false, Setting.Property.NodeScope, Setting.Property.Filtered, Setting.Property.Final);
+
+    private NodeEnvironment nodeEnvironment;
+    private final boolean enabled;
+
+    /**
+     * Constructor with settings.
+     * @param settings OpenSearch node settings
+     */
+    public CryptoDirectoryPlugin(Settings settings) {
         super();
+        this.enabled = settings.getAsBoolean(CRYPTO_PLUGIN_ENABLED, false);
+
+        if (enabled) {
+            log.info("OpenSearch Crypto Directory Plugin is enabled and ready for encryption operations");
+        } else {
+            log
+                .warn(
+                    "OpenSearch Crypto Directory Plugin installed but disabled. "
+                        + "No encryption/decryption will be performed. "
+                        + "To enable encryption, set '{}' to true in opensearch.yml",
+                    CRYPTO_PLUGIN_ENABLED
+                );
+        }
+    }
+
+    /**
+     * Check if the plugin is disabled.
+     * @return true if the plugin is disabled, false otherwise
+     */
+    public boolean isDisabled() {
+        return !enabled;
     }
 
     /**
@@ -72,8 +110,9 @@ public class CryptoDirectoryPlugin extends Plugin implements IndexStorePlugin, E
      */
     @Override
     public List<Setting<?>> getSettings() {
-        return Arrays
+        List<Setting<?>> settings = Arrays
             .asList(
+                CRYPTO_PLUGIN_ENABLED_SETTING,
                 CryptoDirectoryFactory.INDEX_KEY_PROVIDER_SETTING,
                 CryptoDirectoryFactory.INDEX_CRYPTO_PROVIDER_SETTING,
                 CryptoDirectoryFactory.INDEX_KMS_ARN_SETTING,
@@ -84,6 +123,7 @@ public class CryptoDirectoryPlugin extends Plugin implements IndexStorePlugin, E
                 PoolSizeCalculator.NODE_CACHE_TO_POOL_RATIO_SETTING,
                 PoolSizeCalculator.NODE_WARMUP_PERCENTAGE_SETTING
             );
+        return settings;
     }
 
     /**
@@ -91,6 +131,11 @@ public class CryptoDirectoryPlugin extends Plugin implements IndexStorePlugin, E
      */
     @Override
     public Map<String, DirectoryFactory> getDirectoryFactories() {
+        if (isDisabled()) {
+            log.warn("Crypto Directory Plugin is disabled. No directory factories will be registered.");
+            return Collections.emptyMap();
+        }
+        log.info("Crypto Directory Plugin is enabled. Registering cryptofs directory factory.");
         return Collections.singletonMap("cryptofs", new CryptoDirectoryFactory());
     }
 
@@ -99,6 +144,10 @@ public class CryptoDirectoryPlugin extends Plugin implements IndexStorePlugin, E
      */
     @Override
     public Optional<EngineFactory> getEngineFactory(IndexSettings indexSettings) {
+        if (isDisabled()) {
+            return Optional.empty();
+        }
+
         // Only provide our custom engine factory for cryptofs indices
         if ("cryptofs".equals(indexSettings.getValue(IndexModule.INDEX_STORE_TYPE_SETTING))) {
             return Optional.of(new CryptoEngineFactory());
@@ -122,6 +171,11 @@ public class CryptoDirectoryPlugin extends Plugin implements IndexStorePlugin, E
         Tracer tracer,
         MetricsRegistry metricsRegistry
     ) {
+        if (isDisabled()) {
+            log.debug("Crypto Directory Plugin is disabled. Skipping component initialization.");
+            return Collections.emptyList();
+        }
+
         this.nodeEnvironment = nodeEnvironment;
 
         // Initialize health monitor first (creates monitor)
@@ -143,9 +197,14 @@ public class CryptoDirectoryPlugin extends Plugin implements IndexStorePlugin, E
 
     @Override
     public void close() {
+        if (isDisabled()) {
+            log.debug("Crypto Directory Plugin is disabled. No cleanup needed.");
+            return;
+        }
+
         MasterKeyHealthMonitor.shutdown();
         // Close shared pool resources if they were initialized
-        // the shared pool is initilized only when atleast one index
+        // the shared pool is initialized only when at least one index
         // level enc enabled index is created.
         CryptoDirectoryFactory.closeSharedPool();
     }
@@ -165,6 +224,15 @@ public class CryptoDirectoryPlugin extends Plugin implements IndexStorePlugin, E
 
     @Override
     public void onIndexModule(IndexModule indexModule) {
+        if (isDisabled()) {
+            log
+                .debug(
+                    "Crypto Directory Plugin is disabled. Skipping index module initialization for index: {}",
+                    indexModule.getIndex().getName()
+                );
+            return;
+        }
+
         Settings indexSettings = indexModule.getSettings();
         String storeType = indexSettings.get(IndexModule.INDEX_STORE_TYPE_SETTING.getKey());
 

--- a/src/test/java/org/opensearch/index/store/CryptoDirectoryTests.java
+++ b/src/test/java/org/opensearch/index/store/CryptoDirectoryTests.java
@@ -222,4 +222,73 @@ public class CryptoDirectoryTests extends OpenSearchBaseDirectoryTestCase {
          * FIX PENDING: https://github.com/opensearch-project/opensearch-storage-encryption/issues/47
          */
     }
+
+    // ==================== Enable/Disable Flag Tests ====================
+
+    /**
+     * Test that plugin is enabled when setting is true.
+     */
+    public void testPluginEnabledWhenSettingIsTrue() {
+        org.opensearch.common.settings.Settings settings = org.opensearch.common.settings.Settings
+            .builder()
+            .put(CryptoDirectoryPlugin.CRYPTO_PLUGIN_ENABLED, true)
+            .build();
+        CryptoDirectoryPlugin plugin = new CryptoDirectoryPlugin(settings);
+        assertFalse("Plugin should not be disabled when enabled setting is true", plugin.isDisabled());
+    }
+
+    /**
+     * Test that plugin is disabled by default.
+     */
+    public void testPluginDisabledByDefault() {
+        CryptoDirectoryPlugin plugin = new CryptoDirectoryPlugin(org.opensearch.common.settings.Settings.EMPTY);
+        assertTrue("Plugin should be disabled by default", plugin.isDisabled());
+    }
+
+    /**
+     * Test that no directory factories are registered when plugin is disabled.
+     */
+    public void testNoDirectoryFactoriesWhenDisabled() {
+        org.opensearch.common.settings.Settings settings = org.opensearch.common.settings.Settings
+            .builder()
+            .put(CryptoDirectoryPlugin.CRYPTO_PLUGIN_ENABLED, false)
+            .build();
+        CryptoDirectoryPlugin plugin = new CryptoDirectoryPlugin(settings);
+        assertTrue("Directory factories should be empty when disabled", plugin.getDirectoryFactories().isEmpty());
+    }
+
+    /**
+     * Test that directory factory is registered when plugin is enabled.
+     */
+    public void testDirectoryFactoryRegisteredWhenEnabled() {
+        org.opensearch.common.settings.Settings settings = org.opensearch.common.settings.Settings
+            .builder()
+            .put(CryptoDirectoryPlugin.CRYPTO_PLUGIN_ENABLED, true)
+            .build();
+        CryptoDirectoryPlugin plugin = new CryptoDirectoryPlugin(settings);
+        assertFalse("Directory factories should not be empty when enabled", plugin.getDirectoryFactories().isEmpty());
+        assertNotNull("CryptoFS factory should be registered", plugin.getDirectoryFactories().get("cryptofs"));
+    }
+
+    /**
+     * Test that enabled setting is included in plugin settings.
+     */
+    public void testEnabledSettingIncluded() {
+        CryptoDirectoryPlugin plugin = new CryptoDirectoryPlugin(org.opensearch.common.settings.Settings.EMPTY);
+        assertTrue(
+            "Settings should contain enabled setting",
+            plugin.getSettings().contains(CryptoDirectoryPlugin.CRYPTO_PLUGIN_ENABLED_SETTING)
+        );
+    }
+
+    /**
+     * Test that enabled setting has correct default value (false - disabled by default).
+     */
+    public void testEnabledSettingDefault() {
+        assertEquals(
+            "Enabled setting default should be false (disabled by default)",
+            Boolean.FALSE,
+            CryptoDirectoryPlugin.CRYPTO_PLUGIN_ENABLED_SETTING.getDefault(org.opensearch.common.settings.Settings.EMPTY)
+        );
+    }
 }


### PR DESCRIPTION
### Description
Adds enable/disable functionality to the crypto directory plugin using opensearch.yml configuration.

### Related Issues
NA

### Changes
- Add `plugins.crypto.enabled` setting (default: false/disabled)

### Testing
- ✅ Enable with `plugins.crypto.enabled: true`
- ✅ Mixed cluster support (enabled/disabled nodes)
- ✅ AWS KMS integration works when enabled
- ✅ `cryptofs` store type unavailable when disabled

### Configuration
```yaml
# Enable crypto plugin (disabled by default)
plugins.crypto_directory.enabled: true
```


### Check List
- [ X ] New functionality includes testing.
- [ X ] New functionality has been documented.
- [ X ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ X ] Commits are signed per the DCO using `--signoff`.
- [ X ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
