### PR TITLE
Radix block table L1

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,9 +302,31 @@ After adding, removing, or renaming any `@Benchmark` method, regenerate the JMH 
 ./gradlew jmhPrepare
 ```
 
+### Running Benchmarks from Fat JAR
+
+You can also build a self-contained fat JAR and run benchmarks directly:
+
+```bash
+# Build the fat JAR
+./gradlew jmhJar
+
+# List all available benchmarks
+java --enable-preview --enable-native-access=ALL-UNNAMED \
+  -jar build/distributions/storage-encryption-jmh.jar -l
+
+# Run a specific benchmark with custom settings
+java --enable-preview --enable-native-access=ALL-UNNAMED \
+  -jar build/distributions/storage-encryption-jmh.jar RadixBlockTable -wi 2 -i 3 -f 1
+
+# Run all benchmarks
+java --enable-preview --enable-native-access=ALL-UNNAMED \
+  -jar build/distributions/storage-encryption-jmh.jar
+```
+
 ### Benchmark Classes
 
 - `HotPathReadBenchmarks` — 16 benchmark methods measuring throughput with data pre-warmed in block cache (BufferPool) or page cache (MMap). Covers all `RandomAccessInput` and `IndexInput` read APIs plus a mixed workload that randomly interleaves all API types.
+- `RadixBlockTableBenchmark` — 7 benchmark methods comparing L1/L2 cache lookup strategies: RadixBlockTable (two plain array loads), CaffeineBlockCache (ConcurrentHashMap), and stamp-gated cache (VarHandle acquire/release). Includes L1+L2 fallback paths and sparse directory growth scenarios.
 
 ### Filtering Benchmarks
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ plugins {
     id 'jacoco'
     id 'com.diffplug.spotless' version '6.25.0'
     id 'me.champeau.jmh' version '0.7.3'
+    id 'io.github.reyerizo.gradle.jcstress' version '0.9.0'
 }
 
 apply plugin: 'opensearch.opensearchplugin'
@@ -66,6 +67,10 @@ dependencies {
     runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "commons-io:commons-io:2.13.0"
+    testImplementation 'org.openjdk.jmh:jmh-core:1.37'
+    testImplementation 'org.openjdk.jmh:jmh-generator-annprocess:1.37'
+    testAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.37'
+    testImplementation 'org.apache.commons:commons-math3:3.6.1'
 
     // Integration test dependencies
     testImplementation "org.opensearch.plugin:reindex-client:${opensearch_version}"
@@ -194,11 +199,54 @@ forbiddenApisMain.enabled = false
 forbiddenApisTest.enabled = false
 forbiddenApisJmh.enabled = false
 
+// JMH source set is managed by the me.champeau.jmh plugin.
+// The plugin auto-creates jmh source set, configurations, and tasks.
+// We only need the jmh {} config block below to customize behavior.
+
+// ---- JCStress configuration ----
+jcstress {
+    jcstressDependency 'org.openjdk.jcstress:jcstress-core:0.16'
+    mode = 'default'
+    verbose = true
+}
+
+// JCStress source set: do NOT use --enable-preview (annotation processor
+// cannot handle preview-flagged class files). Our stress tests don't need
+// preview features. afterEvaluate ensures this runs after the global
+// configureEach block has already added --enable-preview.
+afterEvaluate {
+    tasks.named('compileJcstressJava').configure {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+        // The opensearch build-tools plugin adds --enable-preview and -proc:none
+        // to ALL JavaCompile tasks. JCStress needs annotation processing to
+        // generate META-INF/TestList, so we must remove -proc:none.
+        options.compilerArgs.removeAll { it == '--enable-preview' || it == '-proc:none' }
+    }
+    tasks.named('compileTestJava').configure {
+        // JMH annotation processor needs to run for benchmark generation
+        options.compilerArgs.removeAll { it == '-proc:none' }
+    }
+}
+
+// Wire jcstress into the standard test task so ./gradlew test runs both
+// unit tests and concurrency stress tests.
+tasks.named('test').configure {
+    finalizedBy tasks.named('jcstress')
+}
+
 task allTests {
     dependsOn test, internalClusterTest, yamlRestTest
     group = 'Verification'
-    description = 'Runs all tests (Unit, Integration, and YAML)'
+    description = 'Runs all tests (Unit, Integration, YAML, and JCStress)'
 }
+
+// JMH fat JAR and runner are provided by the me.champeau.jmh plugin.
+// Build:  ./gradlew jmhJar
+// Run:    java --enable-preview --enable-native-access=ALL-UNNAMED -jar build/distributions/storage-encryption-jmh.jar [regex] [jmh-args]
+// Examples:
+//   java --enable-preview --enable-native-access=ALL-UNNAMED -jar build/distributions/storage-encryption-jmh.jar -l
+//   java --enable-preview --enable-native-access=ALL-UNNAMED -jar build/distributions/storage-encryption-jmh.jar RadixBlockTable -wi 2 -i 3 -f 1
 
 spotless {
     java {

--- a/src/jcstress/java/org/opensearch/index/store/bufferpoolfs/RadixBlockTableStressTests.java
+++ b/src/jcstress/java/org/opensearch/index/store/bufferpoolfs/RadixBlockTableStressTests.java
@@ -1,0 +1,389 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.bufferpoolfs;
+
+import java.nio.ByteBuffer;
+
+import org.openjdk.jcstress.annotations.*;
+import org.openjdk.jcstress.infra.results.*;
+
+/**
+ * JCStress tests for {@link RadixBlockTable} using {@code ByteBuffer}
+ * values — the actual type used in production (cache block buffers).
+ *
+ * <h2>What these tests demonstrate</h2>
+ * <p>RadixBlockTable uses plain loads on the read path (no volatile, no
+ * fences) for maximum throughput. The design explicitly accepts that a
+ * reader may see stale {@code null} (an L1 miss) when another thread has
+ * just written a value. These tests use JCStress to systematically explore
+ * all possible interleavings and memory orderings to confirm:</p>
+ * <ol>
+ *   <li>Stale reads are the <em>only</em> anomaly — no torn references,
+ *       no out-of-thin-air values, no crashes.</li>
+ *   <li>The anomaly is bounded: the reader sees either the correct value
+ *       or {@code null}, never a wrong non-null value.</li>
+ *   <li>When a non-null ByteBuffer is observed, its content is intact —
+ *       no partial writes, no corrupted bytes.</li>
+ * </ol>
+ *
+ * <h2>Content validation</h2>
+ * <p>Each ByteBuffer is filled with a deterministic magic byte derived from
+ * its identity (e.g. 0xAA, 0xBB). Readers verify every byte matches the
+ * expected pattern. A mismatch would indicate a torn reference (reader got
+ * a reference to the wrong buffer) or memory corruption — both FORBIDDEN.</p>
+ *
+ * <h2>Outcome interpretation</h2>
+ * <ul>
+ *   <li>{@code ACCEPTABLE} — expected under sequential consistency</li>
+ *   <li>{@code ACCEPTABLE_INTERESTING} — stale read (null when value was
+ *       just written). Legal per JMM, demonstrates the relaxed-memory
+ *       trade-off. On x86/TSO this is rare; on ARM/RISC-V more common.</li>
+ *   <li>{@code FORBIDDEN} — would indicate a real bug (torn reference,
+ *       wrong value, corrupted content)</li>
+ * </ul>
+ */
+public class RadixBlockTableStressTests {
+
+    /** Size of each test ByteBuffer — small but enough to catch corruption. */
+    private static final int BUF_SIZE = 64;
+
+    /** Creates a ByteBuffer filled entirely with the given magic byte. */
+    private static ByteBuffer makeBuf(byte magic) {
+        ByteBuffer buf = ByteBuffer.allocate(BUF_SIZE);
+        for (int i = 0; i < BUF_SIZE; i++) {
+            buf.put(i, magic);
+        }
+        return buf;
+    }
+
+    /**
+     * Validates that every byte in the buffer matches the expected magic.
+     * Returns true if content is intact, false if any byte is corrupted.
+     */
+    private static boolean validateContent(ByteBuffer buf, byte expectedMagic) {
+        for (int i = 0; i < BUF_SIZE; i++) {
+            if (buf.get(i) != expectedMagic) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // ========================================================================
+    // Test 1: Put-then-Get visibility (same inner array, slot 0)
+    //
+    // Actor 1: put(0, sentinel)
+    // Actor 2: get(0) and validate content
+    //
+    // The inner array for outer=0 is pre-allocated, so this isolates the
+    // plain store → plain load visibility of a single slot write.
+    // ========================================================================
+
+    @JCStressTest
+    @Description("Put/Get visibility on a pre-allocated inner array slot. "
+        + "Reader validates ByteBuffer content to catch torn references.")
+    @Outcome(id = "1", expect = Expect.ACCEPTABLE, desc = "Reader sees the written value with correct content.")
+    @Outcome(id = "0", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Stale read: reader missed the write (L1 miss).")
+    @Outcome(id = "-1", expect = Expect.FORBIDDEN, desc = "Corrupt content — torn reference or wrong buffer.")
+    @Outcome(expect = Expect.FORBIDDEN, desc = "Unexpected value.")
+    @State
+    public static class PutGetVisibility {
+        private static final byte SEED_MAGIC = (byte) 0x11;
+        private static final byte SENTINEL_MAGIC = (byte) 0xAA;
+
+        private final RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        private final ByteBuffer seed = makeBuf(SEED_MAGIC);
+        private final ByteBuffer sentinel = makeBuf(SENTINEL_MAGIC);
+
+        public PutGetVisibility() {
+            table.put(0, seed);
+        }
+
+        @Actor
+        public void writer() {
+            table.put(0, sentinel);
+        }
+
+        @Actor
+        public void reader(I_Result r) {
+            ByteBuffer val = table.get(0);
+            if (val == null) {
+                r.r1 = 0; // stale null
+            } else if (val == sentinel) {
+                r.r1 = validateContent(val, SENTINEL_MAGIC) ? 1 : -1;
+            } else if (val == seed) {
+                r.r1 = validateContent(val, SEED_MAGIC) ? 0 : -1;
+            } else {
+                r.r1 = -1; // wrong reference entirely
+            }
+        }
+    }
+
+    // ========================================================================
+    // Test 2: Inner array publication visibility
+    //
+    // Actor 1: put(blockId, sentinel) — triggers inner array allocation
+    // Actor 2: get(blockId) and validate content
+    // ========================================================================
+
+    @JCStressTest
+    @Description("Inner array allocation + slot write visibility. "
+        + "Reader validates ByteBuffer content on freshly allocated inner array.")
+    @Outcome(id = "1", expect = Expect.ACCEPTABLE, desc = "Reader sees the written value with correct content.")
+    @Outcome(id = "0", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Stale read: inner array or slot not yet visible.")
+    @Outcome(id = "-1", expect = Expect.FORBIDDEN, desc = "Corrupt content or wrong buffer reference.")
+    @Outcome(expect = Expect.FORBIDDEN, desc = "Unexpected value.")
+    @State
+    public static class InnerArrayPublicationVisibility {
+        private static final byte MAGIC = (byte) 0xBB;
+        private static final long BLOCK_ID = RadixBlockTable.PAGE_SIZE; // outer=1, slot=0
+
+        private final RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        private final ByteBuffer sentinel = makeBuf(MAGIC);
+
+        @Actor
+        public void writer() {
+            table.put(BLOCK_ID, sentinel);
+        }
+
+        @Actor
+        public void reader(I_Result r) {
+            ByteBuffer val = table.get(BLOCK_ID);
+            if (val == null) {
+                r.r1 = 0;
+            } else if (val == sentinel) {
+                r.r1 = validateContent(val, MAGIC) ? 1 : -1;
+            } else {
+                r.r1 = -1;
+            }
+        }
+    }
+
+    // ========================================================================
+    // Test 3: Directory growth visibility
+    //
+    // Actor 1: put(blockId far beyond current directory) — triggers growDirectory
+    // Actor 2: get(same blockId) and validate content
+    // ========================================================================
+
+    @JCStressTest
+    @Description("Directory growth visibility. Writer triggers directory " + "expansion. Reader validates ByteBuffer content if visible.")
+    @Outcome(id = "1", expect = Expect.ACCEPTABLE, desc = "Reader sees grown directory and correct content.")
+    @Outcome(id = "0", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Stale read: reader sees old directory (too small).")
+    @Outcome(id = "-1", expect = Expect.FORBIDDEN, desc = "Corrupt content or wrong buffer.")
+    @Outcome(expect = Expect.FORBIDDEN, desc = "Unexpected value.")
+    @State
+    public static class DirectoryGrowthVisibility {
+        private static final byte MAGIC = (byte) 0xCC;
+        private static final long BLOCK_ID = 5L * RadixBlockTable.PAGE_SIZE;
+
+        private final RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+        private final ByteBuffer sentinel = makeBuf(MAGIC);
+
+        @Actor
+        public void writer() {
+            table.put(BLOCK_ID, sentinel);
+        }
+
+        @Actor
+        public void reader(I_Result r) {
+            ByteBuffer val = table.get(BLOCK_ID);
+            if (val == null) {
+                r.r1 = 0;
+            } else if (val == sentinel) {
+                r.r1 = validateContent(val, MAGIC) ? 1 : -1;
+            } else {
+                r.r1 = -1;
+            }
+        }
+    }
+
+    // ========================================================================
+    // Test 4: Remove/Get race — reclamation safety with content validation
+    //
+    // Pre-populate slot. Actor 1 removes it. Actor 2 reads and validates.
+    // ========================================================================
+
+    @JCStressTest
+    @Description("Remove/Get race with inner array reclamation. " + "Reader validates ByteBuffer content to catch use-after-reclaim.")
+    @Outcome(id = "1", expect = Expect.ACCEPTABLE, desc = "Reader sees the value with correct content before removal.")
+    @Outcome(id = "0", expect = Expect.ACCEPTABLE, desc = "Reader sees null (removal visible or stale).")
+    @Outcome(id = "-1", expect = Expect.FORBIDDEN, desc = "Corrupt content or wrong buffer — reclamation bug.")
+    @Outcome(expect = Expect.FORBIDDEN, desc = "Unexpected value.")
+    @State
+    public static class RemoveGetReclamationSafety {
+        private static final byte MAGIC = (byte) 0xDD;
+
+        private final RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        private final ByteBuffer sentinel = makeBuf(MAGIC);
+
+        public RemoveGetReclamationSafety() {
+            table.put(0, sentinel);
+        }
+
+        @Actor
+        public void remover() {
+            table.remove(0);
+        }
+
+        @Actor
+        public void reader(I_Result r) {
+            ByteBuffer val = table.get(0);
+            if (val == null) {
+                r.r1 = 0;
+            } else if (val == sentinel) {
+                r.r1 = validateContent(val, MAGIC) ? 1 : -1;
+            } else {
+                r.r1 = -1;
+            }
+        }
+    }
+
+    // ========================================================================
+    // Test 5: Concurrent put to same slot — last-writer-wins, content intact
+    //
+    // Two actors write different ByteBuffers (different magic bytes).
+    // A third actor reads and validates whichever buffer it sees.
+    // ========================================================================
+
+    @JCStressTest
+    @Description("Two concurrent writers to the same slot + one reader. " + "Reader validates content of whichever ByteBuffer it observes.")
+    @Outcome(id = "1", expect = Expect.ACCEPTABLE, desc = "Reader sees writer A's buffer with correct content.")
+    @Outcome(id = "2", expect = Expect.ACCEPTABLE, desc = "Reader sees writer B's buffer with correct content.")
+    @Outcome(id = "0", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Stale read — seed or null.")
+    @Outcome(id = "-1", expect = Expect.FORBIDDEN, desc = "Corrupt content — torn reference between A and B.")
+    @Outcome(expect = Expect.FORBIDDEN, desc = "Unexpected value.")
+    @State
+    public static class ConcurrentPutSameSlot {
+        private static final byte SEED_MAGIC = (byte) 0x00;
+        private static final byte MAGIC_A = (byte) 0xAA;
+        private static final byte MAGIC_B = (byte) 0xBB;
+
+        private final RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        private final ByteBuffer seed = makeBuf(SEED_MAGIC);
+        private final ByteBuffer bufA = makeBuf(MAGIC_A);
+        private final ByteBuffer bufB = makeBuf(MAGIC_B);
+
+        public ConcurrentPutSameSlot() {
+            table.put(0, seed);
+        }
+
+        @Actor
+        public void writerA() {
+            table.put(0, bufA);
+        }
+
+        @Actor
+        public void writerB() {
+            table.put(0, bufB);
+        }
+
+        @Actor
+        public void reader(I_Result r) {
+            ByteBuffer val = table.get(0);
+            if (val == null) {
+                r.r1 = 0;
+            } else if (val == bufA) {
+                r.r1 = validateContent(val, MAGIC_A) ? 1 : -1;
+            } else if (val == bufB) {
+                r.r1 = validateContent(val, MAGIC_B) ? 2 : -1;
+            } else if (val == seed) {
+                r.r1 = validateContent(val, SEED_MAGIC) ? 0 : -1;
+            } else {
+                r.r1 = -1;
+            }
+        }
+    }
+
+    // ========================================================================
+    // Test 6: Put + Remove on same slot — arbiter validates final state
+    // ========================================================================
+
+    @JCStressTest
+    @Description("Concurrent put and remove on the same slot. " + "Arbiter validates final ByteBuffer content is consistent.")
+    @Outcome(id = "1", expect = Expect.ACCEPTABLE, desc = "Put won: buffer present with correct content.")
+    @Outcome(id = "0", expect = Expect.ACCEPTABLE, desc = "Remove won: slot is null.")
+    @Outcome(id = "-1", expect = Expect.FORBIDDEN, desc = "Corrupt content or wrong buffer.")
+    @Outcome(expect = Expect.FORBIDDEN, desc = "Unexpected value.")
+    @State
+    public static class PutRemoveSameSlot {
+        private static final byte SEED_MAGIC = (byte) 0x11;
+        private static final byte SENTINEL_MAGIC = (byte) 0xEE;
+
+        private final RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        private final ByteBuffer seed = makeBuf(SEED_MAGIC);
+        private final ByteBuffer sentinel = makeBuf(SENTINEL_MAGIC);
+
+        public PutRemoveSameSlot() {
+            table.put(0, seed);
+        }
+
+        @Actor
+        public void putter() {
+            table.put(0, sentinel);
+        }
+
+        @Actor
+        public void remover() {
+            table.remove(0);
+        }
+
+        @Arbiter
+        public void arbiter(I_Result r) {
+            ByteBuffer val = table.get(0);
+            if (val == null) {
+                r.r1 = 0;
+            } else if (val == sentinel) {
+                r.r1 = validateContent(val, SENTINEL_MAGIC) ? 1 : -1;
+            } else {
+                r.r1 = -1;
+            }
+        }
+    }
+
+    // ========================================================================
+    // Test 7: Directory growth + concurrent read of existing entry
+    //
+    // Pre-populate blockId=0. Actor 1 triggers directory growth.
+    // Actor 2 reads blockId=0 and validates content is intact.
+    // ========================================================================
+
+    @JCStressTest
+    @Description("Directory growth must preserve existing entries. " + "Reader validates ByteBuffer content of pre-existing entry.")
+    @Outcome(id = "1", expect = Expect.ACCEPTABLE, desc = "Reader sees pre-existing entry with correct content.")
+    @Outcome(id = "0", expect = Expect.ACCEPTABLE_INTERESTING, desc = "Stale read of old directory — entry appears missing.")
+    @Outcome(id = "-1", expect = Expect.FORBIDDEN, desc = "Corrupt content — growth corrupted existing data.")
+    @Outcome(expect = Expect.FORBIDDEN, desc = "Unexpected value.")
+    @State
+    public static class DirectoryGrowthPreservesExisting {
+        private static final byte EXISTING_MAGIC = (byte) 0x55;
+        private static final byte FAR_MAGIC = (byte) 0x66;
+
+        private final RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+        private final ByteBuffer existing = makeBuf(EXISTING_MAGIC);
+        private final ByteBuffer farAway = makeBuf(FAR_MAGIC);
+
+        public DirectoryGrowthPreservesExisting() {
+            table.put(0, existing);
+        }
+
+        @Actor
+        public void grower() {
+            table.put(10L * RadixBlockTable.PAGE_SIZE, farAway);
+        }
+
+        @Actor
+        public void reader(I_Result r) {
+            ByteBuffer val = table.get(0);
+            if (val == null) {
+                r.r1 = 0;
+            } else if (val == existing) {
+                r.r1 = validateContent(val, EXISTING_MAGIC) ? 1 : -1;
+            } else {
+                r.r1 = -1;
+            }
+        }
+    }
+}

--- a/src/jmh/java/org/opensearch/index/store/benchmark/HotPathReadBenchmarks.java
+++ b/src/jmh/java/org/opensearch/index/store/benchmark/HotPathReadBenchmarks.java
@@ -5,14 +5,8 @@
 package org.opensearch.index.store.benchmark;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.RandomAccessInput;
@@ -23,7 +17,6 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -37,495 +30,448 @@ import org.opensearch.index.store.bufferpoolfs.StaticConfigs;
  * Hot path benchmark: all data is already resident in block cache (BufferPool)
  * or page cache (MMap). Measures pure read throughput without I/O latency.
  *
- * <p>Each benchmark method spawns {@code threadCount} concurrent reader threads,
- * each with its own IndexInput clone. This gives true concurrent read contention
- * as a JMH {@code @Param} without relying on {@code @Threads} annotation.
+ * <p>Thread count is controlled via JMH's {@code -t} flag (e.g., {@code -t 8}).
+ * JMH manages thread lifecycle directly, eliminating ExecutorService scheduling
+ * noise. Each JMH thread gets its own {@link ThreadState} with per-thread
+ * IndexInput clones (Lucene IndexInputs are not thread-safe).
+ *
+ * <p>Run examples:
+ * <pre>
+ *   # Default threads (all available processors via @Threads(MAX))
+ *   java ... -jar storage-encryption-jmh.jar HotPath
+ *
+ *   # Single-threaded
+ *   java ... -jar storage-encryption-jmh.jar HotPath -t 1
+ *
+ *   # 16 threads
+ *   java ... -jar storage-encryption-jmh.jar HotPath -t 16
+ * </pre>
  */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 10, time = 2)
 @Fork(value = 2, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
-@State(Scope.Benchmark)
-@Threads(1)
-public class HotPathReadBenchmarks extends ReadBenchmarkBase {
+@Threads(Threads.MAX)
+public class HotPathReadBenchmarks {
 
-    // Expand to "1", "4", "8", "16", "32" for full sweep
-    @Param({ "8" })
-    public int threadCount;
+    // ========================================================================
+    // Shared state — one instance per benchmark, shared across all threads.
+    // Holds directories, file data, offset arrays, and the master IndexInputs.
+    // ========================================================================
 
-    private ExecutorService executor;
+    @State(Scope.Benchmark)
+    public static class SharedState extends ReadBenchmarkBase {
 
-    /** Pre-warm caches by reading all files once. */
-    @Setup(Level.Trial)
-    public void setupHotPathTrial() throws Exception {
-        super.setupTrial();
-        final int blockSize = StaticConfigs.CACHE_BLOCK_SIZE;
-        byte[] buf = new byte[blockSize];
-        // BufferPool: read all files to populate block cache
-        if ("bufferpool".equals(directoryType)) {
-            for (String fileName : fileNames) {
-                try (IndexInput in = bufferPoolDirectory.openInput(fileName, org.apache.lucene.store.IOContext.DEFAULT)) {
-                    long remaining = in.length();
-                    while (remaining > 0) {
-                        int toRead = (int) Math.min(buf.length, remaining);
-                        in.readBytes(buf, 0, toRead);
-                        remaining -= toRead;
+        @Setup(Level.Trial)
+        public void setup() throws Exception {
+            super.setupTrial();
+            final int blockSize = StaticConfigs.CACHE_BLOCK_SIZE;
+            byte[] buf = new byte[blockSize];
+            // BufferPool: read all files to populate block cache
+            if ("bufferpool".equals(directoryType)) {
+                for (String fileName : fileNames) {
+                    try (IndexInput in = bufferPoolDirectory.openInput(fileName, org.apache.lucene.store.IOContext.DEFAULT)) {
+                        long remaining = in.length();
+                        while (remaining > 0) {
+                            int toRead = (int) Math.min(buf.length, remaining);
+                            in.readBytes(buf, 0, toRead);
+                            remaining -= toRead;
+                        }
+                    }
+                }
+            }
+            // MMap: read all files to populate page cache
+            if ("mmap".equals(directoryType) || "multisegment_mmap_impl".equals(directoryType)) {
+                for (String fileName : fileNames) {
+                    try (IndexInput in = mmapDirectory.openInput(fileName, org.apache.lucene.store.IOContext.DEFAULT)) {
+                        long remaining = in.length();
+                        while (remaining > 0) {
+                            int toRead = (int) Math.min(buf.length, remaining);
+                            in.readBytes(buf, 0, toRead);
+                            remaining -= toRead;
+                        }
                     }
                 }
             }
         }
-        // MMap: read all files to populate page cache
-        if ("mmap".equals(directoryType) || "multisegment_mmap_impl".equals(directoryType)) {
-            for (String fileName : fileNames) {
-                try (IndexInput in = mmapDirectory.openInput(fileName, org.apache.lucene.store.IOContext.DEFAULT)) {
-                    long remaining = in.length();
-                    while (remaining > 0) {
-                        int toRead = (int) Math.min(buf.length, remaining);
-                        in.readBytes(buf, 0, toRead);
-                        remaining -= toRead;
-                    }
+
+        @TearDown(Level.Trial)
+        public void tearDown() throws Exception {
+            super.closeInputs();
+            super.tearDownTrial();
+        }
+    }
+
+    // ========================================================================
+    // Per-thread state — each JMH thread gets its own IndexInput clones.
+    // Lucene IndexInputs are NOT thread-safe, so each thread must clone.
+    // ========================================================================
+
+    @State(Scope.Thread)
+    public static class ThreadState {
+        IndexInput[] threadInputs;
+        int numFilesToRead;
+        int fileSize;
+        long[] blockStartOffsets;
+        long[] randomReadByteOffsets;
+        int sequentialReadNumBytes;
+
+        @Setup(Level.Iteration)
+        public void setup(SharedState shared) {
+            numFilesToRead = shared.numFilesToRead;
+            fileSize = shared.fileSize;
+            blockStartOffsets = shared.blockStartOffsets;
+            randomReadByteOffsets = shared.randomReadByteOffsets;
+            sequentialReadNumBytes = shared.sequentialReadNumBytes;
+            threadInputs = new IndexInput[numFilesToRead];
+            for (int i = 0; i < numFilesToRead; i++) {
+                threadInputs[i] = shared.indexInputs[i].clone();
+            }
+        }
+
+        @TearDown(Level.Iteration)
+        public void tearDown() throws IOException {
+            if (threadInputs != null) {
+                for (IndexInput in : threadInputs) {
+                    if (in != null)
+                        in.close();
                 }
+                threadInputs = null;
             }
         }
     }
 
-    @Setup(Level.Iteration)
-    public void setupIteration() {
-        AtomicInteger counter = new AtomicInteger();
-        executor = Executors.newFixedThreadPool(threadCount, r -> {
-            Thread t = new Thread(r, "jmh-reader-" + counter.getAndIncrement());
-            t.setDaemon(true);
-            return t;
-        });
-    }
+    // ========================================================================
+    // Benchmarks — Random reads via clone (crossing block boundaries)
+    // ========================================================================
 
-    /**
-     * Runs a task on {@code threadCount} threads concurrently.
-     * Waits for all to complete and consumes results via Blackhole.
-     */
-    private void runConcurrent(ReaderTask task, Blackhole bh) throws Exception {
-        List<Future<?>> futures = new ArrayList<>(threadCount);
-        for (int t = 0; t < threadCount; t++) {
-            futures.add(executor.submit(() -> {
-                try {
-                    task.run(bh);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }));
-        }
-        for (Future<?> f : futures) {
-            f.get();
-        }
-    }
-
-    @FunctionalInterface
-    interface ReaderTask {
-        void run(Blackhole bh) throws IOException;
-    }
-
-    // ---- Random reads via clone (crossing block boundaries) ----
     @Benchmark
-    public void randomReadByteFromClone(Blackhole bh) throws Exception {
-        runConcurrent((hole) -> {
-            // Randomly read bytes from distinct blocks across all files
-            long[] randomReadOffsets = getRandomReadByteOffsets();
-            for (int fileIdx = 0; fileIdx < numFilesToRead; fileIdx++) {
-                IndexInput fileInput = indexInputs[fileIdx].clone();
-                RandomAccessInput in = (RandomAccessInput) fileInput;
-                for (long offset : randomReadOffsets) {
-                    byte b = in.readByte(offset);
-                    hole.consume(b);
-                }
+    public void randomReadByteFromClone(ThreadState ts, Blackhole bh) throws IOException {
+        for (int fileIdx = 0; fileIdx < ts.numFilesToRead; fileIdx++) {
+            IndexInput fileInput = ts.threadInputs[fileIdx];
+            RandomAccessInput in = (RandomAccessInput) fileInput;
+            for (long offset : ts.randomReadByteOffsets) {
+                bh.consume(in.readByte(offset));
             }
-        }, bh);
+        }
     }
 
-    // Sequentially read X bytes from each block (no block boundary crossing)
     @Benchmark
-    public void sequentialReadBytesFromClone(Blackhole bh) throws Exception {
-        runConcurrent((hole) -> {
-            for (int fileIdx = 0; fileIdx < numFilesToRead; fileIdx++) {
-                IndexInput fileInput = indexInputs[fileIdx].clone();
-                for (long offset : blockStartOffsets) {
-                    int dummyConsumer = 0;
-                    fileInput.seek(offset);
-                    long remaining = Math.min(sequentialReadNumBytes, fileSize - offset);
-                    for (long i = 0; i < remaining; i++) {
-                        byte b = fileInput.readByte();
-                        dummyConsumer += b;
-                    }
-                    hole.consume(dummyConsumer);
+    public void sequentialReadBytesFromClone(ThreadState ts, Blackhole bh) throws IOException {
+        for (int fileIdx = 0; fileIdx < ts.numFilesToRead; fileIdx++) {
+            IndexInput fileInput = ts.threadInputs[fileIdx];
+            for (long offset : ts.blockStartOffsets) {
+                int dummyConsumer = 0;
+                fileInput.seek(offset);
+                long remaining = Math.min(ts.sequentialReadNumBytes, ts.fileSize - offset);
+                for (long i = 0; i < remaining; i++) {
+                    dummyConsumer += fileInput.readByte();
                 }
+                bh.consume(dummyConsumer);
             }
-        }, bh);
+        }
     }
 
     // ======================== RandomAccessInput API benchmarks ========================
 
-    // RandomAccessInput.readShort(long pos) — random positions across blocks
     @Benchmark
-    public void randomReadShortFromClone(Blackhole bh) throws Exception {
-        runConcurrent((hole) -> {
-            long[] offsets = getRandomReadByteOffsets();
-            for (int fileIdx = 0; fileIdx < numFilesToRead; fileIdx++) {
-                IndexInput fileInput = indexInputs[fileIdx].clone();
-                RandomAccessInput in = (RandomAccessInput) fileInput;
-                for (long offset : offsets) {
-                    if (offset + Short.BYTES <= fileSize) {
-                        hole.consume(in.readShort(offset));
-                    }
+    public void randomReadShortFromClone(ThreadState ts, Blackhole bh) throws IOException {
+        for (int fileIdx = 0; fileIdx < ts.numFilesToRead; fileIdx++) {
+            IndexInput fileInput = ts.threadInputs[fileIdx];
+            RandomAccessInput in = (RandomAccessInput) fileInput;
+            for (long offset : ts.randomReadByteOffsets) {
+                if (offset + Short.BYTES <= ts.fileSize) {
+                    bh.consume(in.readShort(offset));
                 }
             }
-        }, bh);
+        }
     }
 
-    // RandomAccessInput.readInt(long pos) — random positions across blocks
     @Benchmark
-    public void randomReadIntFromClone(Blackhole bh) throws Exception {
-        runConcurrent((hole) -> {
-            long[] offsets = getRandomReadByteOffsets();
-            for (int fileIdx = 0; fileIdx < numFilesToRead; fileIdx++) {
-                IndexInput fileInput = indexInputs[fileIdx].clone();
-                RandomAccessInput in = (RandomAccessInput) fileInput;
-                for (long offset : offsets) {
-                    if (offset + Integer.BYTES <= fileSize) {
-                        hole.consume(in.readInt(offset));
-                    }
+    public void randomReadIntFromClone(ThreadState ts, Blackhole bh) throws IOException {
+        for (int fileIdx = 0; fileIdx < ts.numFilesToRead; fileIdx++) {
+            IndexInput fileInput = ts.threadInputs[fileIdx];
+            RandomAccessInput in = (RandomAccessInput) fileInput;
+            for (long offset : ts.randomReadByteOffsets) {
+                if (offset + Integer.BYTES <= ts.fileSize) {
+                    bh.consume(in.readInt(offset));
                 }
             }
-        }, bh);
+        }
     }
 
-    // RandomAccessInput.readLong(long pos) — random positions across blocks
     @Benchmark
-    public void randomReadLongFromClone(Blackhole bh) throws Exception {
-        runConcurrent((hole) -> {
-            long[] offsets = getRandomReadByteOffsets();
-            for (int fileIdx = 0; fileIdx < numFilesToRead; fileIdx++) {
-                IndexInput fileInput = indexInputs[fileIdx].clone();
-                RandomAccessInput in = (RandomAccessInput) fileInput;
-                for (long offset : offsets) {
-                    if (offset + Long.BYTES <= fileSize) {
-                        hole.consume(in.readLong(offset));
-                    }
+    public void randomReadLongFromClone(ThreadState ts, Blackhole bh) throws IOException {
+        for (int fileIdx = 0; fileIdx < ts.numFilesToRead; fileIdx++) {
+            IndexInput fileInput = ts.threadInputs[fileIdx];
+            RandomAccessInput in = (RandomAccessInput) fileInput;
+            for (long offset : ts.randomReadByteOffsets) {
+                if (offset + Long.BYTES <= ts.fileSize) {
+                    bh.consume(in.readLong(offset));
                 }
             }
-        }, bh);
+        }
     }
 
-    // RandomAccessInput.readBytes(long pos, byte[], int offset, int length) — bulk random read
     @Benchmark
-    public void randomReadBulkBytesFromClone(Blackhole bh) throws Exception {
-        runConcurrent((hole) -> {
-            long[] offsets = getRandomReadByteOffsets();
-            byte[] readBuf = new byte[StaticConfigs.CACHE_BLOCK_SIZE];
-            for (int fileIdx = 0; fileIdx < numFilesToRead; fileIdx++) {
-                IndexInput fileInput = indexInputs[fileIdx].clone();
-                RandomAccessInput in = (RandomAccessInput) fileInput;
-                for (long offset : offsets) {
-                    int readable = (int) Math.min(readBuf.length, fileSize - offset);
-                    if (readable > 0) {
-                        in.readBytes(offset, readBuf, 0, readable);
-                        hole.consume(readBuf[0]);
-                    }
+    public void randomReadBulkBytesFromClone(ThreadState ts, Blackhole bh) throws IOException {
+        byte[] readBuf = new byte[StaticConfigs.CACHE_BLOCK_SIZE];
+        for (int fileIdx = 0; fileIdx < ts.numFilesToRead; fileIdx++) {
+            IndexInput fileInput = ts.threadInputs[fileIdx];
+            RandomAccessInput in = (RandomAccessInput) fileInput;
+            for (long offset : ts.randomReadByteOffsets) {
+                int readable = (int) Math.min(readBuf.length, ts.fileSize - offset);
+                if (readable > 0) {
+                    in.readBytes(offset, readBuf, 0, readable);
+                    bh.consume(readBuf[0]);
                 }
             }
-        }, bh);
+        }
     }
 
     // ======================== IndexInput sequential API benchmarks ========================
 
-    // IndexInput.readBytes(byte[], int, int) — bulk sequential read from block starts
     @Benchmark
-    public void sequentialReadBulkBytesFromClone(Blackhole bh) throws Exception {
-        runConcurrent((hole) -> {
-            byte[] readBuf = new byte[StaticConfigs.CACHE_BLOCK_SIZE];
-            for (int fileIdx = 0; fileIdx < numFilesToRead; fileIdx++) {
-                IndexInput fileInput = indexInputs[fileIdx].clone();
-                for (long offset : blockStartOffsets) {
-                    fileInput.seek(offset);
-                    int readable = (int) Math.min(readBuf.length, fileSize - offset);
-                    if (readable > 0) {
-                        fileInput.readBytes(readBuf, 0, readable);
-                        hole.consume(readBuf[0]);
-                    }
+    public void sequentialReadBulkBytesFromClone(ThreadState ts, Blackhole bh) throws IOException {
+        byte[] readBuf = new byte[StaticConfigs.CACHE_BLOCK_SIZE];
+        for (int fileIdx = 0; fileIdx < ts.numFilesToRead; fileIdx++) {
+            IndexInput fileInput = ts.threadInputs[fileIdx];
+            for (long offset : ts.blockStartOffsets) {
+                fileInput.seek(offset);
+                int readable = (int) Math.min(readBuf.length, ts.fileSize - offset);
+                if (readable > 0) {
+                    fileInput.readBytes(readBuf, 0, readable);
+                    bh.consume(readBuf[0]);
                 }
             }
-        }, bh);
-    }
-
-    // IndexInput.readShort() — sequential short reads from block starts
-    @Benchmark
-    public void sequentialReadShortFromClone(Blackhole bh) throws Exception {
-        runConcurrent((hole) -> {
-            for (int fileIdx = 0; fileIdx < numFilesToRead; fileIdx++) {
-                IndexInput fileInput = indexInputs[fileIdx].clone();
-                for (long offset : blockStartOffsets) {
-                    if (offset + Short.BYTES <= fileSize) {
-                        fileInput.seek(offset);
-                        hole.consume(fileInput.readShort());
-                    }
-                }
-            }
-        }, bh);
-    }
-
-    // IndexInput.readInt() — sequential int reads from block starts
-    @Benchmark
-    public void sequentialReadIntFromClone(Blackhole bh) throws Exception {
-        runConcurrent((hole) -> {
-            for (int fileIdx = 0; fileIdx < numFilesToRead; fileIdx++) {
-                IndexInput fileInput = indexInputs[fileIdx].clone();
-                for (long offset : blockStartOffsets) {
-                    if (offset + Integer.BYTES <= fileSize) {
-                        fileInput.seek(offset);
-                        hole.consume(fileInput.readInt());
-                    }
-                }
-            }
-        }, bh);
-    }
-
-    // IndexInput.readLong() — sequential long reads from block starts
-    @Benchmark
-    public void sequentialReadLongFromClone(Blackhole bh) throws Exception {
-        runConcurrent((hole) -> {
-            for (int fileIdx = 0; fileIdx < numFilesToRead; fileIdx++) {
-                IndexInput fileInput = indexInputs[fileIdx].clone();
-                for (long offset : blockStartOffsets) {
-                    if (offset + Long.BYTES <= fileSize) {
-                        fileInput.seek(offset);
-                        hole.consume(fileInput.readLong());
-                    }
-                }
-            }
-        }, bh);
-    }
-
-    // IndexInput.readInts(int[], int, int) — bulk int array read from block starts
-    @Benchmark
-    public void sequentialReadIntsFromClone(Blackhole bh) throws Exception {
-        runConcurrent((hole) -> {
-            int numInts = StaticConfigs.CACHE_BLOCK_SIZE / Integer.BYTES;
-            int[] intBuf = new int[numInts];
-            for (int fileIdx = 0; fileIdx < numFilesToRead; fileIdx++) {
-                IndexInput fileInput = indexInputs[fileIdx].clone();
-                for (long offset : blockStartOffsets) {
-                    long remaining = fileSize - offset;
-                    int readable = (int) Math.min(numInts, remaining / Integer.BYTES);
-                    if (readable > 0) {
-                        fileInput.seek(offset);
-                        fileInput.readInts(intBuf, 0, readable);
-                        hole.consume(intBuf[0]);
-                    }
-                }
-            }
-        }, bh);
-    }
-
-    // IndexInput.readLongs(long[], int, int) — bulk long array read from block starts
-    @Benchmark
-    public void sequentialReadLongsFromClone(Blackhole bh) throws Exception {
-        runConcurrent((hole) -> {
-            int numLongs = StaticConfigs.CACHE_BLOCK_SIZE / Long.BYTES;
-            long[] longBuf = new long[numLongs];
-            for (int fileIdx = 0; fileIdx < numFilesToRead; fileIdx++) {
-                IndexInput fileInput = indexInputs[fileIdx].clone();
-                for (long offset : blockStartOffsets) {
-                    long remaining = fileSize - offset;
-                    int readable = (int) Math.min(numLongs, remaining / Long.BYTES);
-                    if (readable > 0) {
-                        fileInput.seek(offset);
-                        fileInput.readLongs(longBuf, 0, readable);
-                        hole.consume(longBuf[0]);
-                    }
-                }
-            }
-        }, bh);
-    }
-
-    // IndexInput.readFloats(float[], int, int) — bulk float array read from block starts
-    @Benchmark
-    public void sequentialReadFloatsFromClone(Blackhole bh) throws Exception {
-        runConcurrent((hole) -> {
-            int numFloats = StaticConfigs.CACHE_BLOCK_SIZE / Float.BYTES;
-            float[] floatBuf = new float[numFloats];
-            for (int fileIdx = 0; fileIdx < numFilesToRead; fileIdx++) {
-                IndexInput fileInput = indexInputs[fileIdx].clone();
-                for (long offset : blockStartOffsets) {
-                    long remaining = fileSize - offset;
-                    int readable = (int) Math.min(numFloats, remaining / Float.BYTES);
-                    if (readable > 0) {
-                        fileInput.seek(offset);
-                        fileInput.readFloats(floatBuf, 0, readable);
-                        hole.consume(floatBuf[0]);
-                    }
-                }
-            }
-        }, bh);
-    }
-
-    // IndexInput.slice() + read — create a slice and read through it
-    @Benchmark
-    public void sliceReadBytesFromClone(Blackhole bh) throws Exception {
-        runConcurrent((hole) -> {
-            byte[] readBuf = new byte[StaticConfigs.CACHE_BLOCK_SIZE];
-            for (int fileIdx = 0; fileIdx < numFilesToRead; fileIdx++) {
-                IndexInput fileInput = indexInputs[fileIdx].clone();
-                for (long offset : blockStartOffsets) {
-                    long sliceLen = Math.min(StaticConfigs.CACHE_BLOCK_SIZE, fileSize - offset);
-                    if (sliceLen > 0) {
-                        try (IndexInput slice = fileInput.slice("bench-slice", offset, sliceLen)) {
-                            slice.readBytes(readBuf, 0, (int) sliceLen);
-                            hole.consume(readBuf[0]);
-                        }
-                    }
-                }
-            }
-        }, bh);
-    }
-
-    // IndexInput.skipBytes(long) — seek + skip pattern
-    @Benchmark
-    public void skipBytesFromClone(Blackhole bh) throws Exception {
-        runConcurrent((hole) -> {
-            for (int fileIdx = 0; fileIdx < numFilesToRead; fileIdx++) {
-                IndexInput fileInput = indexInputs[fileIdx].clone();
-                fileInput.seek(0);
-                long pos = 0;
-                while (pos + StaticConfigs.CACHE_BLOCK_SIZE < fileSize) {
-                    fileInput.skipBytes(StaticConfigs.CACHE_BLOCK_SIZE);
-                    pos += StaticConfigs.CACHE_BLOCK_SIZE;
-                    if (pos + 1 <= fileSize) {
-                        hole.consume(fileInput.readByte());
-                        pos++;
-                    }
-                }
-            }
-        }, bh);
-    }
-
-    // Mixed workload: randomly exercises all read APIs in a single benchmark
-    // to simulate realistic Lucene read patterns where different APIs are interleaved.
-    @Benchmark
-    public void mixedReadWorkload(Blackhole bh) throws Exception {
-        runConcurrent((hole) -> {
-            long[] offsets = getRandomReadByteOffsets();
-            byte[] readBuf = new byte[StaticConfigs.CACHE_BLOCK_SIZE];
-            int numInts = StaticConfigs.CACHE_BLOCK_SIZE / Integer.BYTES;
-            int[] intBuf = new int[numInts];
-            int numLongs = StaticConfigs.CACHE_BLOCK_SIZE / Long.BYTES;
-            long[] longBuf = new long[numLongs];
-            int numFloats = StaticConfigs.CACHE_BLOCK_SIZE / Float.BYTES;
-            float[] floatBuf = new float[numFloats];
-
-            for (int fileIdx = 0; fileIdx < numFilesToRead; fileIdx++) {
-                IndexInput fileInput = indexInputs[fileIdx].clone();
-                RandomAccessInput rai = (RandomAccessInput) fileInput;
-                for (int i = 0; i < offsets.length; i++) {
-                    long offset = offsets[i];
-                    int op = ThreadLocalRandom.current().nextInt(12);
-                    switch (op) {
-                        case 0 -> hole.consume(rai.readByte(offset));
-                        case 1 -> {
-                            if (offset + Short.BYTES <= fileSize)
-                                hole.consume(rai.readShort(offset));
-                        }
-                        case 2 -> {
-                            if (offset + Integer.BYTES <= fileSize)
-                                hole.consume(rai.readInt(offset));
-                        }
-                        case 3 -> {
-                            if (offset + Long.BYTES <= fileSize)
-                                hole.consume(rai.readLong(offset));
-                        }
-                        case 4 -> {
-                            int readable = (int) Math.min(readBuf.length, fileSize - offset);
-                            if (readable > 0) {
-                                rai.readBytes(offset, readBuf, 0, readable);
-                                hole.consume(readBuf[0]);
-                            }
-                        }
-                        case 5 -> {
-                            fileInput.seek(offset);
-                            hole.consume(fileInput.readByte());
-                        }
-                        case 6 -> {
-                            fileInput.seek(offset);
-                            int readable = (int) Math.min(readBuf.length, fileSize - offset);
-                            if (readable > 0) {
-                                fileInput.readBytes(readBuf, 0, readable);
-                                hole.consume(readBuf[0]);
-                            }
-                        }
-                        case 7 -> {
-                            fileInput.seek(offset);
-                            long remaining = fileSize - offset;
-                            int readable = (int) Math.min(numInts, remaining / Integer.BYTES);
-                            if (readable > 0) {
-                                fileInput.readInts(intBuf, 0, readable);
-                                hole.consume(intBuf[0]);
-                            }
-                        }
-                        case 8 -> {
-                            fileInput.seek(offset);
-                            long remaining = fileSize - offset;
-                            int readable = (int) Math.min(numLongs, remaining / Long.BYTES);
-                            if (readable > 0) {
-                                fileInput.readLongs(longBuf, 0, readable);
-                                hole.consume(longBuf[0]);
-                            }
-                        }
-                        case 9 -> {
-                            fileInput.seek(offset);
-                            long remaining = fileSize - offset;
-                            int readable = (int) Math.min(numFloats, remaining / Float.BYTES);
-                            if (readable > 0) {
-                                fileInput.readFloats(floatBuf, 0, readable);
-                                hole.consume(floatBuf[0]);
-                            }
-                        }
-                        case 10 -> {
-                            long sliceLen = Math.min(StaticConfigs.CACHE_BLOCK_SIZE, fileSize - offset);
-                            if (sliceLen > 0) {
-                                try (IndexInput slice = fileInput.slice("bench-slice", offset, sliceLen)) {
-                                    slice.readBytes(readBuf, 0, (int) sliceLen);
-                                    hole.consume(readBuf[0]);
-                                }
-                            }
-                        }
-                        case 11 -> {
-                            fileInput.seek(offset);
-                            long skip = Math.min(StaticConfigs.CACHE_BLOCK_SIZE, fileSize - offset);
-                            if (skip > 0) {
-                                fileInput.skipBytes(skip);
-                                hole.consume(fileInput.getFilePointer());
-                            }
-                        }
-                    }
-                }
-            }
-        }, bh);
-    }
-
-    @TearDown(Level.Iteration)
-    public void tearDownIteration() throws IOException {
-        if (executor != null) {
-            executor.shutdownNow();
-            try {
-                executor.awaitTermination(5, TimeUnit.SECONDS);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-            executor = null;
         }
     }
 
-    @TearDown(Level.Trial)
-    public void tearDownHotPathTrial() throws Exception {
-        super.closeInputs();
-        super.tearDownTrial();
+    @Benchmark
+    public void sequentialReadShortFromClone(ThreadState ts, Blackhole bh) throws IOException {
+        for (int fileIdx = 0; fileIdx < ts.numFilesToRead; fileIdx++) {
+            IndexInput fileInput = ts.threadInputs[fileIdx];
+            for (long offset : ts.blockStartOffsets) {
+                if (offset + Short.BYTES <= ts.fileSize) {
+                    fileInput.seek(offset);
+                    bh.consume(fileInput.readShort());
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void sequentialReadIntFromClone(ThreadState ts, Blackhole bh) throws IOException {
+        for (int fileIdx = 0; fileIdx < ts.numFilesToRead; fileIdx++) {
+            IndexInput fileInput = ts.threadInputs[fileIdx];
+            for (long offset : ts.blockStartOffsets) {
+                if (offset + Integer.BYTES <= ts.fileSize) {
+                    fileInput.seek(offset);
+                    bh.consume(fileInput.readInt());
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void sequentialReadLongFromClone(ThreadState ts, Blackhole bh) throws IOException {
+        for (int fileIdx = 0; fileIdx < ts.numFilesToRead; fileIdx++) {
+            IndexInput fileInput = ts.threadInputs[fileIdx];
+            for (long offset : ts.blockStartOffsets) {
+                if (offset + Long.BYTES <= ts.fileSize) {
+                    fileInput.seek(offset);
+                    bh.consume(fileInput.readLong());
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void sequentialReadIntsFromClone(ThreadState ts, Blackhole bh) throws IOException {
+        int numInts = StaticConfigs.CACHE_BLOCK_SIZE / Integer.BYTES;
+        int[] intBuf = new int[numInts];
+        for (int fileIdx = 0; fileIdx < ts.numFilesToRead; fileIdx++) {
+            IndexInput fileInput = ts.threadInputs[fileIdx];
+            for (long offset : ts.blockStartOffsets) {
+                long remaining = ts.fileSize - offset;
+                int readable = (int) Math.min(numInts, remaining / Integer.BYTES);
+                if (readable > 0) {
+                    fileInput.seek(offset);
+                    fileInput.readInts(intBuf, 0, readable);
+                    bh.consume(intBuf[0]);
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void sequentialReadLongsFromClone(ThreadState ts, Blackhole bh) throws IOException {
+        int numLongs = StaticConfigs.CACHE_BLOCK_SIZE / Long.BYTES;
+        long[] longBuf = new long[numLongs];
+        for (int fileIdx = 0; fileIdx < ts.numFilesToRead; fileIdx++) {
+            IndexInput fileInput = ts.threadInputs[fileIdx];
+            for (long offset : ts.blockStartOffsets) {
+                long remaining = ts.fileSize - offset;
+                int readable = (int) Math.min(numLongs, remaining / Long.BYTES);
+                if (readable > 0) {
+                    fileInput.seek(offset);
+                    fileInput.readLongs(longBuf, 0, readable);
+                    bh.consume(longBuf[0]);
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void sequentialReadFloatsFromClone(ThreadState ts, Blackhole bh) throws IOException {
+        int numFloats = StaticConfigs.CACHE_BLOCK_SIZE / Float.BYTES;
+        float[] floatBuf = new float[numFloats];
+        for (int fileIdx = 0; fileIdx < ts.numFilesToRead; fileIdx++) {
+            IndexInput fileInput = ts.threadInputs[fileIdx];
+            for (long offset : ts.blockStartOffsets) {
+                long remaining = ts.fileSize - offset;
+                int readable = (int) Math.min(numFloats, remaining / Float.BYTES);
+                if (readable > 0) {
+                    fileInput.seek(offset);
+                    fileInput.readFloats(floatBuf, 0, readable);
+                    bh.consume(floatBuf[0]);
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void sliceReadBytesFromClone(ThreadState ts, Blackhole bh) throws IOException {
+        byte[] readBuf = new byte[StaticConfigs.CACHE_BLOCK_SIZE];
+        for (int fileIdx = 0; fileIdx < ts.numFilesToRead; fileIdx++) {
+            IndexInput fileInput = ts.threadInputs[fileIdx];
+            for (long offset : ts.blockStartOffsets) {
+                long sliceLen = Math.min(StaticConfigs.CACHE_BLOCK_SIZE, ts.fileSize - offset);
+                if (sliceLen > 0) {
+                    try (IndexInput slice = fileInput.slice("bench-slice", offset, sliceLen)) {
+                        slice.readBytes(readBuf, 0, (int) sliceLen);
+                        bh.consume(readBuf[0]);
+                    }
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void skipBytesFromClone(ThreadState ts, Blackhole bh) throws IOException {
+        for (int fileIdx = 0; fileIdx < ts.numFilesToRead; fileIdx++) {
+            IndexInput fileInput = ts.threadInputs[fileIdx];
+            fileInput.seek(0);
+            long pos = 0;
+            while (pos + StaticConfigs.CACHE_BLOCK_SIZE < ts.fileSize) {
+                fileInput.skipBytes(StaticConfigs.CACHE_BLOCK_SIZE);
+                pos += StaticConfigs.CACHE_BLOCK_SIZE;
+                if (pos + 1 <= ts.fileSize) {
+                    bh.consume(fileInput.readByte());
+                    pos++;
+                }
+            }
+        }
+    }
+
+    // Mixed workload: randomly exercises all read APIs in a single benchmark
+    @Benchmark
+    public void mixedReadWorkload(ThreadState ts, Blackhole bh) throws IOException {
+        long[] offsets = ts.randomReadByteOffsets;
+        byte[] readBuf = new byte[StaticConfigs.CACHE_BLOCK_SIZE];
+        int numInts = StaticConfigs.CACHE_BLOCK_SIZE / Integer.BYTES;
+        int[] intBuf = new int[numInts];
+        int numLongs = StaticConfigs.CACHE_BLOCK_SIZE / Long.BYTES;
+        long[] longBuf = new long[numLongs];
+        int numFloats = StaticConfigs.CACHE_BLOCK_SIZE / Float.BYTES;
+        float[] floatBuf = new float[numFloats];
+
+        for (int fileIdx = 0; fileIdx < ts.numFilesToRead; fileIdx++) {
+            IndexInput fileInput = ts.threadInputs[fileIdx];
+            RandomAccessInput rai = (RandomAccessInput) fileInput;
+            for (int i = 0; i < offsets.length; i++) {
+                long offset = offsets[i];
+                int op = ThreadLocalRandom.current().nextInt(12);
+                switch (op) {
+                    case 0 -> bh.consume(rai.readByte(offset));
+                    case 1 -> {
+                        if (offset + Short.BYTES <= ts.fileSize)
+                            bh.consume(rai.readShort(offset));
+                    }
+                    case 2 -> {
+                        if (offset + Integer.BYTES <= ts.fileSize)
+                            bh.consume(rai.readInt(offset));
+                    }
+                    case 3 -> {
+                        if (offset + Long.BYTES <= ts.fileSize)
+                            bh.consume(rai.readLong(offset));
+                    }
+                    case 4 -> {
+                        int readable = (int) Math.min(readBuf.length, ts.fileSize - offset);
+                        if (readable > 0) {
+                            rai.readBytes(offset, readBuf, 0, readable);
+                            bh.consume(readBuf[0]);
+                        }
+                    }
+                    case 5 -> {
+                        fileInput.seek(offset);
+                        bh.consume(fileInput.readByte());
+                    }
+                    case 6 -> {
+                        fileInput.seek(offset);
+                        int readable = (int) Math.min(readBuf.length, ts.fileSize - offset);
+                        if (readable > 0) {
+                            fileInput.readBytes(readBuf, 0, readable);
+                            bh.consume(readBuf[0]);
+                        }
+                    }
+                    case 7 -> {
+                        fileInput.seek(offset);
+                        long remaining = ts.fileSize - offset;
+                        int readable = (int) Math.min(numInts, remaining / Integer.BYTES);
+                        if (readable > 0) {
+                            fileInput.readInts(intBuf, 0, readable);
+                            bh.consume(intBuf[0]);
+                        }
+                    }
+                    case 8 -> {
+                        fileInput.seek(offset);
+                        long remaining = ts.fileSize - offset;
+                        int readable = (int) Math.min(numLongs, remaining / Long.BYTES);
+                        if (readable > 0) {
+                            fileInput.readLongs(longBuf, 0, readable);
+                            bh.consume(longBuf[0]);
+                        }
+                    }
+                    case 9 -> {
+                        fileInput.seek(offset);
+                        long remaining = ts.fileSize - offset;
+                        int readable = (int) Math.min(numFloats, remaining / Float.BYTES);
+                        if (readable > 0) {
+                            fileInput.readFloats(floatBuf, 0, readable);
+                            bh.consume(floatBuf[0]);
+                        }
+                    }
+                    case 10 -> {
+                        long sliceLen = Math.min(StaticConfigs.CACHE_BLOCK_SIZE, ts.fileSize - offset);
+                        if (sliceLen > 0) {
+                            try (IndexInput slice = fileInput.slice("bench-slice", offset, sliceLen)) {
+                                slice.readBytes(readBuf, 0, (int) sliceLen);
+                                bh.consume(readBuf[0]);
+                            }
+                        }
+                    }
+                    case 11 -> {
+                        fileInput.seek(offset);
+                        long skip = Math.min(StaticConfigs.CACHE_BLOCK_SIZE, ts.fileSize - offset);
+                        if (skip > 0) {
+                            fileInput.skipBytes(skip);
+                            bh.consume(fileInput.getFilePointer());
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/jmh/java/org/opensearch/index/store/benchmark/RadixBlockTableBenchmark.java
+++ b/src/jmh/java/org/opensearch/index/store/benchmark/RadixBlockTableBenchmark.java
@@ -1,0 +1,441 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.benchmark;
+
+import static org.opensearch.index.store.bufferpoolfs.StaticConfigs.CACHE_BLOCK_SIZE;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.opensearch.index.store.block_cache.BlockCacheKey;
+import org.opensearch.index.store.block_cache.BlockCacheValue;
+import org.opensearch.index.store.block_cache.CaffeineBlockCache;
+import org.opensearch.index.store.block_cache.FileBlockCacheKey;
+import org.opensearch.index.store.bufferpoolfs.RadixBlockTable;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+/**
+ * Microbenchmark comparing pure read throughput of three L1/L2 cache strategies:
+ * <ul>
+ *   <li><b>radixL1</b> — RadixBlockTable.get(): two plain array loads, no fences</li>
+ *   <li><b>caffeineL2</b> — CaffeineBlockCache.get(): ConcurrentHashMap lookup</li>
+ *   <li><b>stampGatedL1</b> — BlockSlotTinyCache-style stamp-gated acquire/release lookup</li>
+ * </ul>
+ *
+ * Pre-populates all caches with {@code numBlocks} entries, then measures
+ * pure lookup throughput under JMH-managed thread concurrency.
+ *
+ * <p>Thread count is controlled via JMH's {@code -t} flag (e.g., {@code -t 16})
+ * or the {@code @Threads} annotation. JMH manages thread lifecycle directly,
+ * eliminating ExecutorService scheduling noise and providing accurate
+ * per-operation throughput measurement.
+ *
+ * <p>Run examples:
+ * <pre>
+ *   # Single-threaded (default)
+ *   java ... -jar storage-encryption-jmh.jar RadixBlockTable -t 1
+ *
+ *   # 16 threads
+ *   java ... -jar storage-encryption-jmh.jar RadixBlockTable -t 16
+ *
+ *   # Max threads (all available processors)
+ *   java ... -jar storage-encryption-jmh.jar RadixBlockTable -t max
+ * </pre>
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 2, time = 1)
+@Measurement(iterations = 3, time = 1)
+@Fork(value = 1, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
+@Threads(Threads.MAX)
+public class RadixBlockTableBenchmark {
+
+    // ========================================================================
+    // Shared state — one instance per benchmark, shared across all threads
+    // ========================================================================
+
+    @State(Scope.Benchmark)
+    public static class SharedState {
+
+        /** Number of cache blocks to populate. */
+        @Param({ "128", "8192" })
+        public int numBlocks;
+
+        /**
+         * Percentage of lookups that target populated keys (0-100).
+         * 100 = all hits, 50 = 50% hits / 50% misses.
+         */
+        @Param({ "100" })
+        public int hitPct;
+
+        // ---- caches under test ----
+        RadixBlockTable<ByteBuffer> radixTable;
+        RadixBlockTable<ByteBuffer> sparseRadixTable;
+        CaffeineBlockCache<ByteBuffer, Void> caffeineCache;
+        StampGatedCache stampGatedCache;
+
+        /**
+         * Stride between sparse blockIds. With PAGE_SIZE=1024, a stride of 2048
+         * means every put lands in a different outer directory slot, forcing
+         * directory growth well beyond DEFAULT_OUTER_SLOTS (256).
+         */
+        private static final int SPARSE_STRIDE = 2048;
+
+        // ---- shared data ----
+        ByteBuffer[] byteBuffers;
+        Path tempDir;
+        Path dummyFile;
+
+        // Pre-computed lookup keys for Caffeine
+        FileBlockCacheKey[] hitKeys;
+        FileBlockCacheKey[] missKeys;
+
+        @Setup(Level.Trial)
+        public void setup() throws Exception {
+            tempDir = Files.createTempDirectory("radix-bench");
+            dummyFile = tempDir.resolve("dummy.dat");
+
+            // Write file large enough for all blocks
+            byte[] fileData = new byte[numBlocks * CACHE_BLOCK_SIZE];
+            Files.write(dummyFile, fileData);
+
+            // Allocate backing ByteBuffers
+            byteBuffers = new ByteBuffer[numBlocks];
+            for (int i = 0; i < numBlocks; i++) {
+                byteBuffers[i] = ByteBuffer.allocateDirect(CACHE_BLOCK_SIZE);
+            }
+
+            // Pre-compute Caffeine lookup keys (FileBlockCacheKey uses Path + offset)
+            hitKeys = new FileBlockCacheKey[numBlocks];
+            missKeys = new FileBlockCacheKey[numBlocks];
+            for (int i = 0; i < numBlocks; i++) {
+                hitKeys[i] = new FileBlockCacheKey(dummyFile, (long) i * CACHE_BLOCK_SIZE);
+                missKeys[i] = new FileBlockCacheKey(dummyFile, (long) (numBlocks + i) * CACHE_BLOCK_SIZE);
+            }
+
+            // ---- Populate RadixBlockTable ----
+            radixTable = new RadixBlockTable<>(numBlocks / RadixBlockTable.PAGE_SIZE + 1);
+            for (int i = 0; i < numBlocks; i++) {
+                radixTable.put(i, byteBuffers[i]);
+            }
+
+            // ---- Populate CaffeineBlockCache (mainline L2 cache) ----
+            Cache<BlockCacheKey, BlockCacheValue<ByteBuffer>> rawCache = Caffeine
+                .newBuilder()
+                .initialCapacity(numBlocks)
+                .maximumSize(numBlocks * 2L)
+                .recordStats()
+                .build();
+            caffeineCache = new CaffeineBlockCache<>(rawCache, null, numBlocks * 2L);
+            for (int i = 0; i < numBlocks; i++) {
+                caffeineCache.put(hitKeys[i], new StubBlockCacheValue(byteBuffers[i]));
+            }
+
+            // ---- Populate StampGatedCache (simplified BlockSlotTinyCache) ----
+            stampGatedCache = new StampGatedCache();
+            for (int i = 0; i < numBlocks; i++) {
+                stampGatedCache.put(i, byteBuffers[i]);
+            }
+
+            // ---- Populate sparse RadixBlockTable (forces directory growth) ----
+            sparseRadixTable = new RadixBlockTable<>();
+            for (int i = 0; i < numBlocks; i++) {
+                sparseRadixTable.put((long) i * SPARSE_STRIDE, byteBuffers[i]);
+            }
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() throws Exception {
+            caffeineCache.clear();
+            deleteRecursively(tempDir);
+        }
+    }
+
+    // ========================================================================
+    // Per-thread state — each JMH thread gets its own seed for hit/miss
+    // ========================================================================
+
+    @State(Scope.Thread)
+    public static class ThreadState {
+        int seed;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            seed = (int) Thread.currentThread().threadId();
+        }
+    }
+
+    // ========================================================================
+    // Benchmarks
+    // ========================================================================
+
+    /**
+     * RadixBlockTable.get() — L1 cache.
+     * Two plain array loads, no fences, no synchronization.
+     */
+    @Benchmark
+    public void radixL1Get(SharedState s, ThreadState ts, Blackhole bh) {
+        for (int i = 0; i < s.numBlocks; i++) {
+            long blockId = nextBlockId(i, ts.seed, s.numBlocks, s.hitPct);
+            bh.consume(s.radixTable.get(blockId));
+        }
+    }
+
+    /**
+     * CaffeineBlockCache.get() — L2 cache.
+     * ConcurrentHashMap lookup with hashing.
+     */
+    @Benchmark
+    public void caffeineL2Get(SharedState s, ThreadState ts, Blackhole bh) {
+        for (int i = 0; i < s.numBlocks; i++) {
+            FileBlockCacheKey key = isHit(i, ts.seed, s.hitPct) ? s.hitKeys[i % s.numBlocks] : s.missKeys[i % s.numBlocks];
+            bh.consume(s.caffeineCache.get(key));
+        }
+    }
+
+    /**
+     * Simplified BlockSlotTinyCache-style stamp-gated acquire/release lookup.
+     * Isolates the L1 cache mechanism: VarHandle getAcquire on stamp, then
+     * plain loads of blockIdx and value arrays — mirrors the real
+     * BlockSlotTinyCache read path without the full RefCounted/pin/unpin lifecycle.
+     */
+    @Benchmark
+    public void stampGatedL1Get(SharedState s, ThreadState ts, Blackhole bh) {
+        for (int i = 0; i < s.numBlocks; i++) {
+            long blockId = nextBlockId(i, ts.seed, s.numBlocks, s.hitPct);
+            bh.consume(s.stampGatedCache.get(blockId));
+        }
+    }
+
+    /**
+     * Measures memory overhead of RadixBlockTable: directory array + inner arrays.
+     * Reports bytes per entry as a throughput metric.
+     */
+    @Benchmark
+    public void radixMemoryOverhead(SharedState s, Blackhole bh) {
+        bh.consume(s.radixTable.memoryOverheadBytes());
+    }
+
+    /**
+     * Realistic read path: RadixBlockTable L1 with Caffeine L2 fallback.
+     * On L1 miss, falls through to Caffeine L2 — this is the actual
+     * production read path for the radix-based design.
+     */
+    @Benchmark
+    public void radixL1WithCaffeineL2Fallback(SharedState s, ThreadState ts, Blackhole bh) {
+        for (int i = 0; i < s.numBlocks; i++) {
+            long blockId = nextBlockId(i, ts.seed, s.numBlocks, s.hitPct);
+            ByteBuffer val = s.radixTable.get(blockId);
+            if (val == null) {
+                // L1 miss → fall through to L2
+                int idx = (int) (blockId % s.numBlocks);
+                FileBlockCacheKey key = isHit(i, ts.seed, s.hitPct) ? s.hitKeys[idx] : s.missKeys[idx];
+                bh.consume(s.caffeineCache.get(key));
+            } else {
+                bh.consume(val);
+            }
+        }
+    }
+
+    /**
+     * Realistic read path: StampGated L1 with Caffeine L2 fallback.
+     * On L1 miss (due to 32-slot collision eviction), falls through to
+     * Caffeine L2. With 128+ blocks and only 32 slots, most lookups
+     * will miss L1 and hit L2, showing the true cost of collision pressure.
+     */
+    @Benchmark
+    public void stampGatedL1WithCaffeineL2Fallback(SharedState s, ThreadState ts, Blackhole bh) {
+        for (int i = 0; i < s.numBlocks; i++) {
+            long blockId = nextBlockId(i, ts.seed, s.numBlocks, s.hitPct);
+            ByteBuffer val = s.stampGatedCache.get(blockId);
+            if (val == null) {
+                // L1 miss → fall through to L2
+                int idx = (int) (blockId % s.numBlocks);
+                FileBlockCacheKey key = isHit(i, ts.seed, s.hitPct) ? s.hitKeys[idx] : s.missKeys[idx];
+                bh.consume(s.caffeineCache.get(key));
+            } else {
+                bh.consume(val);
+            }
+        }
+    }
+
+    /**
+     * RadixBlockTable lookup with sparse blockIds that force directory growth.
+     * Populates blocks at blockId offsets of {@code SPARSE_STRIDE * i}, causing
+     * the directory to grow well beyond DEFAULT_OUTER_SLOTS. Measures get()
+     * throughput on a grown directory to verify no performance cliff.
+     */
+    @Benchmark
+    public void radixL1GetSparseGrown(SharedState s, Blackhole bh) {
+        for (int i = 0; i < s.numBlocks; i++) {
+            long blockId = (long) i * SharedState.SPARSE_STRIDE;
+            bh.consume(s.sparseRadixTable.get(blockId));
+        }
+    }
+
+    // ========================================================================
+    // Hit/miss helpers (static — no instance state needed)
+    // ========================================================================
+
+    private static boolean isHit(int i, int seed, int hitPct) {
+        int hash = (i * 1103515245 + seed) & 0x7FFFFFFF;
+        return (hash % 100) < hitPct;
+    }
+
+    private static long nextBlockId(int i, int seed, int numBlocks, int hitPct) {
+        if (isHit(i, seed, hitPct)) {
+            return i % numBlocks;
+        } else {
+            return (long) numBlocks + (i % numBlocks);
+        }
+    }
+
+    // ========================================================================
+    // Simplified stamp-gated cache (mirrors BlockSlotTinyCache read path)
+    // ========================================================================
+
+    /**
+     * A simplified version of BlockSlotTinyCache that isolates the stamp-gated
+     * acquire/release lookup pattern for benchmarking. Uses the same VarHandle
+     * getAcquire/setRelease mechanism as the real BlockSlotTinyCache but without
+     * the RefCounted/pin/unpin lifecycle, allowing a fair comparison of the raw
+     * L1 lookup mechanism.
+     *
+     * <p>32 direct-mapped slots, hash-indexed. Each slot stores:
+     * <ul>
+     *   <li>slotBlockId[i] — which blockId is cached here</li>
+     *   <li>slotValue[i] — the cached ByteBuffer</li>
+     *   <li>slotStamp[i] — packed hash acting as a publication gate (acquire/release)</li>
+     * </ul>
+     */
+    static final class StampGatedCache {
+        private static final int SLOT_COUNT = 32;
+        private static final int SLOT_MASK = SLOT_COUNT - 1;
+        private static final VarHandle STAMP_ARR = MethodHandles.arrayElementVarHandle(long[].class);
+
+        private final long[] slotBlockId = new long[SLOT_COUNT];
+        private final ByteBuffer[] slotValue = new ByteBuffer[SLOT_COUNT];
+        private final long[] slotStamp = new long[SLOT_COUNT];
+
+        StampGatedCache() {
+            for (int i = 0; i < SLOT_COUNT; i++) {
+                slotBlockId[i] = -1;
+            }
+        }
+
+        ByteBuffer get(long blockId) {
+            int hash = hashBlockId(blockId);
+            int slotIdx = (int) ((blockId ^ (blockId >>> 17)) & SLOT_MASK);
+
+            long stamp = (long) STAMP_ARR.getAcquire(slotStamp, slotIdx);
+            if (stamp != 0L) {
+                int gotHash = (int) stamp;
+                if (gotHash == hash) {
+                    if (slotBlockId[slotIdx] == blockId) {
+                        return slotValue[slotIdx];
+                    }
+                }
+            }
+            return null;
+        }
+
+        void put(long blockId, ByteBuffer buffer) {
+            int hash = hashBlockId(blockId);
+            int slotIdx = (int) ((blockId ^ (blockId >>> 17)) & SLOT_MASK);
+
+            slotBlockId[slotIdx] = blockId;
+            slotValue[slotIdx] = buffer;
+            long stamp = hash & 0xFFFF_FFFFL;
+            STAMP_ARR.setRelease(slotStamp, slotIdx, stamp);
+        }
+
+        private static int hashBlockId(long blockId) {
+            return (int) (blockId ^ (blockId >>> 32));
+        }
+    }
+
+    // ========================================================================
+    // Stub BlockCacheValue for benchmark (no ref-counting needed)
+    // ========================================================================
+
+    /**
+     * Minimal BlockCacheValue implementation for benchmarking.
+     * No ref-counting or lifecycle management — just wraps a ByteBuffer.
+     */
+    static final class StubBlockCacheValue implements BlockCacheValue<ByteBuffer> {
+        private final ByteBuffer buffer;
+
+        StubBlockCacheValue(ByteBuffer buffer) {
+            this.buffer = buffer;
+        }
+
+        @Override
+        public boolean tryPin() {
+            return true;
+        }
+
+        @Override
+        public void unpin() {}
+
+        @Override
+        public ByteBuffer value() {
+            return buffer;
+        }
+
+        @Override
+        public int length() {
+            return buffer.capacity();
+        }
+
+        @Override
+        public void close() {}
+
+        @Override
+        public void decRef() {}
+
+        @Override
+        public int getGeneration() {
+            return 0;
+        }
+    }
+
+    // ========================================================================
+    // Utility
+    // ========================================================================
+
+    private static void deleteRecursively(Path path) throws Exception {
+        if (path == null)
+            return;
+        if (Files.isDirectory(path)) {
+            try (var entries = Files.list(path)) {
+                for (Path entry : entries.toList()) {
+                    deleteRecursively(entry);
+                }
+            }
+        }
+        Files.deleteIfExists(path);
+    }
+}

--- a/src/main/java/org/opensearch/index/store/bufferpoolfs/RadixBlockTable.java
+++ b/src/main/java/org/opensearch/index/store/bufferpoolfs/RadixBlockTable.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.bufferpoolfs;
+
+/**
+ * A two-level radix table mapping blockIds to values of type {@code V}.
+ * Designed as a per-VFD L1 lookup cache, but generic enough for any
+ * blockId-to-value mapping.
+ *
+ * <h2>Structure</h2>
+ * <pre>
+ *   outer index = blockId >>> PAGE_SHIFT   (which group of 1024)
+ *   inner slot  = blockId &amp; PAGE_MASK     (position within group)
+ * </pre>
+ *
+ * The outer level defaults to {@value #DEFAULT_OUTER_SLOTS} entries (2 KB),
+ * covering up to 2 GB of file data with 8 KB cache blocks. It can grow
+ * lazily on demand for larger files. Each inner array is a fixed-size
+ * {@code Object[PAGE_SIZE]} (1024 slots / 8 KB), directly indexed by
+ * the inner slot — no popcount, no COW. Inner arrays are reclaimed (nulled)
+ * when all their slots become empty, keeping memory overhead proportional
+ * to actual cached blocks.
+ *
+ * <h2>Sizing rationale</h2>
+ * With 8 KB cache blocks, a 5 GB file has ~655,360 block IDs.
+ * {@code PAGE_SHIFT = 10} gives 1024-slot inner arrays, so the outer
+ * directory needs only 640 entries for 5 GB (256 entries covers 2 GB).
+ * Opening 10,000 idle files (footer-read only) costs:
+ * {@code 10,000 x (2 KB outer + 8 KB inner) = ~100 MB} — well within
+ * the 600 MB budget. The read path remains two plain array loads with
+ * bit-shift indexing.
+ *
+ * <h2>Thread safety</h2>
+ * <ul>
+ *   <li>Reads are plain array loads — no fences, no synchronization.
+ *       JLS §17.7 guarantees reference writes/reads are atomic, so a reader
+ *       either sees the old value or the new value, never a torn reference.</li>
+ *   <li>Stale reads are benign: a stale {@code null} simply means an L1 miss,
+ *       falling through to the Caffeine L2 cache which is the source of truth.</li>
+ *   <li>Writers (search threads on L1/L2 miss, eviction threads nulling slots)
+ *       perform plain stores. Concurrent inner-array allocation is guarded by
+ *       {@code synchronized(this)} only for the allocation; subsequent slot
+ *       writes are plain stores.</li>
+ *   <li>Inner-array reclamation on {@link #remove} is guarded by
+ *       {@code synchronized(this)} to avoid races with concurrent
+ *       {@link #put} that may be allocating the same inner array.</li>
+ *   <li>No {@code volatile}, no {@code VarHandle}, no CAS on the read path.</li>
+ * </ul>
+ *
+ * <h2>Formal correctness properties</h2>
+ * <ol>
+ *   <li><b>No torn references:</b> JLS §17.7 — reference read/write is atomic.</li>
+ *   <li><b>No use-after-free:</b> Values are owned by the L2 cache; L1 holds
+ *       a reference. After eviction, the slot is nulled. A reader that grabbed
+ *       the reference before the null-write safely completes its read (the
+ *       value is still valid until GC collects it after all references
+ *       are released).</li>
+ *   <li><b>No memory leak:</b> {@link #clear()} nulls all inner arrays.
+ *       {@link #remove} reclaims empty inner arrays. Eviction nulls
+ *       individual slots.</li>
+ *   <li><b>Stale reads are benign:</b> A reader seeing a stale non-null
+ *       reference reads valid (possibly evicted) data — harmless for a cache.
+ *       A reader seeing stale null gets an L1 miss — correct fallback.</li>
+ * </ol>
+ *
+ * @param <V> the type of values stored in the table
+ */
+public final class RadixBlockTable<V> {
+
+    /** Each inner array covers 1024 consecutive blockIds. */
+    public static final int PAGE_SHIFT = 10;
+    public static final int PAGE_SIZE = 1 << PAGE_SHIFT; // 1024
+    private static final int PAGE_MASK = PAGE_SIZE - 1;   // 1023
+
+    /**
+     * Default outer directory size. 256 x 1024 = 262,144 block IDs.
+     * With 8 KB cache blocks this covers 2 GB per file without growth.
+     */
+    public static final int DEFAULT_OUTER_SLOTS = 256;
+
+    /**
+     * Outer directory: {@code directory[outer]} is either null (no inner array)
+     * or an {@code Object[PAGE_SIZE]}. Grown on demand under synchronized.
+     * Uses Object[][] due to Java generic array creation restrictions.
+     */
+    private Object[][] directory;
+
+    public RadixBlockTable() {
+        this.directory = new Object[DEFAULT_OUTER_SLOTS][];
+    }
+
+    public RadixBlockTable(int initialOuterSlots) {
+        this.directory = new Object[Math.max(initialOuterSlots, 1)][];
+    }
+
+    /**
+     * Looks up the value for the given blockId.
+     * Lock-free, no fences, no synchronization.
+     *
+     * @return the cached value, or null if not present (L1 miss)
+     */
+    @SuppressWarnings("unchecked")
+    public V get(long blockId) {
+        int outer = (int) (blockId >>> PAGE_SHIFT);
+        Object[][] dir = directory; // single read of the reference
+        if (outer >= dir.length)
+            return null;
+
+        Object[] inner = dir[outer]; // plain array load
+        if (inner == null)
+            return null;
+
+        int slot = (int) (blockId & PAGE_MASK);
+        return (V) inner[slot]; // plain array load — JLS §17.7 atomic reference read
+    }
+
+    /**
+     * Stores a value at the given blockId.
+     * Allocates the inner array lazily if needed (synchronized for allocation only).
+     * The slot write itself is a plain store.
+     *
+     * 
+     */
+    public void put(long blockId, V value) {
+        int outer = (int) (blockId >>> PAGE_SHIFT);
+        int slot = (int) (blockId & PAGE_MASK);
+
+        Object[][] dir = directory;
+        if (outer < dir.length) {
+            Object[] inner = dir[outer];
+            if (inner != null) {
+                // Fast path: inner array exists, plain store
+                inner[slot] = value;
+                return;
+            }
+        }
+
+        // Slow path: need to allocate inner array or grow directory
+        putSlow(outer, slot, value);
+    }
+
+    private synchronized void putSlow(int outer, int slot, V value) {
+        if (outer >= directory.length) {
+            growDirectory(outer);
+        }
+        Object[] inner = directory[outer];
+        if (inner == null) {
+            inner = new Object[PAGE_SIZE];
+            directory[outer] = inner;
+        }
+        inner[slot] = value;
+    }
+
+    /**
+     * Removes (nulls) the entry at the given blockId.
+     * After nulling the slot, scans the inner array. If all slots are null,
+     * the inner array is reclaimed (set to null) under synchronization to
+     * avoid races with concurrent {@link #put} allocating the same inner array.
+     *
+     * @return the previous value, or null if slot was empty
+     */
+    @SuppressWarnings("unchecked")
+    public V remove(long blockId) {
+        int outer = (int) (blockId >>> PAGE_SHIFT);
+        Object[][] dir = directory;
+        if (outer >= dir.length)
+            return null;
+
+        Object[] inner = dir[outer];
+        if (inner == null)
+            return null;
+
+        int slot = (int) (blockId & PAGE_MASK);
+        V prev = (V) inner[slot];
+        inner[slot] = null; // plain store — JLS §17.7 atomic reference write
+
+        // Check if inner array is now empty and reclaim if so
+        if (prev != null) {
+            reclaimIfEmpty(outer, inner);
+        }
+        return prev;
+    }
+
+    /**
+     * Scans the inner array for any non-null slot. If all slots are null,
+     * nulls the inner array in the directory under synchronization.
+     * The scan is 1024 reference checks — fits in ~16 cache lines.
+     */
+    private synchronized void reclaimIfEmpty(int outer, Object[] inner) {
+        // Re-check: another thread may have put into this inner array
+        // between our null-write and acquiring the lock
+        if (directory[outer] != inner) {
+            return; // inner array was replaced (e.g., by clear + re-put)
+        }
+        for (int i = 0; i < PAGE_SIZE; i++) {
+            if (inner[i] != null) {
+                return; // still has entries, don't reclaim
+            }
+        }
+        directory[outer] = null;
+    }
+
+    /**
+     * Clears all entries. Called on parent IndexInput close.
+     * Nulls all inner arrays.
+     */
+    public void clear() {
+        Object[][] dir = directory;
+        for (int i = 0; i < dir.length; i++) {
+            dir[i] = null;
+        }
+    }
+
+    /**
+     * Estimates the memory overhead of this table in bytes.
+     * Counts the object header, directory array, and all allocated inner arrays.
+     * Does not count the values themselves (owned by the L2 cache).
+     *
+     * @return estimated overhead in bytes
+     */
+    public long memoryOverheadBytes() {
+        Object[][] dir = directory;
+        long overhead = 16; // RadixBlockTable object header
+        overhead += 16 + 4 + 4 + (long) dir.length * 8; // directory array (header + length + padding + refs)
+        for (Object[] inner : dir) {
+            if (inner != null) {
+                overhead += 16 + 4 + 4 + (long) PAGE_SIZE * 8; // inner array (header + length + padding + refs)
+            }
+        }
+        return overhead;
+    }
+
+    /**
+     * Returns whether the inner array at the given outer index is allocated.
+     * Visible for testing.
+     */
+    boolean isInnerAllocated(int outer) {
+        Object[][] dir = directory;
+        return outer < dir.length && dir[outer] != null;
+    }
+
+    /**
+     * Returns the current outer directory length. Visible for testing.
+     */
+    int directoryLength() {
+        return directory.length;
+    }
+
+    /**
+     * Counts non-null entries in the inner array at the given outer index.
+     * Visible for testing. Returns -1 if inner array is not allocated.
+     */
+    int countEntries(int outer) {
+        Object[][] dir = directory;
+        if (outer >= dir.length)
+            return -1;
+        Object[] inner = dir[outer];
+        if (inner == null)
+            return -1;
+        int count = 0;
+        for (Object v : inner) {
+            if (v != null)
+                count++;
+        }
+        return count;
+    }
+
+    /**
+     * Returns the number of allocated inner arrays. Visible for testing
+     * and memory overhead measurement.
+     */
+    int allocatedInnerCount() {
+        Object[][] dir = directory;
+        int count = 0;
+        for (Object[] inner : dir) {
+            if (inner != null)
+                count++;
+        }
+        return count;
+    }
+
+    // ---- internal ----
+    private void growDirectory(int requiredOuter) {
+        int newSize = Math.max(requiredOuter + 1, directory.length * 2);
+        Object[][] newDir = new Object[newSize][];
+        System.arraycopy(directory, 0, newDir, 0, directory.length);
+        directory = newDir;
+    }
+}

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/RadixBlockTableConcurrencyTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/RadixBlockTableConcurrencyTests.java
@@ -1,0 +1,629 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.bufferpoolfs;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Concurrency tests for {@link RadixBlockTable} that validate the formal
+ * correctness properties under multi-threaded access using virtual threads.
+ *
+ * <h2>Correctness properties validated</h2>
+ * <ol>
+ *   <li>P1: No torn references (Property 8)</li>
+ *   <li>P2: Reader safety after eviction (Property 9)</li>
+ *   <li>P3: Clear safety (Property 10)</li>
+ *   <li>P4: Stale reads are benign</li>
+ *   <li>P5: Concurrent inner array allocation (Property 11)</li>
+ *   <li>P6: Concurrent directory growth (Property 11)</li>
+ *   <li>Sustained stress: 32+ threads, 10+ seconds, zero corruption</li>
+ * </ol>
+ */
+public class RadixBlockTableConcurrencyTests extends OpenSearchTestCase {
+
+    private static final int BLOCK_SIZE = 64;
+
+    private static ByteBuffer createSentinel(long blockId) {
+        ByteBuffer buf = ByteBuffer.allocateDirect(BLOCK_SIZE);
+        buf.putLong(0, blockId);
+        return buf;
+    }
+
+    private static ByteBuffer[] preallocateSentinels(int count) {
+        ByteBuffer[] sentinels = new ByteBuffer[count];
+        for (int i = 0; i < count; i++) {
+            sentinels[i] = createSentinel(i);
+        }
+        return sentinels;
+    }
+
+    // ========================================================================
+    // P1: No torn references — concurrent writers + readers (Property 8)
+    // ========================================================================
+
+    public void testP1NoTornReferencesConcurrentWritersAndReaders() throws Exception {
+        final int numBlocks = 256;
+        final int writerThreads = 100;
+        final int readerThreads = 100;
+        final long durationMs = 3000;
+        final int totalWorkers = writerThreads + readerThreads;
+
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(numBlocks / RadixBlockTable.PAGE_SIZE + 1);
+        ByteBuffer[] sentinels = preallocateSentinels(numBlocks);
+
+        for (int i = 0; i < numBlocks; i++) {
+            table.put(i, sentinels[i]);
+        }
+
+        AtomicBoolean tornRefDetected = new AtomicBoolean(false);
+        AtomicLong totalReads = new AtomicLong(0);
+        AtomicLong totalHits = new AtomicLong(0);
+        CountDownLatch readyLatch = new CountDownLatch(totalWorkers);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        AtomicBoolean running = new AtomicBoolean(true);
+
+        ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+        try {
+            for (int w = 0; w < writerThreads; w++) {
+                final int writerId = w;
+                executor.submit(() -> {
+                    readyLatch.countDown();
+                    try {
+                        startLatch.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                    int iteration = 0;
+                    while (running.get()) {
+                        int blockId = (int) ((writerId * 4L + (iteration % 4)) % numBlocks);
+                        table.put(blockId, sentinels[blockId]);
+                        iteration++;
+                        if ((iteration & 0xFF) == 0)
+                            Thread.yield();
+                    }
+                });
+            }
+
+            for (int r = 0; r < readerThreads; r++) {
+                executor.submit(() -> {
+                    readyLatch.countDown();
+                    try {
+                        startLatch.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                    long localReads = 0;
+                    while (running.get()) {
+                        long blockId = localReads % numBlocks;
+                        ByteBuffer buf = table.get(blockId);
+                        localReads++;
+                        if (buf != null) {
+                            totalHits.incrementAndGet();
+                            if (buf.getLong(0) != blockId) {
+                                tornRefDetected.set(true);
+                                running.set(false);
+                            }
+                        }
+                    }
+                    totalReads.addAndGet(localReads);
+                });
+            }
+
+            assertTrue(readyLatch.await(10, TimeUnit.SECONDS));
+            startLatch.countDown();
+            Thread.sleep(durationMs);
+            running.set(false);
+        } finally {
+            executor.shutdown();
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+            executor.shutdownNow();
+        }
+
+        assertFalse(tornRefDetected.get());
+        assertTrue(totalReads.get() > 0);
+        assertTrue(totalHits.get() > 0);
+    }
+
+    // ========================================================================
+    // P2: Reader safety after eviction (Property 9)
+    // ========================================================================
+
+    public void testP2ReaderSafetyAfterEviction() throws Exception {
+        final int numBlocks = 128;
+        final int writerCount = 50;
+        final int evictorCount = 50;
+        final int readerCount = 100;
+        final long durationMs = 3000;
+        final int totalWorkers = writerCount + evictorCount + readerCount;
+
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(numBlocks / RadixBlockTable.PAGE_SIZE + 1);
+        ByteBuffer[] sentinels = preallocateSentinels(numBlocks);
+        AtomicBoolean corruption = new AtomicBoolean(false);
+        AtomicLong evictions = new AtomicLong(0);
+        AtomicLong safeReadsAfterEviction = new AtomicLong(0);
+        CountDownLatch readyLatch = new CountDownLatch(totalWorkers);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        AtomicBoolean running = new AtomicBoolean(true);
+
+        for (int i = 0; i < numBlocks; i++) {
+            table.put(i, sentinels[i]);
+        }
+
+        ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+        try {
+            for (int w = 0; w < writerCount; w++) {
+                executor.submit(() -> {
+                    readyLatch.countDown();
+                    try {
+                        startLatch.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                    int iter = 0;
+                    while (running.get()) {
+                        int blockId = iter % numBlocks;
+                        table.put(blockId, sentinels[blockId]);
+                        iter++;
+                        if ((iter & 0xFF) == 0)
+                            Thread.yield();
+                    }
+                });
+            }
+
+            for (int e = 0; e < evictorCount; e++) {
+                executor.submit(() -> {
+                    readyLatch.countDown();
+                    try {
+                        startLatch.await();
+                    } catch (InterruptedException ex) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                    int iter = 0;
+                    while (running.get()) {
+                        long blockId = iter % numBlocks;
+                        ByteBuffer removed = table.remove(blockId);
+                        if (removed != null)
+                            evictions.incrementAndGet();
+                        iter++;
+                        if ((iter & 0xFF) == 0)
+                            Thread.yield();
+                    }
+                });
+            }
+
+            for (int r = 0; r < readerCount; r++) {
+                executor.submit(() -> {
+                    readyLatch.countDown();
+                    try {
+                        startLatch.await();
+                    } catch (InterruptedException ex) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                    int iter = 0;
+                    while (running.get()) {
+                        long blockId = iter % numBlocks;
+                        ByteBuffer buf = table.get(blockId);
+                        Thread.yield();
+                        if (buf != null) {
+                            long sentinel = buf.getLong(0);
+                            if (sentinel != blockId) {
+                                corruption.set(true);
+                                running.set(false);
+                            }
+                            safeReadsAfterEviction.incrementAndGet();
+                        }
+                        iter++;
+                    }
+                });
+            }
+
+            assertTrue(readyLatch.await(10, TimeUnit.SECONDS));
+            startLatch.countDown();
+            Thread.sleep(durationMs);
+            running.set(false);
+        } finally {
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+        }
+
+        assertFalse(corruption.get());
+        assertTrue(evictions.get() > 0);
+        assertTrue(safeReadsAfterEviction.get() > 0);
+    }
+
+    // ========================================================================
+    // P3: Clear safety — concurrent clear vs readers/writers (Property 10)
+    // ========================================================================
+
+    public void testP3ClearSafetyConcurrentClearVsReadersWriters() throws Exception {
+        final int numBlocks = 128;
+        final long durationMs = 3000;
+        final int writerCount = 50;
+        final int readerCount = 100;
+        final int totalWorkers = 1 + writerCount + readerCount;
+
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(numBlocks / RadixBlockTable.PAGE_SIZE + 1);
+        ByteBuffer[] sentinels = preallocateSentinels(numBlocks);
+        AtomicBoolean exceptionThrown = new AtomicBoolean(false);
+        AtomicInteger clearCount = new AtomicInteger(0);
+        CountDownLatch readyLatch = new CountDownLatch(totalWorkers);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        AtomicBoolean running = new AtomicBoolean(true);
+
+        ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+        try {
+            // Clear thread
+            executor.submit(() -> {
+                readyLatch.countDown();
+                try {
+                    startLatch.await();
+                } catch (Exception e) {
+                    exceptionThrown.set(true);
+                    return;
+                }
+                while (running.get()) {
+                    try {
+                        table.clear();
+                        clearCount.incrementAndGet();
+                        Thread.yield();
+                    } catch (Exception e) {
+                        exceptionThrown.set(true);
+                        running.set(false);
+                    }
+                }
+            });
+
+            // Writers
+            for (int w = 0; w < writerCount; w++) {
+                executor.submit(() -> {
+                    readyLatch.countDown();
+                    try {
+                        startLatch.await();
+                    } catch (Exception e) {
+                        exceptionThrown.set(true);
+                        return;
+                    }
+                    int iter = 0;
+                    while (running.get()) {
+                        try {
+                            int blockId = iter % numBlocks;
+                            table.put(blockId, sentinels[blockId]);
+                            iter++;
+                            if ((iter & 0xFF) == 0)
+                                Thread.yield();
+                        } catch (Exception e) {
+                            exceptionThrown.set(true);
+                            running.set(false);
+                        }
+                    }
+                });
+            }
+
+            // Readers
+            for (int r = 0; r < readerCount; r++) {
+                executor.submit(() -> {
+                    readyLatch.countDown();
+                    try {
+                        startLatch.await();
+                    } catch (Exception e) {
+                        exceptionThrown.set(true);
+                        return;
+                    }
+                    int iter = 0;
+                    while (running.get()) {
+                        try {
+                            long blockId = iter % numBlocks;
+                            ByteBuffer buf = table.get(blockId);
+                            if (buf != null) {
+                                long sentinel = buf.getLong(0);
+                                if (sentinel != blockId) {
+                                    exceptionThrown.set(true);
+                                    running.set(false);
+                                }
+                            }
+                            iter++;
+                        } catch (Exception e) {
+                            exceptionThrown.set(true);
+                            running.set(false);
+                        }
+                    }
+                });
+            }
+
+            assertTrue(readyLatch.await(10, TimeUnit.SECONDS));
+            startLatch.countDown();
+            Thread.sleep(durationMs);
+            running.set(false);
+        } finally {
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+        }
+
+        assertFalse(exceptionThrown.get());
+        assertTrue(clearCount.get() > 0);
+
+        table.clear();
+        for (int i = 0; i < numBlocks; i++) {
+            assertNull(table.get(i));
+        }
+    }
+
+    // ========================================================================
+    // P4: Stale reads are benign — high-contention put/remove/get
+    // ========================================================================
+
+    public void testP4StaleReadsAreBenignHighContention() throws Exception {
+        final int numBlocks = 64;
+        final int totalThreads = 200;
+        final long durationMs = 3000;
+
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+        ByteBuffer[] sentinels = preallocateSentinels(numBlocks);
+        AtomicBoolean corruption = new AtomicBoolean(false);
+        AtomicLong ops = new AtomicLong(0);
+        CountDownLatch readyLatch = new CountDownLatch(totalThreads);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        AtomicBoolean running = new AtomicBoolean(true);
+
+        for (int i = 0; i < numBlocks; i++) {
+            table.put(i, sentinels[i]);
+        }
+
+        ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+        try {
+            for (int t = 0; t < totalThreads; t++) {
+                final int threadId = t;
+                executor.submit(() -> {
+                    readyLatch.countDown();
+                    try {
+                        startLatch.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                    int iter = 0;
+                    while (running.get()) {
+                        int blockId = iter % numBlocks;
+                        int op = (threadId + iter) % 3;
+                        if (op == 0) {
+                            table.put(blockId, sentinels[blockId]);
+                        } else if (op == 1) {
+                            table.remove(blockId);
+                        } else {
+                            ByteBuffer buf = table.get(blockId);
+                            if (buf != null) {
+                                long sentinel = buf.getLong(0);
+                                if (sentinel != blockId) {
+                                    corruption.set(true);
+                                    running.set(false);
+                                }
+                            }
+                        }
+                        ops.incrementAndGet();
+                        iter++;
+                    }
+                });
+            }
+
+            assertTrue(readyLatch.await(10, TimeUnit.SECONDS));
+            startLatch.countDown();
+            Thread.sleep(durationMs);
+            running.set(false);
+        } finally {
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+        }
+
+        assertFalse(corruption.get());
+        assertTrue(ops.get() > 10_000);
+    }
+
+    // ========================================================================
+    // P5: Concurrent inner array allocation — no lost writes (Property 11)
+    // ========================================================================
+
+    public void testP5ConcurrentInnerArrayAllocationNoLostWrites() throws Exception {
+        final int threads = 100;
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+        CountDownLatch readyLatch = new CountDownLatch(threads);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threads);
+
+        ByteBuffer[] expected = new ByteBuffer[RadixBlockTable.PAGE_SIZE];
+
+        ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+        try {
+            for (int t = 0; t < threads; t++) {
+                final int slot = t % RadixBlockTable.PAGE_SIZE;
+                final ByteBuffer buf = createSentinel(slot);
+                executor.submit(() -> {
+                    readyLatch.countDown();
+                    try {
+                        startLatch.await();
+                        table.put(slot, buf);
+                        synchronized (expected) {
+                            expected[slot] = buf;
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        doneLatch.countDown();
+                    }
+                });
+            }
+
+            assertTrue(readyLatch.await(10, TimeUnit.SECONDS));
+            startLatch.countDown();
+            assertTrue(doneLatch.await(10, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdown();
+        }
+
+        assertTrue(table.isInnerAllocated(0));
+
+        for (int i = 0; i < RadixBlockTable.PAGE_SIZE; i++) {
+            ByteBuffer buf = table.get(i);
+            if (expected[i] != null) {
+                assertNotNull(buf);
+            }
+        }
+    }
+
+    // ========================================================================
+    // P6: Concurrent directory growth — no lost inner arrays (Property 11)
+    // ========================================================================
+
+    public void testP6DirectoryGrowthNoLostInnerArrays() throws Exception {
+        final int threads = 100;
+        final int blocksPerThread = 64;
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+        CountDownLatch readyLatch = new CountDownLatch(threads);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threads);
+        AtomicBoolean exceptionThrown = new AtomicBoolean(false);
+
+        ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+        try {
+            for (int t = 0; t < threads; t++) {
+                final int threadId = t;
+                executor.submit(() -> {
+                    readyLatch.countDown();
+                    try {
+                        startLatch.await();
+                        for (int i = 0; i < blocksPerThread; i++) {
+                            long blockId = (long) threadId * blocksPerThread + i;
+                            table.put(blockId, createSentinel(blockId));
+                        }
+                    } catch (Exception e) {
+                        exceptionThrown.set(true);
+                    } finally {
+                        doneLatch.countDown();
+                    }
+                });
+            }
+
+            assertTrue(readyLatch.await(10, TimeUnit.SECONDS));
+            startLatch.countDown();
+            assertTrue(doneLatch.await(30, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdown();
+        }
+
+        assertFalse(exceptionThrown.get());
+
+        int verified = 0;
+        for (int t = 0; t < threads; t++) {
+            for (int i = 0; i < blocksPerThread; i++) {
+                long blockId = (long) t * blocksPerThread + i;
+                ByteBuffer buf = table.get(blockId);
+                if (buf != null) {
+                    assertEquals(blockId, buf.getLong(0));
+                    verified++;
+                }
+            }
+        }
+        assertTrue(verified > 0);
+    }
+
+    // ========================================================================
+    // Sustained stress test — 32+ threads, 10+ seconds
+    // ========================================================================
+
+    public void testSustainedStressTest32Threads10Seconds() throws Exception {
+        final int numBlocks = 512;
+        final int totalThreads = 32;
+        final long durationMs = 10_000;
+
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(numBlocks / RadixBlockTable.PAGE_SIZE + 1);
+        ByteBuffer[] sentinels = preallocateSentinels(numBlocks);
+        AtomicBoolean corruption = new AtomicBoolean(false);
+        AtomicBoolean exceptionThrown = new AtomicBoolean(false);
+        AtomicLong totalOps = new AtomicLong(0);
+        CountDownLatch readyLatch = new CountDownLatch(totalThreads);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        AtomicBoolean running = new AtomicBoolean(true);
+
+        for (int i = 0; i < numBlocks; i++) {
+            table.put(i, sentinels[i]);
+        }
+
+        ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+        try {
+            for (int t = 0; t < totalThreads; t++) {
+                final int threadId = t;
+                executor.submit(() -> {
+                    readyLatch.countDown();
+                    try {
+                        startLatch.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                    long localOps = 0;
+                    int iter = 0;
+                    while (running.get()) {
+                        try {
+                            int blockId = iter % numBlocks;
+                            int op = (threadId + iter) % 4;
+                            if (op == 0) {
+                                table.put(blockId, sentinels[blockId]);
+                            } else if (op == 1) {
+                                table.remove(blockId);
+                            } else if (op == 2) {
+                                ByteBuffer buf = table.get(blockId);
+                                if (buf != null) {
+                                    long sentinel = buf.getLong(0);
+                                    if (sentinel != blockId) {
+                                        corruption.set(true);
+                                        running.set(false);
+                                    }
+                                }
+                            } else {
+                                table.put(blockId, sentinels[blockId]);
+                                ByteBuffer buf = table.get(blockId);
+                                if (buf != null && buf.getLong(0) != blockId) {
+                                    corruption.set(true);
+                                    running.set(false);
+                                }
+                            }
+                            localOps++;
+                            iter++;
+                        } catch (Exception e) {
+                            exceptionThrown.set(true);
+                            running.set(false);
+                        }
+                    }
+                    totalOps.addAndGet(localOps);
+                });
+            }
+
+            assertTrue(readyLatch.await(10, TimeUnit.SECONDS));
+            startLatch.countDown();
+            Thread.sleep(durationMs);
+            running.set(false);
+        } finally {
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(15, TimeUnit.SECONDS));
+        }
+
+        assertFalse(corruption.get());
+        assertFalse(exceptionThrown.get());
+        assertTrue(totalOps.get() > 100_000);
+    }
+}

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/RadixBlockTablePropertyTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/RadixBlockTablePropertyTests.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.bufferpoolfs;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Property-based tests for {@link RadixBlockTable}.
+ * Uses randomized iteration (100 tries per property) via OpenSearchTestCase
+ * random utilities instead of jqwik.
+ *
+ * Feature: radix-block-table-pr
+ */
+public class RadixBlockTablePropertyTests extends OpenSearchTestCase {
+
+    private static final int PAGE_SIZE = RadixBlockTable.PAGE_SIZE;
+
+    /** Property 1: Put/get round-trip. */
+    public void testPutGetRoundTrip() {
+        for (int trial = 0; trial < 100; trial++) {
+            int blockId = randomIntBetween(0, 2_621_439);
+            RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+            ByteBuffer buf = ByteBuffer.allocate(8);
+            buf.putInt(0, blockId);
+
+            assertNull(table.get(blockId));
+            table.put(blockId, buf);
+            assertSame(buf, table.get(blockId));
+        }
+    }
+
+    /** Property 2: Remove returns previous and nulls slot. */
+    public void testRemoveReturnsPreviousAndNullsSlot() {
+        for (int trial = 0; trial < 100; trial++) {
+            int blockId = randomIntBetween(0, 2_621_439);
+            RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+            ByteBuffer buf = ByteBuffer.allocate(8);
+            buf.putInt(0, blockId);
+
+            table.put(blockId, buf);
+            ByteBuffer removed = table.remove(blockId);
+            assertSame(buf, removed);
+            assertNull(table.get(blockId));
+        }
+    }
+
+    /** Property 3: Clear resets all state. */
+    public void testClearResetsAllState() {
+        for (int trial = 0; trial < 100; trial++) {
+            int count = randomIntBetween(1, 50);
+            RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+            long[] blockIds = new long[count];
+
+            for (int i = 0; i < count; i++) {
+                blockIds[i] = (long) i * PAGE_SIZE + (i % PAGE_SIZE);
+                table.put(blockIds[i], ByteBuffer.allocate(8));
+            }
+
+            table.clear();
+
+            for (long id : blockIds) {
+                assertNull(table.get(id));
+            }
+        }
+    }
+
+    /** Property 4: Last writer wins (put overwrites). */
+    public void testLastWriterWins() {
+        for (int trial = 0; trial < 100; trial++) {
+            int blockId = randomIntBetween(0, 2_621_439);
+            RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+            ByteBuffer a = ByteBuffer.allocate(8);
+            ByteBuffer b = ByteBuffer.allocate(16);
+
+            table.put(blockId, a);
+            assertSame(a, table.get(blockId));
+
+            table.put(blockId, b);
+            assertSame(b, table.get(blockId));
+        }
+    }
+
+    /** Property 5: Directory growth preserves entries. */
+    public void testDirectoryGrowthPreservesEntries() {
+        for (int trial = 0; trial < 100; trial++) {
+            int numGrowths = randomIntBetween(2, 20);
+            RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+            Map<Long, ByteBuffer> entries = new HashMap<>();
+
+            int prevDirLen = table.directoryLength();
+            for (int i = 0; i < numGrowths; i++) {
+                int outerIndex = prevDirLen + i;
+                long blockId = (long) outerIndex * PAGE_SIZE;
+                ByteBuffer buf = ByteBuffer.allocate(8);
+                buf.putInt(0, i);
+                table.put(blockId, buf);
+                entries.put(blockId, buf);
+
+                int newDirLen = table.directoryLength();
+                assertTrue(newDirLen >= outerIndex + 1);
+                prevDirLen = newDirLen;
+            }
+
+            for (Map.Entry<Long, ByteBuffer> entry : entries.entrySet()) {
+                assertSame(entry.getValue(), table.get(entry.getKey()));
+            }
+        }
+    }
+
+    /** Property 6: Inner allocation accuracy. */
+    public void testInnerAllocationAccuracy() {
+        for (int trial = 0; trial < 100; trial++) {
+            int numPuts = randomIntBetween(1, 80);
+            RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+            Set<Integer> allocatedOuters = new HashSet<>();
+
+            for (int i = 0; i < numPuts; i++) {
+                int outerIndex = i % 80;
+                long blockId = (long) outerIndex * PAGE_SIZE;
+                table.put(blockId, ByteBuffer.allocate(8));
+                allocatedOuters.add(outerIndex);
+            }
+
+            for (int outerIndex : allocatedOuters) {
+                assertTrue(table.isInnerAllocated(outerIndex));
+            }
+
+            assertEquals(allocatedOuters.size(), table.allocatedInnerCount());
+        }
+    }
+
+    /** Property 7: countEntries reflects actual state. */
+    public void testCountEntriesReflectsActualState() {
+        for (int trial = 0; trial < 100; trial++) {
+            int outerIndex = randomIntBetween(0, 10);
+            int numOps = randomIntBetween(1, 100);
+            RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+
+            assertEquals(-1, table.countEntries(outerIndex));
+
+            Set<Integer> occupiedSlots = new HashSet<>();
+
+            for (int i = 0; i < numOps; i++) {
+                int slot = i % PAGE_SIZE;
+                long blockId = (long) outerIndex * PAGE_SIZE + slot;
+
+                if (occupiedSlots.contains(slot)) {
+                    table.remove(blockId);
+                    occupiedSlots.remove(slot);
+                } else {
+                    table.put(blockId, ByteBuffer.allocate(8));
+                    occupiedSlots.add(slot);
+                }
+            }
+
+            int expected = occupiedSlots.size();
+            int actual = table.countEntries(outerIndex);
+
+            if (expected == 0) {
+                // Inner array reclaimed when all slots removed
+                assertEquals(-1, actual);
+            } else {
+                assertEquals(expected, actual);
+            }
+        }
+    }
+
+    /** Property 12: Multi-table isolation. */
+    public void testMultiTableIsolation() {
+        for (int trial = 0; trial < 100; trial++) {
+            int blockId = randomIntBetween(0, 2_621_439);
+            RadixBlockTable<ByteBuffer> table1 = new RadixBlockTable<>(1);
+            RadixBlockTable<ByteBuffer> table2 = new RadixBlockTable<>(1);
+
+            ByteBuffer buf1 = ByteBuffer.allocate(8);
+            buf1.putInt(0, 1);
+
+            table1.put(blockId, buf1);
+
+            assertNull(table2.get(blockId));
+            assertSame(buf1, table1.get(blockId));
+
+            ByteBuffer buf2 = ByteBuffer.allocate(16);
+            buf2.putInt(0, 2);
+            table2.put(blockId, buf2);
+
+            assertSame(buf1, table1.get(blockId));
+            assertSame(buf2, table2.get(blockId));
+        }
+    }
+}

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/RadixBlockTableTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/RadixBlockTableTests.java
@@ -1,0 +1,505 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.bufferpoolfs;
+
+import java.nio.ByteBuffer;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class RadixBlockTableTests extends OpenSearchTestCase {
+
+    private static final int PS = RadixBlockTable.PAGE_SIZE; // 1024
+
+    private static ByteBuffer buf(int capacity) {
+        return ByteBuffer.allocate(capacity);
+    }
+
+    // ---- basic put/get/remove ----
+
+    public void testPutGetRoundTrip() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        ByteBuffer b = buf(8);
+        table.put(10, b);
+        assertSame(b, table.get(10));
+    }
+
+    public void testRemoveReturnsPreviousAndNullsSlot() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        ByteBuffer b = buf(8);
+        table.put(10, b);
+        assertSame(b, table.remove(10));
+        assertNull(table.get(10));
+    }
+
+    public void testClearResetsAllState() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        table.put(0, buf(8));
+        table.put(PS, buf(8));
+        table.put(2 * PS, buf(8));
+        table.clear();
+        assertNull(table.get(0));
+        assertNull(table.get(PS));
+        assertNull(table.get(2 * PS));
+    }
+
+    public void testPutOverwritesExistingEntry() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        ByteBuffer a = buf(8);
+        ByteBuffer b = buf(16);
+        table.put(5, a);
+        assertSame(a, table.get(5));
+        table.put(5, b);
+        assertSame(b, table.get(5));
+    }
+
+    // ---- get edge cases ----
+
+    public void testGetOuterOobReturnsNull() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+        assertNull(table.get(PS));
+    }
+
+    public void testGetInnerNullReturnsNull() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        assertNull(table.get(0));
+    }
+
+    public void testGetSlotNullReturnsNull() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        table.put(0, buf(8));
+        assertNull(table.get(1));
+    }
+
+    public void testGetSlotPopulatedReturnsBuffer() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        ByteBuffer b = buf(8);
+        table.put(5, b);
+        assertSame(b, table.get(5));
+    }
+
+    // ---- put paths ----
+
+    public void testPutFastPathInnerExists() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        table.put(0, buf(8));
+        ByteBuffer b = buf(16);
+        table.put(1, b);
+        assertSame(b, table.get(1));
+    }
+
+    public void testPutSlowInnerNull() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        assertFalse(table.isInnerAllocated(0));
+        ByteBuffer b = buf(8);
+        table.put(0, b);
+        assertTrue(table.isInnerAllocated(0));
+        assertSame(b, table.get(0));
+    }
+
+    public void testPutSlowDirectoryGrowth() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+        assertEquals(1, table.directoryLength());
+        ByteBuffer b = buf(8);
+        table.put(PS, b);
+        assertTrue(table.directoryLength() > 1);
+        assertSame(b, table.get(PS));
+    }
+
+    public void testPutSlowRaceInnerAlreadyAllocated() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        ByteBuffer a = buf(8);
+        table.put(0, a);
+        assertTrue(table.isInnerAllocated(0));
+        ByteBuffer b = buf(16);
+        table.put(1, b);
+        assertSame(a, table.get(0));
+        assertSame(b, table.get(1));
+        assertEquals(2, table.countEntries(0));
+    }
+
+    // ---- remove edge cases ----
+
+    public void testRemoveOuterOobReturnsNull() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+        assertNull(table.remove(PS));
+    }
+
+    public void testRemoveInnerNullReturnsNull() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        assertNull(table.remove(0));
+    }
+
+    public void testRemoveSlotNullReturnsNull() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        table.put(0, buf(8));
+        assertNull(table.remove(1));
+    }
+
+    public void testRemoveSlotPopulatedReturnsPrevious() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        ByteBuffer b = buf(8);
+        table.put(5, b);
+        assertSame(b, table.remove(5));
+        assertNull(table.get(5));
+    }
+
+    // ---- clear ----
+
+    public void testClearPopulatedTable() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        table.put(0, buf(8));
+        table.put(PS, buf(8));
+        table.put(2 * PS, buf(8));
+        table.clear();
+        assertNull(table.get(0));
+        assertNull(table.get(PS));
+        assertNull(table.get(2 * PS));
+        assertFalse(table.isInnerAllocated(0));
+        assertFalse(table.isInnerAllocated(1));
+        assertFalse(table.isInnerAllocated(2));
+    }
+
+    public void testClearEmptyTable() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        table.clear(); // should not throw
+    }
+
+    // ---- directory growth ----
+
+    public void testGrowDirectorySizingInvariants() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(2);
+        assertEquals(2, table.directoryLength());
+        ByteBuffer existing = buf(8);
+        table.put(0, existing);
+        table.put(5 * PS, buf(8));
+        int newLen = table.directoryLength();
+        assertTrue(newLen >= 6);
+        assertSame(existing, table.get(0));
+    }
+
+    public void testInitialOuterSlots1WithMultipleGrowths() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+        assertEquals(1, table.directoryLength());
+        ByteBuffer b1 = buf(8);
+        table.put(PS, b1);
+        assertTrue(table.directoryLength() >= 2);
+        ByteBuffer b2 = buf(8);
+        table.put(4 * PS, b2);
+        assertTrue(table.directoryLength() >= 5);
+        ByteBuffer b3 = buf(8);
+        table.put(20 * PS, b3);
+        assertTrue(table.directoryLength() >= 21);
+        assertSame(b1, table.get(PS));
+        assertSame(b2, table.get(4 * PS));
+        assertSame(b3, table.get(20 * PS));
+    }
+
+    public void testGrowDirectoryDoublesOrFitsRequired() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+        assertEquals(1, table.directoryLength());
+        table.put(3 * PS, buf(8));
+        int len1 = table.directoryLength();
+        assertTrue(len1 >= 4);
+        table.put(100 * PS, buf(8));
+        int len2 = table.directoryLength();
+        assertTrue(len2 >= 101);
+        assertNotNull(table.get(3 * PS));
+        assertNotNull(table.get(100 * PS));
+    }
+
+    public void testGrowDirectoryPreservesAllEntries() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+        ByteBuffer[] bufs = new ByteBuffer[50];
+        for (int i = 0; i < 50; i++) {
+            bufs[i] = buf(8);
+            table.put((long) i * PS, bufs[i]);
+        }
+        assertTrue(table.directoryLength() >= 50);
+        for (int i = 0; i < 50; i++) {
+            assertSame(bufs[i], table.get((long) i * PS));
+        }
+    }
+
+    // ---- edge cases ----
+
+    public void testEdgeCaseBlockId0() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        ByteBuffer b = buf(8);
+        table.put(0, b);
+        assertSame(b, table.get(0));
+        assertSame(b, table.remove(0));
+        assertNull(table.get(0));
+    }
+
+    public void testEdgeCaseLastSlotInInnerArray() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        ByteBuffer b = buf(8);
+        table.put(PS - 1, b);
+        assertSame(b, table.get(PS - 1));
+        assertEquals(1, table.countEntries(0));
+    }
+
+    public void testEdgeCaseFirstSlotInSecondInnerArray() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        ByteBuffer b = buf(8);
+        table.put(PS, b);
+        assertSame(b, table.get(PS));
+        assertTrue(table.isInnerAllocated(1));
+        assertFalse(table.isInnerAllocated(0));
+    }
+
+    public void testEdgeCaseMaxBlockId() {
+        long maxBlockId = 2_621_439L;
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+        ByteBuffer b = buf(8);
+        table.put(maxBlockId, b);
+        assertSame(b, table.get(maxBlockId));
+        assertSame(b, table.remove(maxBlockId));
+        assertNull(table.get(maxBlockId));
+    }
+
+    public void testFullInnerArrayPopulateThenRemoveAll() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        ByteBuffer[] buffers = new ByteBuffer[PS];
+        for (int i = 0; i < PS; i++) {
+            buffers[i] = buf(8);
+            table.put(i, buffers[i]);
+        }
+        assertEquals(PS, table.countEntries(0));
+        for (int i = 0; i < PS; i++) {
+            assertSame(buffers[i], table.remove(i));
+        }
+        assertFalse(table.isInnerAllocated(0));
+    }
+
+    // ---- helper method tests ----
+
+    public void testIsInnerAllocatedCorrectness() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        assertFalse(table.isInnerAllocated(0));
+        assertFalse(table.isInnerAllocated(1));
+        table.put(0, buf(8));
+        assertTrue(table.isInnerAllocated(0));
+        assertFalse(table.isInnerAllocated(1));
+        table.put(PS, buf(8));
+        assertTrue(table.isInnerAllocated(0));
+        assertTrue(table.isInnerAllocated(1));
+        assertFalse(table.isInnerAllocated(100));
+    }
+
+    public void testCountEntriesCorrectness() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        assertEquals(-1, table.countEntries(0));
+        table.put(0, buf(8));
+        assertEquals(1, table.countEntries(0));
+        table.put(1, buf(8));
+        assertEquals(2, table.countEntries(0));
+        table.remove(0);
+        assertEquals(1, table.countEntries(0));
+        table.remove(1);
+        assertEquals(-1, table.countEntries(0));
+        assertEquals(-1, table.countEntries(100));
+    }
+
+    public void testDirectoryLengthCorrectness() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        assertEquals(4, table.directoryLength());
+        table.put(10 * PS, buf(8));
+        assertTrue(table.directoryLength() >= 11);
+        int lenBeforeClear = table.directoryLength();
+        table.clear();
+        assertEquals(lenBeforeClear, table.directoryLength());
+    }
+
+    public void testAllocatedInnerCount() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        assertEquals(0, table.allocatedInnerCount());
+        table.put(0, buf(8));
+        assertEquals(1, table.allocatedInnerCount());
+        table.put(PS, buf(8));
+        assertEquals(2, table.allocatedInnerCount());
+        table.put(2 * PS, buf(8));
+        assertEquals(3, table.allocatedInnerCount());
+        table.put(1, buf(8));
+        assertEquals(3, table.allocatedInnerCount());
+    }
+
+    // ---- inner array reclamation tests ----
+
+    public void testRemoveLastSlotReclaimsInnerArray() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        table.put(0, buf(8));
+        assertTrue(table.isInnerAllocated(0));
+        assertEquals(1, table.allocatedInnerCount());
+        table.remove(0);
+        assertFalse(table.isInnerAllocated(0));
+        assertEquals(0, table.allocatedInnerCount());
+    }
+
+    public void testRemoveNonLastSlotDoesNotReclaimInnerArray() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        table.put(0, buf(8));
+        table.put(1, buf(8));
+        assertEquals(2, table.countEntries(0));
+        table.remove(0);
+        assertTrue(table.isInnerAllocated(0));
+        assertEquals(1, table.countEntries(0));
+    }
+
+    public void testRemoveAlreadyNullSlotDoesNotReclaim() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        table.put(0, buf(8));
+        table.put(1, buf(8));
+        assertNull(table.remove(2));
+        assertTrue(table.isInnerAllocated(0));
+        assertEquals(2, table.countEntries(0));
+    }
+
+    public void testReclaimMultipleInnerArraysIndependently() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        table.put(0, buf(8));
+        table.put(PS, buf(8));
+        table.put(2 * PS, buf(8));
+        assertEquals(3, table.allocatedInnerCount());
+        table.remove(PS);
+        assertEquals(2, table.allocatedInnerCount());
+        assertFalse(table.isInnerAllocated(1));
+        assertTrue(table.isInnerAllocated(0));
+        assertTrue(table.isInnerAllocated(2));
+        table.remove(0);
+        assertEquals(1, table.allocatedInnerCount());
+        assertFalse(table.isInnerAllocated(0));
+    }
+
+    public void testReclaimThenReAllocateInnerArray() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        ByteBuffer a = buf(8);
+        table.put(0, a);
+        assertTrue(table.isInnerAllocated(0));
+        table.remove(0);
+        assertFalse(table.isInnerAllocated(0));
+        ByteBuffer b = buf(16);
+        table.put(0, b);
+        assertTrue(table.isInnerAllocated(0));
+        assertSame(b, table.get(0));
+    }
+
+    public void testReclaimAllSlotsInFullInnerArray() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        for (int i = 0; i < PS; i++) {
+            table.put(i, buf(8));
+        }
+        assertEquals(PS, table.countEntries(0));
+        assertTrue(table.isInnerAllocated(0));
+        for (int i = 0; i < PS - 1; i++) {
+            table.remove(i);
+        }
+        assertTrue(table.isInnerAllocated(0));
+        assertEquals(1, table.countEntries(0));
+        table.remove(PS - 1);
+        assertFalse(table.isInnerAllocated(0));
+        assertEquals(-1, table.countEntries(0));
+    }
+
+    public void testClearAfterPartialReclamation() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(4);
+        table.put(0, buf(8));
+        table.put(PS, buf(8));
+        table.put(2 * PS, buf(8));
+        table.remove(PS);
+        assertFalse(table.isInnerAllocated(1));
+        table.clear();
+        assertFalse(table.isInnerAllocated(0));
+        assertFalse(table.isInnerAllocated(1));
+        assertFalse(table.isInnerAllocated(2));
+        assertEquals(0, table.allocatedInnerCount());
+    }
+
+    // ---- memory overhead measurement tests ----
+
+    public void testMemoryOverheadUntouchedTable() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+        assertEquals(1, table.directoryLength());
+        assertEquals(0, table.allocatedInnerCount());
+    }
+
+    public void testMemoryOverheadProportionalToUsage() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+        for (int i = 0; i < 1000; i++) {
+            table.put(i, buf(8));
+        }
+        int innerCount = table.allocatedInnerCount();
+        // ceil(1000/1024) = 1 inner array
+        assertEquals(1, innerCount);
+        long overheadBytes = (long) innerCount * PS * 8; // inner array ref slots (8 bytes per ref)
+        long dataBytes = 1000L * 8; // actual entry references
+        double overheadRatio = (double) overheadBytes / dataBytes;
+        assertTrue("Overhead ratio " + overheadRatio + " exceeds 5%", overheadRatio < 1.10);
+    }
+
+    public void testMemoryOverheadAfterFullEviction() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+        for (int i = 0; i < 1000; i++) {
+            table.put(i, buf(8));
+        }
+        assertEquals(1, table.allocatedInnerCount());
+        for (int i = 0; i < 1000; i++) {
+            table.remove(i);
+        }
+        assertEquals(0, table.allocatedInnerCount());
+    }
+
+    public void testMemoryOverheadSparseAccess() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+        int sparseCount = 100;
+        for (int i = 0; i < sparseCount; i++) {
+            table.put((long) i * PS, buf(8));
+        }
+        assertEquals(sparseCount, table.allocatedInnerCount());
+        long overheadBytes = (long) sparseCount * PS * 8;
+        long dataBytes = (long) sparseCount * 8;
+        double overheadRatio = (double) overheadBytes / dataBytes;
+        assertTrue("Sparse overhead ratio " + overheadRatio + " is unreasonable", overheadRatio <= (double) PS);
+    }
+
+    public void testMemoryOverheadSparseEvictionReclaims() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+        int sparseCount = 100;
+        for (int i = 0; i < sparseCount; i++) {
+            table.put((long) i * PS, buf(8));
+        }
+        assertEquals(sparseCount, table.allocatedInnerCount());
+        for (int i = 0; i < sparseCount; i++) {
+            table.remove((long) i * PS);
+        }
+        assertEquals(0, table.allocatedInnerCount());
+    }
+
+    public void testDirectoryGrowthPattern() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>(1);
+        assertEquals(1, table.directoryLength());
+        int prevLen = table.directoryLength();
+        for (int outer = 0; outer < 200; outer++) {
+            table.put((long) outer * PS, buf(8));
+            int curLen = table.directoryLength();
+            if (curLen != prevLen) {
+                assertTrue(
+                    "Directory grew from " + prevLen + " to " + curLen + " which is less than required " + (outer + 1),
+                    curLen >= outer + 1
+                );
+                prevLen = curLen;
+            }
+        }
+        assertTrue(table.directoryLength() >= 200);
+    }
+
+    // ---- default constructor test ----
+
+    public void testDefaultConstructorUsesDefaultOuterSlots() {
+        RadixBlockTable<ByteBuffer> table = new RadixBlockTable<>();
+        assertEquals(RadixBlockTable.DEFAULT_OUTER_SLOTS, table.directoryLength());
+        assertEquals(0, table.allocatedInnerCount());
+    }
+}


### PR DESCRIPTION
### Description

This change focuses on improving hot path performance in the bufferpool implementation. We plan to address a few areas incrementally and evaluate their impact carefully. The current set of explorations includes (not all changes are part of this PR):

1. **Direct ByteBuffer-based blocks**  
   We are exploring the use of direct `ByteBuffer` instances for block storage. In this approach, we do not maintain explicit reference counting and instead rely on the garbage collector to reclaim native memory once buffers become unreachable.  
   We are not planning to reuse direct buffers at this stage. As part of this exploration, we are also evaluating whether allocating buffers via jemalloc can help reduce fragmentation.  
   A memory pool will still be used to bound total allocation. Additionally, we are experimenting with a Cleaner-based mechanism to replenish buffers as existing ones are reclaimed. This part is currently experimental and will be evaluated further.

2. **Simplifying IndexInput hot paths**  
   We have observed that some `IndexInput` read paths are not consistently reaching higher-tier JIT optimizations (e.g., Tier 4). We are investigating opportunities to simplify these paths to make them more JIT-friendly.  
   Initial areas of focus include reducing instruction footprint in the hot path, minimizing branching, and improving overall predictability for the compiler.

3. **Exploring improvements to L1 cache capacity**  
   The current L1 cache uses a fixed-size structure (32 slots), which works well for smaller working sets. For larger files, collision rates may increase, leading to more frequent lookups in the L2 cache.  
   We are exploring alternative structures (such as a RadixBlockTable-style approach) to evaluate whether we can achieve similar or improved performance while keeping the memory overhead of the L1 cache within ~1–5% of the resident data it references.  
   We are also considering whether selectively bypassing L1 during writes could simplify behavior without impacting read performance.

All of the above changes are being evaluated incrementally, with a focus on maintaining correctness, predictable performance, and bounded memory usage. All reads are going to be lock less in the hot path with above approach. 

We have conducted initial POC experiments for some of these ideas in a separate branch:  
https://github.com/abiesps/opensearch-storage-encryption/tree/hot-path-perf-poc  

These experiments indicate that the hot path performance becomes comparable (within ~0.80–1.0x of mmap depending on workload)

Results:  https://github.com/opensearch-project/opensearch-storage-encryption/pull/154#issuecomment-4070742070

---

## RadixBlockTable


### What it is

A two-level radix table that maps `blockId → V` (typically `ByteBuffer`) for a single file. It replaces the 32-slot direct-mapped `BlockSlotTinyCache` as the L1 cache sitting in front of the Caffeine L2 cache. The L1 cache provides a 'view' on CaffeineBlockCache. Lifecycle of elements into L1 cache is controlled by CaffeineBlockCache.

### Structure

```
blockId = 42753

outer index = blockId >>> 10  = 41    (which group of 1024)
inner slot  = blockId & 1023  = 769   (position within group)

directory[41][769] → ByteBuffer
```

The outer directory is an `Object[][]` defaulting to 256 entries (covers 8 GB per file with 32 KB cache blocks). Each inner array is a fixed `Object[1024]`, allocated lazily on first write to that range. Both levels grow on demand.


### Thread safety

- **Reads are plain loads** — JLS §17.7 guarantees reference read/write atomicity, so a reader sees either the old value or the new value, never a torn reference.
- **Stale reads are benign**: a stale `null` means an L1 miss → falls through to Caffeine L2 (source of truth). A stale non-null reference points to a valid (possibly evicted) ByteBuffer — harmless for a cache.
- **Writers** use plain stores for slot writes. Inner array allocation and reclamation use `synchronized(this)` only for the allocation/reclaim — not on the read path.
- No `volatile`, no `VarHandle`, no CAS anywhere in the read path.

### Memory overhead

- Outer directory: 256 × 8 bytes = **2 KB per file**
- Each inner array: 1024 × 8 bytes = **8 KB** (allocated only when blocks in that range are cached) 
- 16KB book keeping overhead in worst case for resident memory of 8MB (for cache block size 8kb) and 32MB( for cache block size of 32kb) per file. 
- Inner arrays are reclaimed (nulled) when all their slots become empty after eviction. 

### Correctness guarantees

1. **No torn references** (JLS §17.7)
2. **No use-after-free** (values owned by L2; L1 holds a reference; after eviction the slot is nulled; a reader that grabbed the reference before the null-write safely completes)
3. **No memory leak** (`clear()` nulls all inner arrays; `remove()` reclaims empty inner arrays)
4. **Stale reads are benign** (miss → L2 fallback; stale hit → valid data)

Verified by 7 JCStress tests (zero FORBIDDEN outcomes across millions of iterations), 7 concurrency tests, property-based tests, and integration tests.

---

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [Y ] New functionality includes testing.
- [ Y] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
