### PR TITLE
Make crypto settings immutable after index creation

### DIFF
--- a/src/main/java/org/opensearch/index/store/CryptoDirectoryFactory.java
+++ b/src/main/java/org/opensearch/index/store/CryptoDirectoryFactory.java
@@ -122,7 +122,8 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
             }
         },
         Property.NodeScope,
-        Property.IndexScope
+        Property.IndexScope,
+        Property.InternalIndex
     );
 
     /**
@@ -138,7 +139,8 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
                 throw new SettingsException("index.store.kms.arn must be set");
             }
         },
-        Property.IndexScope
+        Property.IndexScope,
+        Property.InternalIndex
     );
 
     /**
@@ -149,7 +151,8 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
         "index.store.crypto.kms.encryption_context",
         Constants.DEFAULT_KMS_ENC_CTX,
         Function.identity(),
-        Property.IndexScope
+        Property.IndexScope,
+        Property.InternalIndex
     );
 
     /**


### PR DESCRIPTION
### Description
Make crypto settings immutable after index creation. 

### Related Issues

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
