### PR TITLE
Bug fix: unpin blocks pinned by clones

### DIFF
--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/BlockSlotTinyCacheBenchmarkTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/BlockSlotTinyCacheBenchmarkTests.java
@@ -285,7 +285,7 @@ public class BlockSlotTinyCacheBenchmarkTests {
                     OffsetGenerator generator = new OffsetGenerator(scenario.pattern, scenario.uniqueBlocks, threadSeed);
                     for (int i = 0; i < opsPerThread; i++) {
                         long offset = generator.nextOffset();
-                        BlockCacheValue<RefCountedMemorySegment> val = cache.acquireRefCountedValue(offset).value();
+                        BlockCacheValue<RefCountedMemorySegment> val = cache.acquireRefCountedValue(offset, null);
                         val.unpin();
                     }
                 } catch (Exception e) {

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/BlockSlotTinyCacheTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/BlockSlotTinyCacheTests.java
@@ -78,7 +78,7 @@ public class BlockSlotTinyCacheTests extends OpenSearchTestCase {
         assertEquals(1, refSegment.getRefCount());
 
         // Acquire the block - should return with refCount incremented (pinned)
-        BlockCacheValue<RefCountedMemorySegment> result = cache.acquireRefCountedValue(0).value();
+        BlockCacheValue<RefCountedMemorySegment> result = cache.acquireRefCountedValue(0);
         assertNotNull(result);
 
         // RefCount should now be 2 (cache + our pin)
@@ -117,15 +117,15 @@ public class BlockSlotTinyCacheTests extends OpenSearchTestCase {
         assertEquals(1, refSegment.getRefCount());
 
         // First acquisition
-        BlockCacheValue<RefCountedMemorySegment> result1 = cache.acquireRefCountedValue(0).value();
+        BlockCacheValue<RefCountedMemorySegment> result1 = cache.acquireRefCountedValue(0);
         assertEquals(2, refSegment.getRefCount());
 
         // Second acquisition (same block) - should hit thread-local cache and pin again
-        BlockCacheValue<RefCountedMemorySegment> result2 = cache.acquireRefCountedValue(0).value();
+        BlockCacheValue<RefCountedMemorySegment> result2 = cache.acquireRefCountedValue(0);
         assertEquals(3, refSegment.getRefCount());
 
         // Third acquisition
-        BlockCacheValue<RefCountedMemorySegment> result3 = cache.acquireRefCountedValue(0).value();
+        BlockCacheValue<RefCountedMemorySegment> result3 = cache.acquireRefCountedValue(0);
         assertEquals(4, refSegment.getRefCount());
 
         // Unpin all three
@@ -164,7 +164,7 @@ public class BlockSlotTinyCacheTests extends OpenSearchTestCase {
         when(mockCache.get(any(FileBlockCacheKey.class))).thenReturn(cacheValue);
 
         // Acquire and unpin
-        BlockCacheValue<RefCountedMemorySegment> result = cache.acquireRefCountedValue(0).value();
+        BlockCacheValue<RefCountedMemorySegment> result = cache.acquireRefCountedValue(0);
         assertEquals(2, refSegment.getRefCount());
 
         result.unpin();
@@ -209,7 +209,7 @@ public class BlockSlotTinyCacheTests extends OpenSearchTestCase {
         int initialGeneration = refSegment1.getGeneration();
         assertEquals(0, initialGeneration);
 
-        BlockCacheValue<RefCountedMemorySegment> result1 = cache.acquireRefCountedValue(0).value();
+        BlockCacheValue<RefCountedMemorySegment> result1 = cache.acquireRefCountedValue(0);
         assertEquals(refSegment1, result1.value());
         result1.unpin();
 
@@ -239,7 +239,7 @@ public class BlockSlotTinyCacheTests extends OpenSearchTestCase {
         when(mockCache.get(any(FileBlockCacheKey.class))).thenReturn(cacheValue2);
 
         // Next acquisition should detect stale generation and reload from L2
-        BlockCacheValue<RefCountedMemorySegment> result2 = cache.acquireRefCountedValue(0).value();
+        BlockCacheValue<RefCountedMemorySegment> result2 = cache.acquireRefCountedValue(0);
 
         // Should get the new segment (generation check should have failed tryPin on old segment)
         assertEquals(refSegment2, result2.value());
@@ -279,7 +279,7 @@ public class BlockSlotTinyCacheTests extends OpenSearchTestCase {
                 try {
                     barrier.await(); // Synchronize start
                     for (int j = 0; j < acquisitionsPerThread; j++) {
-                        BlockCacheValue<RefCountedMemorySegment> result = cache.acquireRefCountedValue(0).value();
+                        BlockCacheValue<RefCountedMemorySegment> result = cache.acquireRefCountedValue(0);
                         assertNotNull(result);
                         // Block is pinned - refCount should be > 1
                         assertTrue(result.value().getRefCount() > 1);
@@ -342,9 +342,9 @@ public class BlockSlotTinyCacheTests extends OpenSearchTestCase {
         });
 
         // Acquire all three blocks
-        BlockCacheValue<RefCountedMemorySegment> result0 = cache.acquireRefCountedValue(0).value();
-        BlockCacheValue<RefCountedMemorySegment> result1 = cache.acquireRefCountedValue(BLOCK_SIZE).value();
-        BlockCacheValue<RefCountedMemorySegment> result2 = cache.acquireRefCountedValue(BLOCK_SIZE * 2L).value();
+        BlockCacheValue<RefCountedMemorySegment> result0 = cache.acquireRefCountedValue(0);
+        BlockCacheValue<RefCountedMemorySegment> result1 = cache.acquireRefCountedValue(BLOCK_SIZE);
+        BlockCacheValue<RefCountedMemorySegment> result2 = cache.acquireRefCountedValue(BLOCK_SIZE * 2L);
 
         // Each should be pinned (refCount = 2)
         assertEquals(2, segments.get(0).getRefCount());
@@ -399,7 +399,7 @@ public class BlockSlotTinyCacheTests extends OpenSearchTestCase {
         when(mockCache.getOrLoad(any(FileBlockCacheKey.class))).thenReturn(cacheValue);
 
         // Should succeed after retries
-        BlockCacheValue<RefCountedMemorySegment> result = cache.acquireRefCountedValue(0).value();
+        BlockCacheValue<RefCountedMemorySegment> result = cache.acquireRefCountedValue(0);
         assertNotNull(result);
         assertEquals(2, refSegment.getRefCount()); // Successfully pinned
 
@@ -454,7 +454,7 @@ public class BlockSlotTinyCacheTests extends OpenSearchTestCase {
         when(mockCache.get(any(FileBlockCacheKey.class))).thenReturn(cacheValue1);
 
         // Populate cache
-        BlockCacheValue<RefCountedMemorySegment> result1 = cache.acquireRefCountedValue(0).value();
+        BlockCacheValue<RefCountedMemorySegment> result1 = cache.acquireRefCountedValue(0);
         result1.unpin();
 
         // Clear cache
@@ -475,7 +475,7 @@ public class BlockSlotTinyCacheTests extends OpenSearchTestCase {
         when(mockCache.get(any(FileBlockCacheKey.class))).thenReturn(cacheValue2);
 
         // Next acquisition should get the new segment (not stale cached one)
-        BlockCacheValue<RefCountedMemorySegment> result2 = cache.acquireRefCountedValue(0).value();
+        BlockCacheValue<RefCountedMemorySegment> result2 = cache.acquireRefCountedValue(0);
         assertEquals(refSegment2, result2.value());
         result2.unpin();
     }
@@ -500,11 +500,11 @@ public class BlockSlotTinyCacheTests extends OpenSearchTestCase {
         when(mockCache.get(any(FileBlockCacheKey.class))).thenReturn(cacheValue);
 
         // First acquisition
-        BlockCacheValue<RefCountedMemorySegment> result1 = cache.acquireRefCountedValue(0).value();
+        BlockCacheValue<RefCountedMemorySegment> result1 = cache.acquireRefCountedValue(0);
         assertEquals(2, refSegment.getRefCount());
 
         // Second acquisition on same thread - should hit thread-local cache but still pin
-        BlockCacheValue<RefCountedMemorySegment> result2 = cache.acquireRefCountedValue(0).value();
+        BlockCacheValue<RefCountedMemorySegment> result2 = cache.acquireRefCountedValue(0);
         assertEquals(3, refSegment.getRefCount());
 
         // Verify tryPin was called at least twice (once per acquisition)

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputConcurrencyTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputConcurrencyTests.java
@@ -454,9 +454,8 @@ public class CachedMemorySegmentIndexInputConcurrencyTests extends OpenSearchTes
         when(value.value()).thenReturn(refSegment);
         when(value.tryPin()).thenReturn(true);
 
-        // Wrap in LookupResult for the new API
-        BlockSlotTinyCache.LookupResult lookupResult = new BlockSlotTinyCache.LookupResult(value, true);
-        when(mockTinyCache.acquireRefCountedValue(eq(offset))).thenReturn(lookupResult);
+        when(mockTinyCache.acquireRefCountedValue(eq(offset), any())).thenReturn(value);
+        when(mockTinyCache.acquireRefCountedValue(eq(offset))).thenReturn(value);
         when(mockCache.getOrLoad(any(FileBlockCacheKey.class))).thenReturn(value);
     }
 

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputTests.java
@@ -1416,9 +1416,8 @@ public class CachedMemorySegmentIndexInputTests extends OpenSearchTestCase {
         when(value.value()).thenReturn(refSegment);
         when(value.tryPin()).thenReturn(true);
 
-        // Wrap in LookupResult for the new API
-        BlockSlotTinyCache.LookupResult lookupResult = new BlockSlotTinyCache.LookupResult(value, true);
-        when(mockTinyCache.acquireRefCountedValue(eq(offset))).thenReturn(lookupResult);
+        when(mockTinyCache.acquireRefCountedValue(eq(offset), any())).thenReturn(value);
+        when(mockTinyCache.acquireRefCountedValue(eq(offset))).thenReturn(value);
         when(mockCache.getOrLoad(any(FileBlockCacheKey.class))).thenReturn(value);
     }
 


### PR DESCRIPTION
### Description

Lucene IndexInput slices are lightweight views over a shared file and are heavily used across codec paths. However, slices are not guaranteed to be closed promptly. In practice, many slices remain reachable for the lifetime of a query or reader, and in some cases are only closed when the owning IndexInput or segment reader is closed. Retaining pinned cache blocks in slice state until close() therefore makes pin lifetime proportional to slice fan-out rather than actual read activity.

This caused a real failure during testing of the https_hourly_aggr_filter workload on a t3.medium instance, where a single aggregation query created roughly 50,000 slices. Each slice pinned one cache block and retained it for the duration of the query, resulting in tens of thousands of simultaneously pinned segments. This exhausted the memory segment pool, led to repeated pin failures, and ultimately caused OOM and shard failures. The issue is fundamentally unbounded and can occur on any instance size given sufficient slice fan-out.

To fix this, we treat master IndexInputs and slices differently. Master inputs retain the existing one-block pin optimization, keeping a single block pinned across calls for fast sequential access. Slices, however, no longer retain pinned blocks in instance state. A block is pinned only for the duration of an individual read operation and is unpinned immediately once the read completes. This ensures that pin count scales with concurrent reads rather than the number of live slices, eliminating unbounded pin accumulation while preserving the performance characteristics of non-slice inputs.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
