### PR TITLE
feat(block_loader): Add node-level FileChannelCache with RefCountedCh…

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -150,16 +150,41 @@ cd "${STORAGE_ENCRYPTION_DIR}"
 ./gradlew test
 ```
 
+This runs unit tests and then JCStress concurrency tests in `quick` mode (fast sanity check).
+
+### JCStress Concurrency Tests
+
+JCStress tests validate lock-free and concurrent data structures under real thread contention.
+The mode controls how many iterations and thread configurations are explored:
+
+| Command | Mode | Use case |
+|---------|------|----------|
+| `./gradlew test` | `quick` | Fast feedback during development (runs as finalizer after unit tests) |
+| `./gradlew jcstress` | `default` | Thorough testing before merging |
+| `./gradlew jcstress -Pjcstress.mode=stress` | `stress` | Maximum thoroughness for CI or pre-release validation |
+
+You can also skip jcstress entirely during development:
+
+```bash
+./gradlew test -x jcstress
+```
+
 ### Integration Tests
 
 ```bash
-./gradlew integrationTest
+./gradlew internalClusterTest
 ```
 
 ### YAML Rest Tests
 
 ```bash
 ./gradlew yamlRestTest
+```
+
+### All Tests
+
+```bash
+./gradlew allTests
 ```
 
 ## Debugging

--- a/build.gradle
+++ b/build.gradle
@@ -181,9 +181,15 @@ forbiddenApisJmh.enabled = false
 // We only need the jmh {} config block below to customize behavior.
 
 // ---- JCStress configuration ----
+// When triggered via ./gradlew test, jcstress runs in 'quick' mode (fast sanity check).
+// When run explicitly via ./gradlew jcstress, it uses 'default' mode (thorough).
+// Override with: ./gradlew jcstress -Pjcstress.mode=stress
+def isExplicitJcstress = gradle.startParameter.taskNames.any { it.toLowerCase().contains('jcstress') }
+def jcstressMode = project.findProperty('jcstress.mode') ?: (isExplicitJcstress ? 'default' : 'quick')
+
 jcstress {
     jcstressDependency 'org.openjdk.jcstress:jcstress-core:0.16'
-    mode = 'default'
+    mode = jcstressMode
     verbose = true
 }
 

--- a/src/internalClusterTest/java/org/opensearch/index/store/CacheInvalidationIntegTests.java
+++ b/src/internalClusterTest/java/org/opensearch/index/store/CacheInvalidationIntegTests.java
@@ -12,10 +12,12 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.action.admin.indices.forcemerge.ForceMergeResponse;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.store.block_cache.BlockCache;
 import org.opensearch.index.store.block_cache.CaffeineBlockCache;
+import org.opensearch.index.store.block_loader.FileChannelCache;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
@@ -117,9 +119,6 @@ public class CacheInvalidationIntegTests extends OpenSearchIntegTestCase {
         DeleteIndexRequest deleteRequest = new DeleteIndexRequest("test-cache-invalidation");
         client().admin().indices().delete(deleteRequest).actionGet();
 
-        // Allow some time for cache cleanup to complete
-        Thread.sleep(100);
-
         // Verify cache size decreased
         long cacheSizeAfter = 0;
         if (cache instanceof CaffeineBlockCache<?, ?> caffeineCache) {
@@ -185,8 +184,6 @@ public class CacheInvalidationIntegTests extends OpenSearchIntegTestCase {
         // Delete only the first index
         DeleteIndexRequest deleteRequest = new DeleteIndexRequest("test-index-1");
         client().admin().indices().delete(deleteRequest).actionGet();
-
-        Thread.sleep(100);
 
         // Verify index-2 still works perfectly
         SearchResponse response = client().prepareSearch("test-index-2").setSize(0).get();
@@ -270,8 +267,6 @@ public class CacheInvalidationIntegTests extends OpenSearchIntegTestCase {
             // Delete index
             DeleteIndexRequest deleteRequest = new DeleteIndexRequest(indexNames[idx]);
             client().admin().indices().delete(deleteRequest).actionGet();
-
-            Thread.sleep(100);
 
             // Verify cache size decreased
             long currentCacheSize = 0;
@@ -482,9 +477,6 @@ public class CacheInvalidationIntegTests extends OpenSearchIntegTestCase {
             client().admin().indices().delete(deleteRequest).actionGet();
         }
 
-        // Allow time for cache cleanup
-        Thread.sleep(200);
-
         // Verify cache is empty
         long cacheSizeAfter = 0;
         if (cache instanceof CaffeineBlockCache<?, ?> caffeineCache) {
@@ -576,5 +568,343 @@ public class CacheInvalidationIntegTests extends OpenSearchIntegTestCase {
         }
 
         logger.info("All {} indices reopened successfully with data intact and searchable", numIndices);
+    }
+
+    // ==================== FD Cache (FileChannelCache) Invalidation Tests ====================
+
+    /**
+     * Clears the shared block cache so that subsequent reads are cold and go through
+     * the block loader, which populates the FD cache via fileChannelCache.acquire().
+     *
+     * Without this, the block cache is warm from indexing writes, so reads are all
+     * block cache hits that never touch the FD cache.
+     */
+    @SuppressWarnings("unchecked")
+    private void clearBlockCache() {
+        BlockCache<?> cache = CryptoDirectoryFactory.getSharedBlockCache();
+        if (cache instanceof CaffeineBlockCache<?, ?> caffeineCache) {
+            caffeineCache.clear();
+            caffeineCache.getCache().cleanUp();
+        }
+    }
+
+    /**
+     * Tests that FD cache entries are invalidated when an encrypted index is deleted.
+     * After deletion, the FD cache should be empty (all entries for that index invalidated).
+     * This prevents FD leaks where stale FileChannels remain open to deleted files.
+     */
+    public void testFdCacheInvalidationOnIndexDelete() throws Exception {
+        internalCluster().startNode();
+
+        Settings settings = Settings
+            .builder()
+            .put(cryptoIndexSettings())
+            .put("index.number_of_shards", 2)
+            .put("index.number_of_replicas", 0)
+            .build();
+
+        createIndex("test-fd-cache-delete", settings);
+        ensureGreen("test-fd-cache-delete");
+
+        int numDocs = randomIntBetween(100, 200);
+        for (int i = 0; i < numDocs; i++) {
+            StringBuilder largeValue = new StringBuilder();
+            for (int j = 0; j < 100; j++) {
+                largeValue.append("data-").append(i).append("-").append(j).append(" ");
+            }
+            index("test-fd-cache-delete", "_doc", String.valueOf(i), "field", largeValue.toString(), "number", i);
+        }
+        refresh();
+        flush("test-fd-cache-delete");
+
+        // Clear block cache so reads go through block loader → FD cache
+        clearBlockCache();
+
+        // Reads now trigger block cache misses → CryptoDirectIOBlockLoader.load() → fileChannelCache.acquire()
+        for (int i = 0; i < Math.min(50, numDocs); i++) {
+            SearchResponse response = client()
+                .prepareSearch("test-fd-cache-delete")
+                .setQuery(org.opensearch.index.query.QueryBuilders.termQuery("number", i))
+                .get();
+            assertThat(response.getHits().getTotalHits().value(), equalTo(1L));
+        }
+
+        FileChannelCache fdCache = CryptoDirectoryFactory.getSharedFileChannelCache();
+        assertNotNull("Shared FD cache should be initialized", fdCache);
+
+        fdCache.cleanUp();
+        long fdCacheSizeBefore = fdCache.estimatedSize();
+        logger.info("FD cache size before index deletion: {}", fdCacheSizeBefore);
+        assertThat("FD cache should have entries after cold reads", fdCacheSizeBefore, greaterThan(0L));
+
+        // Delete the index — triggers BufferPoolDirectory.close() → fdCache.invalidateByPathPrefix()
+        client().admin().indices().delete(new DeleteIndexRequest("test-fd-cache-delete")).actionGet();
+
+        fdCache.cleanUp();
+        long fdCacheSizeAfter = fdCache.estimatedSize();
+        logger.info("FD cache size after index deletion: {} (was: {})", fdCacheSizeAfter, fdCacheSizeBefore);
+        assertThat("FD cache should be empty after index deletion", fdCacheSizeAfter, equalTo(0L));
+    }
+
+    /**
+     * Tests that deleting one index only invalidates FD cache entries for that index,
+     * preserving entries for other indices.
+     */
+    public void testFdCacheInvalidationPreservesOtherIndices() throws Exception {
+        internalCluster().startNode();
+
+        Settings settings = Settings
+            .builder()
+            .put(cryptoIndexSettings())
+            .put("index.number_of_shards", 1)
+            .put("index.number_of_replicas", 0)
+            .build();
+
+        createIndex("test-fd-idx-1", settings);
+        createIndex("test-fd-idx-2", settings);
+        ensureGreen("test-fd-idx-1", "test-fd-idx-2");
+
+        int numDocs = 50;
+        for (int i = 0; i < numDocs; i++) {
+            StringBuilder largeValue = new StringBuilder();
+            for (int j = 0; j < 50; j++) {
+                largeValue.append("data-").append(i).append("-").append(j).append(" ");
+            }
+            index("test-fd-idx-1", "_doc", String.valueOf(i), "field", largeValue.toString(), "number", i);
+            index("test-fd-idx-2", "_doc", String.valueOf(i), "field", largeValue.toString(), "number", i);
+        }
+        refresh();
+        flush("test-fd-idx-1", "test-fd-idx-2");
+
+        // Clear block cache so reads populate FD cache
+        clearBlockCache();
+
+        for (int i = 0; i < 20; i++) {
+            client().prepareSearch("test-fd-idx-1").setQuery(org.opensearch.index.query.QueryBuilders.termQuery("number", i)).get();
+            client().prepareSearch("test-fd-idx-2").setQuery(org.opensearch.index.query.QueryBuilders.termQuery("number", i)).get();
+        }
+
+        FileChannelCache fdCache = CryptoDirectoryFactory.getSharedFileChannelCache();
+        assertNotNull("Shared FD cache should be initialized", fdCache);
+
+        fdCache.cleanUp();
+        long fdCacheSizeBefore = fdCache.estimatedSize();
+        logger.info("FD cache size before deleting idx-1: {}", fdCacheSizeBefore);
+        assertThat("FD cache should have entries from both indices", fdCacheSizeBefore, greaterThan(0L));
+
+        // Delete only index-1
+        client().admin().indices().delete(new DeleteIndexRequest("test-fd-idx-1")).actionGet();
+
+        fdCache.cleanUp();
+        long fdCacheSizeAfter = fdCache.estimatedSize();
+        logger.info("FD cache size after deleting idx-1: {} (was: {})", fdCacheSizeAfter, fdCacheSizeBefore);
+
+        assertThat("FD cache should have fewer entries", fdCacheSizeAfter, lessThan(fdCacheSizeBefore));
+        assertThat("FD cache should still have entries from index-2", fdCacheSizeAfter, greaterThan(0L));
+
+        // Verify index-2 still works
+        SearchResponse response = client().prepareSearch("test-fd-idx-2").setSize(0).get();
+        assertThat("Index-2 should still have all documents", response.getHits().getTotalHits().value(), equalTo((long) numDocs));
+    }
+
+    /**
+     * Tests that force-merge (which deletes old segment files) invalidates FD cache entries
+     * for the deleted segments via BufferPoolDirectory.deleteFile() → fileChannelCache.invalidate().
+     *
+     * After force-merge, the FD cache may contain entries for the new merged segment (opened
+     * during merge reads or post-merge searches). The key invariant is:
+     * 1. Old segment FDs are invalidated (deleteFile calls invalidate())
+     * 2. Deleting the index after merge leaves the FD cache empty (no leaked FDs)
+     * 3. Data remains readable through the merged segment
+     */
+    public void testFdCacheInvalidationOnForceMerge() throws Exception {
+        internalCluster().startNode();
+
+        Settings settings = Settings
+            .builder()
+            .put(cryptoIndexSettings())
+            .put("index.number_of_shards", 1)
+            .put("index.number_of_replicas", 0)
+            .put("index.merge.policy.max_merged_segment", "100gb")
+            .build();
+
+        createIndex("test-fd-merge", settings);
+        ensureGreen("test-fd-merge");
+
+        // Index in multiple batches with flush → creates multiple segments
+        for (int batch = 0; batch < 5; batch++) {
+            for (int i = 0; i < 20; i++) {
+                int docId = batch * 20 + i;
+                StringBuilder value = new StringBuilder();
+                for (int j = 0; j < 50; j++) {
+                    value.append("batch-").append(batch).append("-doc-").append(docId).append("-").append(j).append(" ");
+                }
+                index("test-fd-merge", "_doc", String.valueOf(docId), "field", value.toString(), "number", docId);
+            }
+            flush("test-fd-merge");
+        }
+        refresh();
+
+        // Clear block cache so reads populate FD cache
+        clearBlockCache();
+
+        for (int i = 0; i < 50; i++) {
+            client().prepareSearch("test-fd-merge").setQuery(org.opensearch.index.query.QueryBuilders.termQuery("number", i)).get();
+        }
+
+        FileChannelCache fdCache = CryptoDirectoryFactory.getSharedFileChannelCache();
+        assertNotNull("Shared FD cache should be initialized", fdCache);
+
+        fdCache.cleanUp();
+        long fdCacheSizeBeforeMerge = fdCache.estimatedSize();
+        logger.info("FD cache size before force-merge: {}", fdCacheSizeBeforeMerge);
+        assertThat("FD cache should have entries for multiple segments", fdCacheSizeBeforeMerge, greaterThan(1L));
+
+        // Force-merge to 1 segment — old segment files deleted → FD cache entries invalidated
+        // Note: the merge itself may open new FDs for the merged segment, so the net FD count
+        // may not decrease. The important thing is old segment FDs are cleaned up.
+        ForceMergeResponse mergeResponse = client().admin().indices().prepareForceMerge("test-fd-merge").setMaxNumSegments(1).get();
+        assertThat("Force merge should succeed", mergeResponse.getFailedShards(), equalTo(0));
+
+        // Verify data is still readable through the merged segment
+        SearchResponse response = client().prepareSearch("test-fd-merge").setSize(0).get();
+        assertThat("All 100 documents should be readable after merge", response.getHits().getTotalHits().value(), equalTo(100L));
+
+        // The real invariant: deleting the index after merge should leave FD cache empty.
+        // This proves no stale FDs leaked from the old segments.
+        client().admin().indices().delete(new DeleteIndexRequest("test-fd-merge")).actionGet();
+
+        fdCache.cleanUp();
+        long fdCacheSizeAfterDelete = fdCache.estimatedSize();
+        logger
+            .info(
+                "FD cache size after index deletion (post-merge): {} (was: {} before merge)",
+                fdCacheSizeAfterDelete,
+                fdCacheSizeBeforeMerge
+            );
+        assertThat("FD cache should be empty after deleting merged index", fdCacheSizeAfterDelete, equalTo(0L));
+    }
+
+    /**
+     * Tests that closing an index (shard close) invalidates FD cache entries.
+     * BufferPoolDirectory.close() calls fileChannelCache.invalidateByPathPrefix(dirPath).
+     * After reopening, reads should still work (FD cache re-populates on demand).
+     */
+    public void testFdCacheInvalidationOnIndexClose() throws Exception {
+        internalCluster().startNode();
+
+        Settings settings = Settings
+            .builder()
+            .put(cryptoIndexSettings())
+            .put("index.number_of_shards", 1)
+            .put("index.number_of_replicas", 0)
+            .build();
+
+        createIndex("test-fd-close", settings);
+        ensureGreen("test-fd-close");
+
+        int numDocs = 50;
+        for (int i = 0; i < numDocs; i++) {
+            StringBuilder largeValue = new StringBuilder();
+            for (int j = 0; j < 50; j++) {
+                largeValue.append("data-").append(i).append("-").append(j).append(" ");
+            }
+            index("test-fd-close", "_doc", String.valueOf(i), "field", largeValue.toString(), "number", i);
+        }
+        refresh();
+        flush("test-fd-close");
+
+        // Clear block cache so reads populate FD cache
+        clearBlockCache();
+
+        for (int i = 0; i < 20; i++) {
+            client().prepareSearch("test-fd-close").setQuery(org.opensearch.index.query.QueryBuilders.termQuery("number", i)).get();
+        }
+
+        FileChannelCache fdCache = CryptoDirectoryFactory.getSharedFileChannelCache();
+        assertNotNull("Shared FD cache should be initialized", fdCache);
+
+        fdCache.cleanUp();
+        long fdCacheSizeBefore = fdCache.estimatedSize();
+        logger.info("FD cache size before index close: {}", fdCacheSizeBefore);
+        assertThat("FD cache should have entries", fdCacheSizeBefore, greaterThan(0L));
+
+        // Close the index — triggers BufferPoolDirectory.close() → fdCache.invalidateByPathPrefix()
+        client().admin().indices().prepareClose("test-fd-close").get();
+
+        fdCache.cleanUp();
+        long fdCacheSizeAfterClose = fdCache.estimatedSize();
+        logger.info("FD cache size after index close: {} (was: {})", fdCacheSizeAfterClose, fdCacheSizeBefore);
+        assertThat("FD cache should be empty after index close", fdCacheSizeAfterClose, equalTo(0L));
+
+        // Reopen and verify data is still accessible
+        client().admin().indices().prepareOpen("test-fd-close").get();
+        ensureGreen("test-fd-close");
+
+        SearchResponse response = client().prepareSearch("test-fd-close").setSize(0).get();
+        assertThat("All documents should be accessible after reopen", response.getHits().getTotalHits().value(), equalTo((long) numDocs));
+    }
+
+    /**
+     * Tests that deleting all encrypted indices results in an empty FD cache.
+     * Verifies complete FD cleanup with no leaked FileChannels.
+     */
+    public void testFdCacheEmptyAfterAllIndicesDeleted() throws Exception {
+        internalCluster().startNode();
+
+        int numIndices = 3;
+        String[] indexNames = new String[numIndices];
+
+        Settings settings = Settings
+            .builder()
+            .put(cryptoIndexSettings())
+            .put("index.number_of_shards", 2)
+            .put("index.number_of_replicas", 0)
+            .build();
+
+        for (int idx = 0; idx < numIndices; idx++) {
+            indexNames[idx] = "test-fd-all-" + idx;
+            createIndex(indexNames[idx], settings);
+        }
+        ensureGreen(indexNames);
+
+        for (int idx = 0; idx < numIndices; idx++) {
+            for (int i = 0; i < 30; i++) {
+                StringBuilder value = new StringBuilder();
+                for (int j = 0; j < 30; j++) {
+                    value.append("idx-").append(idx).append("-doc-").append(i).append("-").append(j).append(" ");
+                }
+                index(indexNames[idx], "_doc", String.valueOf(i), "field", value.toString(), "number", i);
+            }
+        }
+        refresh(indexNames);
+        flush(indexNames);
+
+        // Clear block cache so reads populate FD cache
+        clearBlockCache();
+
+        for (int idx = 0; idx < numIndices; idx++) {
+            for (int i = 0; i < 10; i++) {
+                client().prepareSearch(indexNames[idx]).setQuery(org.opensearch.index.query.QueryBuilders.termQuery("number", i)).get();
+            }
+        }
+
+        FileChannelCache fdCache = CryptoDirectoryFactory.getSharedFileChannelCache();
+        assertNotNull("Shared FD cache should be initialized", fdCache);
+
+        fdCache.cleanUp();
+        long fdCacheSizeBefore = fdCache.estimatedSize();
+        logger.info("FD cache size before deleting all indices: {}", fdCacheSizeBefore);
+        assertThat("FD cache should have entries", fdCacheSizeBefore, greaterThan(0L));
+
+        // Delete all indices
+        for (String indexName : indexNames) {
+            client().admin().indices().delete(new DeleteIndexRequest(indexName)).actionGet();
+        }
+
+        fdCache.cleanUp();
+        long fdCacheSizeAfter = fdCache.estimatedSize();
+        logger.info("FD cache size after deleting all {} indices: {} (was: {})", numIndices, fdCacheSizeAfter, fdCacheSizeBefore);
+        assertThat("FD cache should be empty after all indices deleted", fdCacheSizeAfter, equalTo(0L));
     }
 }

--- a/src/jcstress/java/org/opensearch/index/store/block_loader/FileChannelCacheStressTests.java
+++ b/src/jcstress/java/org/opensearch/index/store/block_loader/FileChannelCacheStressTests.java
@@ -1,0 +1,544 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.block_loader;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import org.openjdk.jcstress.annotations.*;
+import org.openjdk.jcstress.infra.results.*;
+
+/**
+ * JCStress tests for {@link FileChannelCache} and {@link RefCountedChannel}.
+ *
+ * <h2>Contracts under test</h2>
+ * <ol>
+ *   <li>{@link FileChannelCache#acquire(String)} MUST always return a valid,
+ *       acquired {@link RefCountedChannel} — even under concurrent evictions.</li>
+ *   <li>An acquired {@link RefCountedChannel} MUST keep its underlying
+ *       {@link FileChannel} open for the duration of in-flight I/O, even if
+ *       the cache evicts the entry or another thread calls {@code close()}.</li>
+ *   <li>{@link RefCountedChannel#acquire()} on a dead channel (refCount ≤ 0)
+ *       MUST throw {@link IllegalStateException}, never return.</li>
+ * </ol>
+ *
+ * <h2>Approach</h2>
+ * <p>We use real temp files with known content so that I/O reads can validate
+ * data integrity. Each {@code @State} constructor creates its own temp file
+ * and cache instance. JCStress explores all thread interleavings.</p>
+ *
+ * <h2>Outcome encoding</h2>
+ * <ul>
+ *   <li>Positive values = success (specific meaning per test)</li>
+ *   <li>0 = acceptable edge case (e.g., stale read)</li>
+ *   <li>-1 = FORBIDDEN — contract violation</li>
+ * </ul>
+ */
+public class FileChannelCacheStressTests {
+
+    /** Magic byte written to every byte of the temp file. */
+    private static final byte MAGIC = (byte) 0xCA;
+    /** Size of temp files — small but enough to validate reads. */
+    private static final int FILE_SIZE = 4096;
+
+    /**
+     * Creates a temp file filled with {@link #MAGIC} bytes.
+     * The file is marked deleteOnExit for cleanup.
+     */
+    private static Path createTempFile() {
+        try {
+            Path tmp = Files.createTempFile("jcstress-fcc-", ".dat");
+            tmp.toFile().deleteOnExit();
+            byte[] data = new byte[FILE_SIZE];
+            java.util.Arrays.fill(data, MAGIC);
+            Files.write(tmp, data);
+            return tmp;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Reads 64 bytes from offset 0 and validates all bytes match MAGIC.
+     * Returns true if content is intact, false if channel is broken or data corrupt.
+     */
+    private static boolean readAndValidate(FileChannel fc) {
+        try {
+            ByteBuffer buf = ByteBuffer.allocate(64);
+            int read = fc.read(buf, 0);
+            if (read <= 0)
+                return false;
+            buf.flip();
+            for (int i = 0; i < read; i++) {
+                if (buf.get(i) != MAGIC)
+                    return false;
+            }
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    // ========================================================================
+    // Test 1: RefCountedChannel — acquire + releaseBase race
+    //
+    // Actor 1: acquires the channel (simulating in-flight I/O)
+    // Actor 2: calls releaseBase() (simulating cache eviction)
+    // Arbiter: validates the acquired channel is still open and readable
+    //
+    // Contract: in-flight I/O MUST complete successfully even after eviction.
+    // ========================================================================
+
+    @JCStressTest
+    @Description("In-flight I/O survives cache eviction. Actor 1 acquires, "
+        + "Actor 2 releases base ref. Arbiter validates channel still readable.")
+    @Outcome(id = "1", expect = Expect.ACCEPTABLE, desc = "Channel readable after eviction — in-flight I/O protected.")
+    @Outcome(id = "-1", expect = Expect.FORBIDDEN, desc = "Channel closed or corrupt during in-flight I/O — contract violation.")
+    @State
+    public static class AcquireSurvivesEviction {
+        private final Path tmpFile = createTempFile();
+        private final RefCountedChannel ref;
+        private volatile RefCountedChannel acquired;
+
+        public AcquireSurvivesEviction() {
+            try {
+                FileChannel fc = FileChannel.open(tmpFile, StandardOpenOption.READ);
+                ref = new RefCountedChannel(fc);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Actor
+        public void ioThread() {
+            // Simulate in-flight I/O: acquire a ref
+            try {
+                acquired = ref.acquire();
+            } catch (IllegalStateException e) {
+                // Base already released — acquire correctly rejected
+                acquired = null;
+            }
+        }
+
+        @Actor
+        public void evictionThread() {
+            // Simulate cache eviction: release the base reference
+            ref.releaseBase();
+        }
+
+        @Arbiter
+        public void arbiter(I_Result r) {
+            RefCountedChannel acq = acquired;
+            if (acq == null) {
+                // acquire() threw because base was already released — that's fine,
+                // FileChannelCache.acquire() would retry with a fresh entry
+                r.r1 = 1;
+            } else {
+                // We got an acquired ref — the channel MUST still be open and readable
+                boolean ok = readAndValidate(acq.channel());
+                acq.close(); // release our I/O ref
+                r.r1 = ok ? 1 : -1;
+            }
+        }
+    }
+
+    // ========================================================================
+    // Test 2: RefCountedChannel — multiple concurrent close() calls
+    //
+    // Pre-acquire 2 extra refs (simulating 2 in-flight I/Os).
+    // Actor 1 and Actor 2 each close one ref.
+    // Arbiter validates the channel is still open (base ref remains).
+    //
+    // Contract: close() is idempotent per-ref. Channel closes only when
+    // ALL refs (including base) are released.
+    // ========================================================================
+
+    @JCStressTest
+    @Description("Two concurrent close() calls on separate acquired refs. " + "Channel must stay open because base ref is still held.")
+    @Outcome(id = "1", expect = Expect.ACCEPTABLE, desc = "Channel still open after both I/O refs released — base ref holds it.")
+    @Outcome(id = "-1", expect = Expect.FORBIDDEN, desc = "Channel prematurely closed — refCount accounting bug.")
+    @State
+    public static class ConcurrentCloseKeepsChannelOpen {
+        private final Path tmpFile = createTempFile();
+        private final RefCountedChannel ref;
+        private final RefCountedChannel io1;
+        private final RefCountedChannel io2;
+
+        public ConcurrentCloseKeepsChannelOpen() {
+            try {
+                FileChannel fc = FileChannel.open(tmpFile, StandardOpenOption.READ);
+                ref = new RefCountedChannel(fc);
+                io1 = ref.acquire(); // refCount = 2
+                io2 = ref.acquire(); // refCount = 3
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Actor
+        public void closer1() {
+            io1.close(); // refCount -> 2
+        }
+
+        @Actor
+        public void closer2() {
+            io2.close(); // refCount -> 1
+        }
+
+        @Arbiter
+        public void arbiter(I_Result r) {
+            // Base ref still held — channel must be open and readable
+            boolean ok = readAndValidate(ref.channel());
+            ref.releaseBase(); // cleanup
+            r.r1 = ok ? 1 : -1;
+        }
+    }
+
+    // ========================================================================
+    // Test 3: RefCountedChannel — acquire on dead channel throws
+    //
+    // Actor 1: releases base (kills the channel)
+    // Actor 2: tries to acquire
+    // Arbiter: validates acquire either succeeded (before death) or threw
+    //
+    // Contract: acquire() MUST throw IllegalStateException on dead channel,
+    // never return a ref to a closed FileChannel.
+    // ========================================================================
+
+    @JCStressTest
+    @Description("acquire() on a dead RefCountedChannel must throw, never " + "return a ref to a closed channel.")
+    @Outcome(id = "1", expect = Expect.ACCEPTABLE, desc = "Acquired before death — channel readable, then released.")
+    @Outcome(id = "2", expect = Expect.ACCEPTABLE, desc = "acquire() correctly threw IllegalStateException on dead channel.")
+    @Outcome(id = "-1", expect = Expect.FORBIDDEN, desc = "acquire() returned a ref to a closed/corrupt channel.")
+    @State
+    public static class AcquireOnDeadChannelThrows {
+        private final Path tmpFile = createTempFile();
+        private final RefCountedChannel ref;
+        private volatile RefCountedChannel acquired;
+        private volatile boolean threw;
+
+        public AcquireOnDeadChannelThrows() {
+            try {
+                FileChannel fc = FileChannel.open(tmpFile, StandardOpenOption.READ);
+                ref = new RefCountedChannel(fc);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Actor
+        public void killer() {
+            ref.releaseBase();
+        }
+
+        @Actor
+        public void acquirer() {
+            try {
+                acquired = ref.acquire();
+            } catch (IllegalStateException e) {
+                threw = true;
+            }
+        }
+
+        @Arbiter
+        public void arbiter(I_Result r) {
+            if (threw) {
+                // Correctly rejected — dead channel
+                r.r1 = 2;
+            } else {
+                RefCountedChannel acq = acquired;
+                if (acq == null) {
+                    // Shouldn't happen — acquire either returns or throws
+                    r.r1 = -1;
+                } else {
+                    // Acquired before death — channel must be readable
+                    boolean ok = readAndValidate(acq.channel());
+                    acq.close();
+                    r.r1 = ok ? 1 : -1;
+                }
+            }
+        }
+    }
+
+    // ========================================================================
+    // Test 4: FileChannelCache — acquire always returns valid channel
+    //
+    // Cache with maxSize=1. Two actors acquire different paths, forcing
+    // eviction. Both must get a valid, readable channel.
+    //
+    // Contract: acquire() MUST always return a valid RefCountedChannel,
+    // transparently retrying on eviction races.
+    // ========================================================================
+
+    @JCStressTest
+    @Description("FileChannelCache.acquire() returns valid channel under " + "eviction pressure. Cache size=1, two paths compete.")
+    @Outcome(id = "1, 1", expect = Expect.ACCEPTABLE, desc = "Both actors got valid readable channels despite eviction.")
+    @Outcome(id = "-1, 1", expect = Expect.FORBIDDEN, desc = "Actor 1 got invalid channel — acquire contract violated.")
+    @Outcome(id = "1, -1", expect = Expect.FORBIDDEN, desc = "Actor 2 got invalid channel — acquire contract violated.")
+    @Outcome(id = "-1, -1", expect = Expect.FORBIDDEN, desc = "Both actors got invalid channels — acquire contract violated.")
+    @State
+    public static class AcquireUnderEvictionPressure {
+        private final Path tmpFile1 = createTempFile();
+        private final Path tmpFile2 = createTempFile();
+        private final FileChannelCache cache;
+        private final String path1;
+        private final String path2;
+
+        public AcquireUnderEvictionPressure() {
+            path1 = tmpFile1.toAbsolutePath().normalize().toString();
+            path2 = tmpFile2.toAbsolutePath().normalize().toString();
+            // maxSize=1 forces eviction when second path is acquired
+            cache = new FileChannelCache(1, null);
+        }
+
+        @Actor
+        public void actor1(II_Result r) {
+            try (RefCountedChannel ref = cache.acquire(path1)) {
+                r.r1 = readAndValidate(ref.channel()) ? 1 : -1;
+            } catch (Exception e) {
+                r.r1 = -1;
+            }
+        }
+
+        @Actor
+        public void actor2(II_Result r) {
+            try (RefCountedChannel ref = cache.acquire(path2)) {
+                r.r2 = readAndValidate(ref.channel()) ? 1 : -1;
+            } catch (Exception e) {
+                r.r2 = -1;
+            }
+        }
+    }
+
+    // ========================================================================
+    // Test 5: FileChannelCache — in-flight I/O survives eviction
+    //
+    // Actor 1: acquires path1 and holds the ref (simulating long I/O)
+    // Actor 2: acquires path2, forcing eviction of path1 from cache
+    // Arbiter: validates Actor 1's channel is still open and readable
+    //
+    // Contract: eviction releases the base ref, but the in-flight I/O ref
+    // keeps the FileChannel alive. The channel MUST NOT close until the
+    // last ref is released.
+    // ========================================================================
+
+    @JCStressTest
+    @Description("In-flight I/O on evicted entry survives. Actor 1 holds ref, "
+        + "Actor 2 forces eviction. Arbiter validates Actor 1 can still read.")
+    @Outcome(id = "1", expect = Expect.ACCEPTABLE, desc = "Evicted channel still readable — in-flight I/O protected.")
+    @Outcome(id = "-1", expect = Expect.FORBIDDEN, desc = "Evicted channel closed during in-flight I/O — contract violation.")
+    @State
+    public static class InFlightIOSurvivesCacheEviction {
+        private final Path tmpFile1 = createTempFile();
+        private final Path tmpFile2 = createTempFile();
+        private final FileChannelCache cache;
+        private final String path1;
+        private final String path2;
+        private volatile RefCountedChannel heldRef;
+
+        public InFlightIOSurvivesCacheEviction() {
+            path1 = tmpFile1.toAbsolutePath().normalize().toString();
+            path2 = tmpFile2.toAbsolutePath().normalize().toString();
+            cache = new FileChannelCache(1, null);
+            // Pre-load path1 into cache and acquire an I/O ref
+            try {
+                heldRef = cache.acquire(path1);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Actor
+        public void evictor() {
+            // Acquire path2 — forces eviction of path1's cache entry
+            try (RefCountedChannel ref = cache.acquire(path2)) {
+                // Just trigger the eviction, don't need to do anything with it
+            } catch (IOException e) {
+                // Shouldn't happen with valid temp files
+            }
+        }
+
+        @Actor
+        public void holder() {
+            // Just hold the ref — simulating long-running I/O
+            // The arbiter will validate and release
+        }
+
+        @Arbiter
+        public void arbiter(I_Result r) {
+            RefCountedChannel ref = heldRef;
+            if (ref == null) {
+                r.r1 = -1;
+                return;
+            }
+            // path1 was evicted from cache, but our held ref should keep it alive
+            boolean ok = readAndValidate(ref.channel());
+            ref.close(); // release our I/O ref — now channel can close
+            r.r1 = ok ? 1 : -1;
+        }
+    }
+
+    // ========================================================================
+    // Test 6: FileChannelCache — concurrent acquire on same path
+    //
+    // Two actors acquire the same path concurrently. Both must get a valid
+    // channel. This tests the Caffeine cache's compute-if-absent atomicity
+    // combined with RefCountedChannel's CAS-based acquire.
+    //
+    // Contract: both actors get a valid, readable channel. They may share
+    // the same underlying RefCountedChannel or get different ones (if one
+    // was evicted and recreated), but both MUST be valid.
+    // ========================================================================
+
+    @JCStressTest
+    @Description("Two concurrent acquires on the same path. Both must get " + "valid readable channels.")
+    @Outcome(id = "1, 1", expect = Expect.ACCEPTABLE, desc = "Both actors got valid channels for the same path.")
+    @Outcome(id = "-1, 1", expect = Expect.FORBIDDEN, desc = "Actor 1 got invalid channel.")
+    @Outcome(id = "1, -1", expect = Expect.FORBIDDEN, desc = "Actor 2 got invalid channel.")
+    @Outcome(id = "-1, -1", expect = Expect.FORBIDDEN, desc = "Both actors got invalid channels.")
+    @State
+    public static class ConcurrentAcquireSamePath {
+        private final Path tmpFile = createTempFile();
+        private final FileChannelCache cache;
+        private final String path;
+
+        public ConcurrentAcquireSamePath() {
+            path = tmpFile.toAbsolutePath().normalize().toString();
+            cache = new FileChannelCache(16, null);
+        }
+
+        @Actor
+        public void actor1(II_Result r) {
+            try (RefCountedChannel ref = cache.acquire(path)) {
+                r.r1 = readAndValidate(ref.channel()) ? 1 : -1;
+            } catch (Exception e) {
+                r.r1 = -1;
+            }
+        }
+
+        @Actor
+        public void actor2(II_Result r) {
+            try (RefCountedChannel ref = cache.acquire(path)) {
+                r.r2 = readAndValidate(ref.channel()) ? 1 : -1;
+            } catch (Exception e) {
+                r.r2 = -1;
+            }
+        }
+    }
+
+    // ========================================================================
+    // Test 7: FileChannelCache — acquire + invalidate race
+    //
+    // Actor 1: acquires a channel and holds it (in-flight I/O)
+    // Actor 2: invalidates the same path (simulating storage migration)
+    // Arbiter: validates the held channel is still readable
+    //
+    // Contract: invalidate() triggers eviction which releases the base ref,
+    // but the in-flight I/O ref keeps the channel alive.
+    // ========================================================================
+
+    @JCStressTest
+    @Description("acquire + invalidate race. Held channel must survive " + "explicit invalidation for in-flight I/O.")
+    @Outcome(id = "1", expect = Expect.ACCEPTABLE, desc = "Channel survived invalidation — in-flight I/O completed.")
+    @Outcome(id = "-1", expect = Expect.FORBIDDEN, desc = "Channel closed by invalidation during in-flight I/O.")
+    @State
+    public static class AcquireSurvivesInvalidation {
+        private final Path tmpFile = createTempFile();
+        private final FileChannelCache cache;
+        private final String path;
+        private volatile RefCountedChannel heldRef;
+
+        public AcquireSurvivesInvalidation() {
+            path = tmpFile.toAbsolutePath().normalize().toString();
+            cache = new FileChannelCache(16, null);
+            try {
+                heldRef = cache.acquire(path);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Actor
+        public void invalidator() {
+            cache.invalidate(path);
+        }
+
+        @Actor
+        public void holder() {
+            // Hold the ref — simulating in-flight I/O
+        }
+
+        @Arbiter
+        public void arbiter(I_Result r) {
+            RefCountedChannel ref = heldRef;
+            if (ref == null) {
+                r.r1 = -1;
+                return;
+            }
+            boolean ok = readAndValidate(ref.channel());
+            ref.close();
+            r.r1 = ok ? 1 : -1;
+        }
+    }
+
+    // ========================================================================
+    // Test 8: FileChannelCache — close() with in-flight I/O
+    //
+    // Actor 1: holds an acquired ref (in-flight I/O)
+    // Actor 2: calls cache.close() (invalidateAll — bulk cleanup)
+    // Arbiter: validates the held channel is still readable
+    //
+    // Contract: cache.close() invalidates all entries, but in-flight I/O
+    // refs keep their channels alive until released.
+    // ========================================================================
+
+    @JCStressTest
+    @Description("cache.close() with in-flight I/O. Held channel must " + "survive invalidateAll for ongoing reads.")
+    @Outcome(id = "1", expect = Expect.ACCEPTABLE, desc = "Channel survived cache.close() — in-flight I/O completed.")
+    @Outcome(id = "-1", expect = Expect.FORBIDDEN, desc = "Channel closed by cache.close() during in-flight I/O.")
+    @State
+    public static class CacheCloseWithInFlightIO {
+        private final Path tmpFile = createTempFile();
+        private final FileChannelCache cache;
+        private final String path;
+        private volatile RefCountedChannel heldRef;
+
+        public CacheCloseWithInFlightIO() {
+            path = tmpFile.toAbsolutePath().normalize().toString();
+            cache = new FileChannelCache(16, null);
+            try {
+                heldRef = cache.acquire(path);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Actor
+        public void cacheCloser() {
+            cache.close();
+        }
+
+        @Actor
+        public void holder() {
+            // Hold the ref — simulating in-flight I/O
+        }
+
+        @Arbiter
+        public void arbiter(I_Result r) {
+            RefCountedChannel ref = heldRef;
+            if (ref == null) {
+                r.r1 = -1;
+                return;
+            }
+            boolean ok = readAndValidate(ref.channel());
+            ref.close();
+            r.r1 = ok ? 1 : -1;
+        }
+    }
+}

--- a/src/jcstress/java/org/opensearch/index/store/block_loader/FileChannelCacheStressTests.java
+++ b/src/jcstress/java/org/opensearch/index/store/block_loader/FileChannelCacheStressTests.java
@@ -13,6 +13,7 @@ import java.nio.file.StandardOpenOption;
 
 import org.openjdk.jcstress.annotations.*;
 import org.openjdk.jcstress.infra.results.*;
+import org.opensearch.common.SuppressForbidden;
 
 /**
  * JCStress tests for {@link FileChannelCache} and {@link RefCountedChannel}.
@@ -46,15 +47,33 @@ public class FileChannelCacheStressTests {
     private static final byte MAGIC = (byte) 0xCA;
     /** Size of temp files — small but enough to validate reads. */
     private static final int FILE_SIZE = 4096;
+    /** Shared temp directory for all jcstress test files. */
+    private static final Path TEMP_DIR;
+
+    static {
+        try {
+            TEMP_DIR = Files.createTempDirectory(Path.of(System.getProperty("java.io.tmpdir")), "jcstress-fcc");
+            // Register shutdown hook to clean up temp directory
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                try (var stream = Files.walk(TEMP_DIR)) {
+                    stream.sorted(java.util.Comparator.reverseOrder()).forEach(p -> {
+                        try {
+                            Files.deleteIfExists(p);
+                        } catch (IOException ignored) {}
+                    });
+                } catch (IOException ignored) {}
+            }));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create temp directory for jcstress tests", e);
+        }
+    }
 
     /**
      * Creates a temp file filled with {@link #MAGIC} bytes.
-     * The file is marked deleteOnExit for cleanup.
      */
     private static Path createTempFile() {
         try {
-            Path tmp = Files.createTempFile("jcstress-fcc-", ".dat");
-            tmp.toFile().deleteOnExit();
+            Path tmp = Files.createTempFile(TEMP_DIR, "jcstress-fcc-", ".dat");
             byte[] data = new byte[FILE_SIZE];
             java.util.Arrays.fill(data, MAGIC);
             Files.write(tmp, data);
@@ -68,6 +87,7 @@ public class FileChannelCacheStressTests {
      * Reads 64 bytes from offset 0 and validates all bytes match MAGIC.
      * Returns true if content is intact, false if channel is broken or data corrupt.
      */
+    @SuppressForbidden(reason = "FileChannel#read is required to validate channel liveness in stress tests")
     private static boolean readAndValidate(FileChannel fc) {
         try {
             ByteBuffer buf = ByteBuffer.allocate(64);

--- a/src/jmh/java/org/opensearch/index/store/benchmark/FileChannelCacheBenchmark.java
+++ b/src/jmh/java/org/opensearch/index/store/benchmark/FileChannelCacheBenchmark.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.benchmark;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.opensearch.index.store.block_loader.FileChannelCache;
+import org.opensearch.index.store.block_loader.RefCountedChannel;
+
+/**
+ * JMH benchmark comparing I/O latency for small reads (8 KB) with and without
+ * the FileChannelCache.
+ *
+ * <p>Three strategies are compared:
+ * <ul>
+ *   <li><b>openEveryTime</b>: open() + read() + close() per I/O — the baseline
+ *       without FD caching. This is what any Directory implementation does today
+ *       if it doesn't cache FileChannels.</li>
+ *   <li><b>cachedChannel</b>: acquire() from FileChannelCache + read() + release()
+ *       — the FD cache approach. open() is amortized across many reads.</li>
+ *   <li><b>singleChannel</b>: one pre-opened FileChannel, read() only — theoretical
+ *       lower bound (no open/close, no cache lookup). Shows the pure read cost.</li>
+ * </ul>
+ *
+ * <p>Run:
+ * <pre>
+ *   ./gradlew jmhJar
+ *   java --enable-native-access=ALL-UNNAMED --enable-preview \
+ *        -jar build/libs/*-jmh.jar FileChannelCacheBenchmark \
+ *        -t 1 -f 2 -wi 3 -i 5
+ *
+ *   # Multi-threaded (8 threads, simulating concurrent shard reads):
+ *   java --enable-native-access=ALL-UNNAMED --enable-preview \
+ *        -jar build/libs/*-jmh.jar FileChannelCacheBenchmark \
+ *        -t 8 -f 2 -wi 3 -i 5
+ * </pre>
+ */
+@BenchmarkMode({ Mode.AverageTime, Mode.Throughput })
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 3)
+@Fork(value = 2, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
+@Threads(1)
+public class FileChannelCacheBenchmark {
+
+    // ========================================================================
+    // Shared state — one per benchmark trial. Creates test files on disk.
+    // ========================================================================
+
+    @State(Scope.Benchmark)
+    public static class SharedState {
+
+        @Param({ "8192" })
+        public int readSizeBytes;
+
+        @Param({ "1", "64", "256" })
+        public int numFiles;
+
+        private Path tempDir;
+        private String[] filePaths;
+        private FileChannelCache fdCache;
+
+        @Setup(Level.Trial)
+        public void setup() throws Exception {
+            tempDir = Files.createTempDirectory("fcc-bench");
+            filePaths = new String[numFiles];
+
+            // Create test files — 1 MB each, filled with deterministic pattern
+            byte[] data = BenchmarkConfig.buildDeterministicPattern(1024 * 1024);
+            for (int i = 0; i < numFiles; i++) {
+                Path f = tempDir.resolve("seg_" + i + ".dat");
+                Files.write(f, data);
+                filePaths[i] = f.toAbsolutePath().normalize().toString();
+            }
+
+            // FD cache sized to hold all files (no eviction during benchmark)
+            fdCache = new FileChannelCache(Math.max(numFiles, 256), null);
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() throws Exception {
+            if (fdCache != null) {
+                fdCache.close();
+            }
+            BenchmarkConfig.deleteRecursively(tempDir);
+        }
+    }
+
+    // ========================================================================
+    // Per-thread state — each JMH thread gets its own read buffer and RNG
+    // ========================================================================
+
+    @State(Scope.Thread)
+    public static class ThreadState {
+        ByteBuffer readBuf;
+        Random rng;
+        int fileIndex;
+
+        @Setup(Level.Iteration)
+        public void setup(SharedState shared) {
+            readBuf = ByteBuffer.allocateDirect(shared.readSizeBytes);
+            rng = new Random(Thread.currentThread().threadId());
+            fileIndex = 0;
+        }
+
+        /** Round-robin across files to simulate multi-shard access */
+        String nextPath(SharedState shared) {
+            String path = shared.filePaths[fileIndex];
+            fileIndex = (fileIndex + 1) % shared.numFiles;
+            return path;
+        }
+
+        /** Random offset within the file, aligned to read size */
+        long randomOffset(SharedState shared) {
+            int maxBlocks = (1024 * 1024) / shared.readSizeBytes;
+            return (long) rng.nextInt(maxBlocks) * shared.readSizeBytes;
+        }
+    }
+
+    // ========================================================================
+    // Benchmark: open() + read() + close() per I/O — no FD caching
+    // ========================================================================
+
+    @Benchmark
+    public void openEveryTime(SharedState shared, ThreadState ts, Blackhole bh) throws IOException {
+        String path = ts.nextPath(shared);
+        long offset = ts.randomOffset(shared);
+        ts.readBuf.clear();
+
+        try (FileChannel fc = FileChannel.open(Path.of(path), StandardOpenOption.READ)) {
+            int n = fc.read(ts.readBuf, offset);
+            bh.consume(n);
+        }
+    }
+
+    // ========================================================================
+    // Benchmark: FileChannelCache acquire() + read() + release()
+    // ========================================================================
+
+    @Benchmark
+    public void cachedChannel(SharedState shared, ThreadState ts, Blackhole bh) throws IOException {
+        String path = ts.nextPath(shared);
+        long offset = ts.randomOffset(shared);
+        ts.readBuf.clear();
+
+        try (RefCountedChannel ref = shared.fdCache.acquire(path)) {
+            int n = ref.channel().read(ts.readBuf, offset);
+            bh.consume(n);
+        }
+    }
+
+    // ========================================================================
+    // Benchmark: pre-opened channel, read() only — theoretical lower bound
+    // ========================================================================
+
+    @State(Scope.Thread)
+    public static class PreOpenedState {
+        FileChannel[] channels;
+
+        @Setup(Level.Trial)
+        public void setup(SharedState shared) throws IOException {
+            channels = new FileChannel[shared.numFiles];
+            for (int i = 0; i < shared.numFiles; i++) {
+                channels[i] = FileChannel.open(Path.of(shared.filePaths[i]), StandardOpenOption.READ);
+            }
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() throws IOException {
+            if (channels != null) {
+                for (FileChannel fc : channels) {
+                    if (fc != null)
+                        fc.close();
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void singleChannel(SharedState shared, ThreadState ts, PreOpenedState pre, Blackhole bh) throws IOException {
+        long offset = ts.randomOffset(shared);
+        ts.readBuf.clear();
+
+        FileChannel fc = pre.channels[ts.fileIndex == 0 ? shared.numFiles - 1 : ts.fileIndex - 1];
+        int n = fc.read(ts.readBuf, offset);
+        bh.consume(n);
+    }
+}

--- a/src/jmh/java/org/opensearch/index/store/benchmark/FileChannelCacheBenchmark.java
+++ b/src/jmh/java/org/opensearch/index/store/benchmark/FileChannelCacheBenchmark.java
@@ -5,9 +5,12 @@
 package org.opensearch.index.store.benchmark;
 
 import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Random;
@@ -28,23 +31,27 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
+import org.opensearch.index.store.block_loader.DirectIOReaderUtil;
 import org.opensearch.index.store.block_loader.FileChannelCache;
 import org.opensearch.index.store.block_loader.RefCountedChannel;
+import org.opensearch.index.store.bufferpoolfs.StaticConfigs;
 
 /**
  * JMH benchmark comparing I/O latency for small reads (8 KB) with and without
- * the FileChannelCache.
+ * the FileChannelCache, using O_DIRECT to bypass the OS page cache.
  *
  * <p>Three strategies are compared:
  * <ul>
- *   <li><b>openEveryTime</b>: open() + read() + close() per I/O — the baseline
- *       without FD caching. This is what any Directory implementation does today
- *       if it doesn't cache FileChannels.</li>
+ *   <li><b>openEveryTime</b>: open(O_DIRECT) + read() + close() per I/O — the baseline
+ *       without FD caching.</li>
  *   <li><b>cachedChannel</b>: acquire() from FileChannelCache + read() + release()
  *       — the FD cache approach. open() is amortized across many reads.</li>
- *   <li><b>singleChannel</b>: one pre-opened FileChannel, read() only — theoretical
- *       lower bound (no open/close, no cache lookup). Shows the pure read cost.</li>
+ *   <li><b>singleChannel</b>: one pre-opened O_DIRECT FileChannel, read() only —
+ *       theoretical lower bound (no open/close, no cache lookup).</li>
  * </ul>
+ *
+ * <p>All reads use sector-aligned buffers allocated via {@link Arena#allocate(long, long)}
+ * to satisfy O_DIRECT alignment requirements.
  *
  * <p>Run:
  * <pre>
@@ -61,10 +68,11 @@ import org.opensearch.index.store.block_loader.RefCountedChannel;
  */
 @BenchmarkMode({ Mode.AverageTime, Mode.Throughput })
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 3, time = 2)
-@Measurement(iterations = 5, time = 3)
-@Fork(value = 2, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
+@Warmup(iterations = 2, time = 1)
+@Measurement(iterations = 3, time = 2)
+@Fork(value = 1, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
 @Threads(1)
+@SuppressWarnings("preview")
 public class FileChannelCacheBenchmark {
 
     // ========================================================================
@@ -77,12 +85,14 @@ public class FileChannelCacheBenchmark {
         @Param({ "8192" })
         public int readSizeBytes;
 
-        @Param({ "1", "64", "256" })
+        @Param({ "1", "64" })
         public int numFiles;
 
         private Path tempDir;
         private String[] filePaths;
         private FileChannelCache fdCache;
+        private OpenOption directOption;
+        private int alignment;
 
         @Setup(Level.Trial)
         public void setup() throws Exception {
@@ -97,8 +107,12 @@ public class FileChannelCacheBenchmark {
                 filePaths[i] = f.toAbsolutePath().normalize().toString();
             }
 
+            // O_DIRECT setup
+            directOption = DirectIOReaderUtil.getDirectOpenOption();
+            alignment = StaticConfigs.getDirectIOAlignment(tempDir);
+
             // FD cache sized to hold all files (no eviction during benchmark)
-            fdCache = new FileChannelCache(Math.max(numFiles, 256), null);
+            fdCache = new FileChannelCache(Math.max(numFiles, 256), directOption);
         }
 
         @TearDown(Level.Trial)
@@ -111,20 +125,31 @@ public class FileChannelCacheBenchmark {
     }
 
     // ========================================================================
-    // Per-thread state — each JMH thread gets its own read buffer and RNG
+    // Per-thread state — each JMH thread gets its own aligned read buffer and RNG
     // ========================================================================
 
     @State(Scope.Thread)
     public static class ThreadState {
+        Arena arena;
         ByteBuffer readBuf;
         Random rng;
         int fileIndex;
 
         @Setup(Level.Iteration)
         public void setup(SharedState shared) {
-            readBuf = ByteBuffer.allocateDirect(shared.readSizeBytes);
+            arena = Arena.ofConfined();
+            // Allocate sector-aligned buffer for O_DIRECT reads
+            MemorySegment segment = arena.allocate(shared.readSizeBytes, shared.alignment);
+            readBuf = segment.asByteBuffer();
             rng = new Random(Thread.currentThread().threadId());
             fileIndex = 0;
+        }
+
+        @TearDown(Level.Iteration)
+        public void tearDown() {
+            if (arena != null) {
+                arena.close();
+            }
         }
 
         /** Round-robin across files to simulate multi-shard access */
@@ -142,7 +167,7 @@ public class FileChannelCacheBenchmark {
     }
 
     // ========================================================================
-    // Benchmark: open() + read() + close() per I/O — no FD caching
+    // Benchmark: open(O_DIRECT) + read() + close() per I/O — no FD caching
     // ========================================================================
 
     @Benchmark
@@ -151,7 +176,7 @@ public class FileChannelCacheBenchmark {
         long offset = ts.randomOffset(shared);
         ts.readBuf.clear();
 
-        try (FileChannel fc = FileChannel.open(Path.of(path), StandardOpenOption.READ)) {
+        try (FileChannel fc = FileChannel.open(Path.of(path), StandardOpenOption.READ, shared.directOption)) {
             int n = fc.read(ts.readBuf, offset);
             bh.consume(n);
         }
@@ -174,7 +199,7 @@ public class FileChannelCacheBenchmark {
     }
 
     // ========================================================================
-    // Benchmark: pre-opened channel, read() only — theoretical lower bound
+    // Benchmark: pre-opened O_DIRECT channel, read() only — theoretical lower bound
     // ========================================================================
 
     @State(Scope.Thread)
@@ -185,7 +210,7 @@ public class FileChannelCacheBenchmark {
         public void setup(SharedState shared) throws IOException {
             channels = new FileChannel[shared.numFiles];
             for (int i = 0; i < shared.numFiles; i++) {
-                channels[i] = FileChannel.open(Path.of(shared.filePaths[i]), StandardOpenOption.READ);
+                channels[i] = FileChannel.open(Path.of(shared.filePaths[i]), StandardOpenOption.READ, shared.directOption);
             }
         }
 

--- a/src/jmh/java/org/opensearch/index/store/benchmark/ReadBenchmarkBase.java
+++ b/src/jmh/java/org/opensearch/index/store/benchmark/ReadBenchmarkBase.java
@@ -148,7 +148,12 @@ public class ReadBenchmarkBase {
 
         EncryptionMetadataCache encMetaCache = EncryptionMetadataCacheRegistry.getOrCreateCache(indexUuid, shardId, indexName);
 
-        BlockLoader<RefCountedMemorySegment> loader = new CryptoDirectIOBlockLoader(segmentPool, keyResolver, encMetaCache);
+        BlockLoader<RefCountedMemorySegment> loader = new CryptoDirectIOBlockLoader(
+            segmentPool,
+            keyResolver,
+            encMetaCache,
+            poolResources.getFileChannelCache()
+        );
         Worker worker = poolResources.getSharedReadaheadWorker();
 
         @SuppressWarnings("unchecked")
@@ -170,7 +175,8 @@ public class ReadBenchmarkBase {
             directoryCache,
             loader,
             worker,
-            encMetaCache
+            encMetaCache,
+            poolResources.getFileChannelCache()
         );
 
         // Write test files through bufferpool write path

--- a/src/main/java/org/opensearch/index/store/CryptoDirectoryFactory.java
+++ b/src/main/java/org/opensearch/index/store/CryptoDirectoryFactory.java
@@ -36,6 +36,7 @@ import org.opensearch.index.store.block_cache.BlockCache;
 import org.opensearch.index.store.block_cache.CaffeineBlockCache;
 import org.opensearch.index.store.block_loader.BlockLoader;
 import org.opensearch.index.store.block_loader.CryptoDirectIOBlockLoader;
+import org.opensearch.index.store.block_loader.FileChannelCache;
 import org.opensearch.index.store.bufferpoolfs.BufferPoolDirectory;
 import org.opensearch.index.store.cipher.EncryptionMetadataCache;
 import org.opensearch.index.store.cipher.EncryptionMetadataCacheRegistry;
@@ -498,7 +499,8 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
         BlockLoader<RefCountedMemorySegment> loader = new CryptoDirectIOBlockLoader(
             resources.getSegmentPool(),
             keyResolver,
-            encryptionMetadataCache
+            encryptionMetadataCache,
+            resources.getFileChannelCache()
         );
 
         // Cache architecture: One shared Caffeine cache storage, multiple wrapper instances
@@ -530,7 +532,8 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
             directoryCache,
             loader,
             readaheadWorker,
-            encryptionMetadataCache
+            encryptionMetadataCache,
+            resources.getFileChannelCache()
         );
     }
 
@@ -617,5 +620,12 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
      */
     public static BlockCache<?> getSharedBlockCache() {
         return poolResources != null ? poolResources.getBlockCache() : null;
+    }
+
+    /**
+     * Returns the shared node-level FileChannelCache, or null if not yet initialized.
+     */
+    public static FileChannelCache getSharedFileChannelCache() {
+        return poolResources != null ? poolResources.getFileChannelCache() : null;
     }
 }

--- a/src/main/java/org/opensearch/index/store/CryptoDirectoryPlugin.java
+++ b/src/main/java/org/opensearch/index/store/CryptoDirectoryPlugin.java
@@ -35,6 +35,7 @@ import org.opensearch.index.shard.IndexEventListener;
 import org.opensearch.index.store.action.GetIndexCountForKeyAction;
 import org.opensearch.index.store.action.TransportGetIndexCountForKeyAction;
 import org.opensearch.index.store.block_cache.BlockCache;
+import org.opensearch.index.store.block_loader.FileChannelCache;
 import org.opensearch.index.store.key.MasterKeyHealthMonitor;
 import org.opensearch.index.store.key.NodeLevelKeyCache;
 import org.opensearch.index.store.key.ShardKeyResolverRegistry;
@@ -145,7 +146,9 @@ public class CryptoDirectoryPlugin extends Plugin implements IndexStorePlugin, E
                 CryptoDirectoryFactory.WRITE_CACHE_ENABLED_SETTING,
                 PoolSizeCalculator.NODE_POOL_SIZE_PERCENTAGE_SETTING,
                 PoolSizeCalculator.NODE_CACHE_TO_POOL_RATIO_SETTING,
-                PoolSizeCalculator.NODE_WARMUP_PERCENTAGE_SETTING
+                PoolSizeCalculator.NODE_WARMUP_PERCENTAGE_SETTING,
+                PoolSizeCalculator.NODE_MAX_FILE_CHANNELS_SETTING,
+                PoolSizeCalculator.NODE_FD_CACHE_EXPIRE_SECONDS_SETTING
             );
         return settings;
     }
@@ -291,6 +294,14 @@ public class CryptoDirectoryPlugin extends Plugin implements IndexStorePlugin, E
                     if (cache != null && nodeEnvironment != null) {
                         for (Path indexPath : nodeEnvironment.indexPaths(index)) {
                             cache.invalidateByPathPrefix(indexPath);
+                        }
+                    }
+
+                    // Invalidate FD cache entries for all files in the deleted index
+                    FileChannelCache fdCache = CryptoDirectoryFactory.getSharedFileChannelCache();
+                    if (fdCache != null && nodeEnvironment != null) {
+                        for (Path indexPath : nodeEnvironment.indexPaths(index)) {
+                            fdCache.invalidateByPathPrefix(indexPath);
                         }
                     }
 

--- a/src/main/java/org/opensearch/index/store/block_loader/CryptoDirectIOBlockLoader.java
+++ b/src/main/java/org/opensearch/index/store/block_loader/CryptoDirectIOBlockLoader.java
@@ -44,6 +44,7 @@ import org.opensearch.index.store.pool.Pool;
  * <li>Automatic in-place decryption of loaded blocks</li>
  * <li>Memory pool integration for efficient buffer management</li>
  * <li>Block-aligned operations for optimal storage performance</li>
+ * <li>Cached FileChannels via {@link FileChannelCache} to avoid per-load open/close overhead</li>
  * </ul>
  *
  * @opensearch.internal
@@ -55,21 +56,26 @@ public class CryptoDirectIOBlockLoader implements BlockLoader<RefCountedMemorySe
     private final KeyResolver keyResolver;
     private final Pool<RefCountedMemorySegment> segmentPool;
     private final EncryptionMetadataCache encryptionMetadataCache;
+    private final FileChannelCache fileChannelCache;
 
     /**
      * Constructs a new CryptoDirectIOBlockLoader with the specified memory pool and key resolver.
      *
      * @param segmentPool the memory segment pool for acquiring buffer space
      * @param keyResolver the resolver for obtaining encryption keys and initialization vectors
+     * @param encryptionMetadataCache cache for encryption metadata
+     * @param fileChannelCache node-level cache of FileChannels bounded by max open FDs
      */
     public CryptoDirectIOBlockLoader(
         Pool<RefCountedMemorySegment> segmentPool,
         KeyResolver keyResolver,
-        EncryptionMetadataCache encryptionMetadataCache
+        EncryptionMetadataCache encryptionMetadataCache,
+        FileChannelCache fileChannelCache
     ) {
         this.segmentPool = segmentPool;
         this.keyResolver = keyResolver;
         this.encryptionMetadataCache = encryptionMetadataCache;
+        this.fileChannelCache = fileChannelCache;
     }
 
     @Override
@@ -88,19 +94,16 @@ public class CryptoDirectIOBlockLoader implements BlockLoader<RefCountedMemorySe
 
         RefCountedMemorySegment[] result = new RefCountedMemorySegment[(int) blockCount];
         long readLength = blockCount << CACHE_BLOCK_SIZE_POWER;
+        String normalizedPath = filePath.toAbsolutePath().normalize().toString();
 
-        try (
-            Arena arena = Arena.ofConfined();
-            FileChannel channel = FileChannel.open(filePath, StandardOpenOption.READ, DirectIOReaderUtil.getDirectOpenOption())
-        ) {
-            MemorySegment readBytes = directIOReadAligned(channel, filePath, startOffset, readLength, arena);
+        try (Arena arena = Arena.ofConfined(); RefCountedChannel ref = fileChannelCache.acquire(normalizedPath)) {
+            MemorySegment readBytes = directIOReadAligned(ref.channel(), filePath, startOffset, readLength, arena);
             long bytesRead = readBytes.byteSize();
 
-            String normalizedPath = filePath.toAbsolutePath().normalize().toString();
             byte[] masterKey = keyResolver.getDataKey().getEncoded();
 
             // Get footer from disk and load metadata (footer + derived key) atomically into cache
-            EncryptionFooter footer = readFooterFromDisk(filePath, masterKey);
+            EncryptionFooter footer = readFooterFromDisk(normalizedPath, filePath, masterKey);
 
             // Get or create metadata atomically - ensures footer and key are always consistent
             var metadata = encryptionMetadataCache.getOrLoadMetadata(normalizedPath, footer, masterKey);
@@ -112,12 +115,12 @@ public class CryptoDirectIOBlockLoader implements BlockLoader<RefCountedMemorySe
                 .decryptInPlaceFrameBased(
                     readBytes.address(),
                     readBytes.byteSize(),
-                    fileKey,                                    // Derived file key (matches write path)
-                    masterKey,                                  // Master key for IV computation
-                    messageId,                                  // Message ID from footer
-                    org.opensearch.index.store.footer.EncryptionMetadataTrailer.DEFAULT_FRAME_SIZE, // Frame size
-                    startOffset,                                 // File offset
-                    filePath.toAbsolutePath().normalize().toString(),
+                    fileKey,
+                    masterKey,
+                    messageId,
+                    EncryptionMetadataTrailer.DEFAULT_FRAME_SIZE,
+                    startOffset,
+                    normalizedPath,
                     encryptionMetadataCache
                 );
 
@@ -130,9 +133,7 @@ public class CryptoDirectIOBlockLoader implements BlockLoader<RefCountedMemorySe
 
             try {
                 while (blockIndex < blockCount && bytesCopied < bytesRead) {
-                    // Use caller-specified timeout (5s for critical loads, 50ms for prefetch)
                     RefCountedMemorySegment handle = segmentPool.tryAcquire(poolTimeoutMs, TimeUnit.MILLISECONDS);
-
                     MemorySegment pooled = handle.segment();
 
                     int remaining = (int) (bytesRead - bytesCopied);
@@ -142,10 +143,9 @@ public class CryptoDirectIOBlockLoader implements BlockLoader<RefCountedMemorySe
                         MemorySegment.copy(readBytes, bytesCopied, pooled, 0, toCopy);
                     }
 
-                    result[blockIndex++] = handle;  // Store the handle, not the segment
+                    result[blockIndex++] = handle;
                     bytesCopied += toCopy;
                 }
-
             } catch (InterruptedException e) {
                 releaseHandles(result, blockIndex);
                 Thread.currentThread().interrupt();
@@ -156,7 +156,6 @@ public class CryptoDirectIOBlockLoader implements BlockLoader<RefCountedMemorySe
             }
 
             return result;
-
         } catch (NoSuchFileException e) {
             throw e;
         } catch (Exception e) {
@@ -173,16 +172,14 @@ public class CryptoDirectIOBlockLoader implements BlockLoader<RefCountedMemorySe
         }
     }
 
-    private EncryptionFooter readFooterFromDisk(Path filePath, byte[] masterKey) throws IOException {
-        String normalizedPath = filePath.toAbsolutePath().normalize().toString();
-
+    private EncryptionFooter readFooterFromDisk(String normalizedPath, Path filePath, byte[] masterKey) throws IOException {
         // Check cache first for fast path
         EncryptionFooter cachedFooter = encryptionMetadataCache.getFooter(normalizedPath);
         if (cachedFooter != null) {
             return cachedFooter;
         }
 
-        // Cache miss - read from disk
+        // Cache miss - read from disk using a buffered channel (footer reads are small, no O_DIRECT needed)
         try (FileChannel channel = FileChannel.open(filePath, StandardOpenOption.READ)) {
             long fileSize = channel.size();
             if (fileSize < EncryptionMetadataTrailer.MIN_FOOTER_SIZE) {
@@ -196,7 +193,6 @@ public class CryptoDirectIOBlockLoader implements BlockLoader<RefCountedMemorySe
 
             // Check if this is an OSEF file
             if (!isValidOSEFFile(minFooterBytes)) {
-                // Not an OSEF file
                 throw new IOException("Not an OSEF file -" + filePath);
             }
 

--- a/src/main/java/org/opensearch/index/store/block_loader/FileChannelCache.java
+++ b/src/main/java/org/opensearch/index/store/block_loader/FileChannelCache.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.block_loader;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.TimeUnit;
+
+import org.opensearch.index.store.metrics.CryptoMetricsService;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+
+/**
+ * Node-level cache of {@link FileChannel} instances, bounded by max open FDs
+ * and optional time-based expiry for idle channels.
+ *
+ * <p>Each cached entry is a {@link RefCountedChannel}. The cache holds one "base"
+ * reference. When Caffeine evicts an entry (size pressure, time expiry, or explicit
+ * invalidation), the base ref is released via {@link RefCountedChannel#releaseBase()}.
+ * If no I/O is in flight, the FileChannel closes immediately. If I/O is in flight,
+ * the channel stays open until the last I/O completes.
+ *
+ * <p>Eviction policies (both active simultaneously):
+ * <ul>
+ *   <li>Size-based: LRU eviction when cache reaches {@code maxOpenFDs}</li>
+ *   <li>Time-based: channels not accessed within {@code expireAfterAccessSeconds}
+ *       are evicted (disabled when set to 0)</li>
+ * </ul>
+ *
+ * <p>Usage pattern in BlockLoader:
+ * <pre>{@code
+ *   try (RefCountedChannel ref = fileChannelCache.acquire(path)) {
+ *       ref.channel().read(buf, offset);
+ *   }
+ * }</pre>
+ *
+ * <p>For bulk cleanup (e.g., storage migration): call {@link #close()} which
+ * invalidates all entries. Idle channels close immediately. In-flight channels
+ * close when I/O finishes.
+ */
+public class FileChannelCache implements Closeable {
+
+    private static final int MAX_ACQUIRE_RETRIES = 3;
+
+    private final Cache<String, RefCountedChannel> fdCache;
+    private final OpenOption directOpenOption;
+
+    /**
+     * @param maxOpenFDs maximum number of cached FileChannels
+     * @param expireAfterAccessSeconds seconds of idle time before a channel is evicted (0 to disable)
+     * @param directOpenOption the O_DIRECT open option, or null for buffered I/O
+     */
+    public FileChannelCache(int maxOpenFDs, long expireAfterAccessSeconds, OpenOption directOpenOption) {
+        this.directOpenOption = directOpenOption;
+        Caffeine<String, RefCountedChannel> builder = Caffeine
+            .newBuilder()
+            .maximumSize(maxOpenFDs)
+            .recordStats()
+            .evictionListener((String path, RefCountedChannel ref, RemovalCause cause) -> {
+                // evictionListener fires synchronously and ONLY for automatic evictions
+                // (size pressure, time expiry). Manual invalidations are handled explicitly
+                // in invalidate(), invalidateByPathPrefix(), and close() to guarantee
+                // synchronous FileChannel closure and avoid FD leaks.
+                if (ref != null) {
+                    ref.releaseBase();
+                }
+            });
+        if (expireAfterAccessSeconds > 0) {
+            builder.expireAfterAccess(expireAfterAccessSeconds, TimeUnit.SECONDS);
+        }
+        this.fdCache = builder.build();
+    }
+
+    /**
+     * Convenience constructor without time-based expiry (size-based eviction only).
+     * Primarily for tests.
+     *
+     * @param maxOpenFDs maximum number of cached FileChannels
+     * @param directOpenOption the O_DIRECT open option, or null for buffered I/O
+     */
+    public FileChannelCache(int maxOpenFDs, OpenOption directOpenOption) {
+        this(maxOpenFDs, 0, directOpenOption);
+    }
+
+    /**
+     * Acquire a {@link RefCountedChannel} for the given path. The returned ref
+     * has already been acquired (refCount incremented) and MUST be closed when
+     * done, typically via try-with-resources.
+     *
+     * <p>If the cached entry was concurrently evicted (stale), this method
+     * transparently evicts the stale entry and retries up to {@link #MAX_ACQUIRE_RETRIES} times.
+     *
+     * @param normalizedPath the absolute normalized file path
+     * @return an acquired RefCountedChannel — never null
+     * @throws IOException if the channel cannot be opened or acquired after retries
+     */
+    public RefCountedChannel acquire(String normalizedPath) throws IOException {
+        for (int attempt = 0; attempt < MAX_ACQUIRE_RETRIES; attempt++) {
+            RefCountedChannel ref;
+            try {
+                ref = fdCache.get(normalizedPath, this::openChannel);
+            } catch (RuntimeException e) {
+                // Caffeine wraps loader exceptions in RuntimeException.
+                // Unwrap so callers see the original IOException (e.g., NoSuchFileException).
+                if (e.getCause() instanceof IOException ioe) {
+                    throw ioe;
+                }
+                throw e;
+            }
+            try {
+                return ref.acquire();
+            } catch (IllegalStateException e) {
+                // Stale entry — evict and release its base ref to close the FD.
+                // asMap().remove(key, value) is a conditional remove — only removes
+                // if the mapping still points to this exact ref (avoids racing with
+                // a concurrent loader that already replaced it).
+                if (fdCache.asMap().remove(normalizedPath, ref)) {
+                    ref.releaseBase();
+                }
+            }
+        }
+        throw new IOException("Failed to acquire FileChannel after " + MAX_ACQUIRE_RETRIES + " retries: " + normalizedPath);
+    }
+
+    /**
+     * Invalidate the cached channel for a specific path.
+     * Synchronously releases the base reference to close the FileChannel
+     * (or mark it for deferred close if I/O is in flight).
+     */
+    public void invalidate(String normalizedPath) {
+        RefCountedChannel ref = fdCache.asMap().remove(normalizedPath);
+        if (ref != null) {
+            ref.releaseBase();
+        }
+    }
+
+    /**
+     * Invalidate all cached channels whose path starts with the given prefix.
+     * Used when a shard directory is closed or an index is deleted.
+     * Synchronously releases base references for all matching entries.
+     *
+     * @param prefix the directory path prefix (e.g., shard or index directory)
+     */
+    public void invalidateByPathPrefix(Path prefix) {
+        String normalized = prefix.toAbsolutePath().normalize().toString();
+        // Ensure prefix ends with separator to avoid matching /indices/abc when prefix is /indices/ab
+        String prefixStr = normalized.endsWith("/") ? normalized : normalized + "/";
+        var iterator = fdCache.asMap().entrySet().iterator();
+        while (iterator.hasNext()) {
+            var entry = iterator.next();
+            if (entry.getKey().startsWith(prefixStr)) {
+                iterator.remove();
+                entry.getValue().releaseBase();
+            }
+        }
+    }
+
+    /**
+     * Returns the estimated number of entries in the cache.
+     */
+    public long estimatedSize() {
+        return fdCache.estimatedSize();
+    }
+
+    /**
+     * Trigger pending maintenance operations (evictions, size recalculation).
+     * Caffeine caches are lazy — this forces immediate processing.
+     */
+    public void cleanUp() {
+        fdCache.cleanUp();
+    }
+
+    /**
+     * Publish FD cache statistics to the metrics service.
+     */
+    public void recordStats() {
+        var stats = fdCache.stats();
+        try {
+            CryptoMetricsService
+                .getInstance()
+                .recordFdCacheStats(
+                    fdCache.estimatedSize(),
+                    stats.hitCount(),
+                    stats.missCount(),
+                    stats.hitRate() * 100,
+                    stats.evictionCount()
+                );
+        } catch (IllegalStateException e) {
+            // Metrics not initialized yet — skip
+        }
+    }
+
+    private RefCountedChannel openChannel(String path) {
+        try {
+            FileChannel fc;
+            if (directOpenOption != null) {
+                fc = FileChannel.open(Paths.get(path), StandardOpenOption.READ, directOpenOption);
+            } else {
+                fc = FileChannel.open(Paths.get(path), StandardOpenOption.READ);
+            }
+            return new RefCountedChannel(fc);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to open FileChannel: " + path, e);
+        }
+    }
+
+    @Override
+    public void close() {
+        // Synchronously release all base refs to close idle channels immediately
+        var iterator = fdCache.asMap().entrySet().iterator();
+        while (iterator.hasNext()) {
+            var entry = iterator.next();
+            iterator.remove();
+            entry.getValue().releaseBase();
+        }
+        fdCache.cleanUp();
+    }
+}

--- a/src/main/java/org/opensearch/index/store/block_loader/RefCountedChannel.java
+++ b/src/main/java/org/opensearch/index/store/block_loader/RefCountedChannel.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.block_loader;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A reference-counted wrapper around a {@link FileChannel} that guarantees
+ * the underlying channel stays open for the duration of any in-flight I/O.
+ *
+ * <p>Lifecycle:
+ * <ol>
+ *   <li>Created with refCount=1 (the cache's "base" reference).</li>
+ *   <li>Each in-flight I/O calls {@link #acquire()} which atomically increments
+ *       the refCount and returns the FileChannel. Acquire never returns null —
+ *       if the channel is already dead (refCount ≤ 0), it throws.</li>
+ *   <li>When I/O completes, {@link #close()} (AutoCloseable) decrements the refCount.</li>
+ *   <li>When the cache evicts this entry, it calls {@link #releaseBase()} to drop
+ *       the base ref. If no I/O is in flight, the FileChannel closes immediately.
+ *       Otherwise it closes when the last I/O calls {@link #close()}.</li>
+ * </ol>
+ *
+ * <p>Usage:
+ * <pre>{@code
+ *   try (RefCountedChannel ref = fileChannelCache.acquire(path)) {
+ *       FileChannel fc = ref.channel();
+ *       fc.read(buf, offset);
+ *   }
+ * }</pre>
+ */
+public class RefCountedChannel implements AutoCloseable {
+
+    private final FileChannel channel;
+    private final AtomicInteger refCount;
+
+    public RefCountedChannel(FileChannel channel) {
+        this.channel = channel;
+        this.refCount = new AtomicInteger(1);
+    }
+
+    /**
+     * Increment refCount for an in-flight I/O operation and return this instance.
+     * The caller MUST call {@link #close()} when done (typically via try-with-resources).
+     *
+     * @return this RefCountedChannel (never null)
+     * @throws IllegalStateException if the channel is already dead (refCount ≤ 0)
+     */
+    public RefCountedChannel acquire() {
+        while (true) {
+            int current = refCount.get();
+            if (current <= 0) {
+                throw new IllegalStateException("RefCountedChannel already closed");
+            }
+            if (refCount.compareAndSet(current, current + 1)) {
+                return this;
+            }
+        }
+    }
+
+    /**
+     * Returns the underlying FileChannel. Guaranteed open while this ref is acquired.
+     */
+    public FileChannel channel() {
+        return channel;
+    }
+
+    /**
+     * Check if this channel is still alive (refCount > 0).
+     */
+    boolean isAlive() {
+        return refCount.get() > 0;
+    }
+
+    /**
+     * Release one I/O reference. Called automatically via try-with-resources.
+     * Closes the FileChannel when the last reference (including the base) is released.
+     */
+    @Override
+    public void close() {
+        while (true) {
+            int current = refCount.get();
+            if (current <= 0) {
+                return; // Already fully released — guard against double-release
+            }
+            if (refCount.compareAndSet(current, current - 1)) {
+                if (current == 1) {
+                    try {
+                        channel.close();
+                    } catch (IOException ignored) {
+                        // Best-effort close
+                    }
+                }
+                return;
+            }
+        }
+    }
+
+    /**
+     * Release the cache's base reference. Called by the cache eviction listener.
+     * Same as {@link #close()} but named for clarity at the call site.
+     */
+    void releaseBase() {
+        close();
+    }
+}

--- a/src/main/java/org/opensearch/index/store/bufferpoolfs/BufferPoolDirectory.java
+++ b/src/main/java/org/opensearch/index/store/bufferpoolfs/BufferPoolDirectory.java
@@ -30,6 +30,7 @@ import org.opensearch.index.store.block_cache.BlockCache;
 import org.opensearch.index.store.block_cache.CaffeineBlockCache;
 import org.opensearch.index.store.block_cache.FileBlockCacheKey;
 import org.opensearch.index.store.block_loader.BlockLoader;
+import org.opensearch.index.store.block_loader.FileChannelCache;
 import org.opensearch.index.store.cipher.EncryptionMetadataCache;
 import org.opensearch.index.store.footer.EncryptionFooter;
 import org.opensearch.index.store.footer.EncryptionMetadataTrailer;
@@ -76,6 +77,7 @@ public class BufferPoolDirectory extends FSDirectory {
     private final Path dirPath;
     private final byte[] masterKeyBytes;
     private final EncryptionMetadataCache encryptionMetadataCache;
+    private final FileChannelCache fileChannelCache;
 
     /**
      * Creates a new CryptoDirectIODirectory with the specified components.
@@ -99,7 +101,8 @@ public class BufferPoolDirectory extends FSDirectory {
         BlockCache<RefCountedMemorySegment> blockCache,
         BlockLoader<RefCountedMemorySegment> blockLoader,
         Worker worker,
-        EncryptionMetadataCache encryptionMetadataCache
+        EncryptionMetadataCache encryptionMetadataCache,
+        FileChannelCache fileChannelCache
     )
         throws IOException {
         super(path, lockFactory);
@@ -110,6 +113,7 @@ public class BufferPoolDirectory extends FSDirectory {
         this.dirPath = getDirectory();
         this.masterKeyBytes = keyResolver.getDataKey().getEncoded();
         this.encryptionMetadataCache = encryptionMetadataCache;
+        this.fileChannelCache = fileChannelCache;
 
         // startCacheStatsTelemetry(); // uncomment for local testing
     }
@@ -212,6 +216,15 @@ public class BufferPoolDirectory extends FSDirectory {
         if (blockCache != null) {
             blockCache.invalidateByPathPrefix(dirPath);
         }
+
+        // Invalidate all FD cache entries for files in this directory.
+        // Idle channels close immediately; in-flight channels close when I/O finishes.
+        if (fileChannelCache != null) {
+            fileChannelCache.invalidateByPathPrefix(dirPath);
+        }
+
+        // Mark directory as closed so ensureOpen() throws AlreadyClosedException
+        super.close();
     }
 
     @Override
@@ -240,6 +253,11 @@ public class BufferPoolDirectory extends FSDirectory {
         }
         super.deleteFile(name);
         encryptionMetadataCache.invalidateFile(EncryptionMetadataCache.normalizePath(file));
+
+        // Invalidate the FD cache entry for the deleted file
+        if (fileChannelCache != null) {
+            fileChannelCache.invalidate(file.toAbsolutePath().normalize().toString());
+        }
     }
 
     /**

--- a/src/main/java/org/opensearch/index/store/bufferpoolfs/StaticConfigs.java
+++ b/src/main/java/org/opensearch/index/store/bufferpoolfs/StaticConfigs.java
@@ -60,6 +60,18 @@ public class StaticConfigs {
     public static final long CACHE_BLOCK_MASK = CACHE_BLOCK_SIZE - 1;
 
     /**
+     * Default maximum number of cached FileChannels in the node-level FileChannelCache.
+     */
+    public static final int DEFAULT_MAX_FILE_CHANNELS = 256;
+
+    /**
+     * Default expiry time in seconds for idle FileChannels in the FileChannelCache.
+     * Channels not accessed within this duration are evicted. 300s (5 min) balances
+     * FD reuse for active shards with timely cleanup for idle ones.
+     */
+    public static final long DEFAULT_FD_CACHE_EXPIRE_AFTER_ACCESS_SECONDS = 300;
+
+    /**
      * Returns the correct Direct I/O alignment for the filesystem containing the given path.
      *
      * <p>Direct I/O requires buffers and offsets to be aligned to the filesystem's logical

--- a/src/main/java/org/opensearch/index/store/metrics/CryptoMetricsService.java
+++ b/src/main/java/org/opensearch/index/store/metrics/CryptoMetricsService.java
@@ -21,16 +21,19 @@ public class CryptoMetricsService {
     private final MetricsRegistry metricsRegistry;
     private final Histogram poolStatsHistogram;
     private final Histogram cacheStatsHistogram;
+    private final Histogram fdCacheStatsHistogram;
     private final Counter errorCounter;
 
     // Metric names
     private static final String POOL_STATS_NAME = "crypto.pool.stats";
     private static final String CACHE_STATS_NAME = "crypto.cache.stats";
+    private static final String FD_CACHE_STATS_NAME = "crypto.fd_cache.stats";
     private static final String ERROR_COUNTER_NAME = "crypto.error.total";
 
     // Metric descriptions
     private static final String POOL_STATS_DESC = "Crypto Pool statistics";
     private static final String CACHE_STATS_DESC = "Crypto Cache statistics";
+    private static final String FD_CACHE_STATS_DESC = "FileChannel cache statistics";
     private static final String ERROR_COUNTER_DESC = "Total crypto operation errors";
 
     // Units
@@ -53,6 +56,7 @@ public class CryptoMetricsService {
         this.errorCounter = createCounter(ERROR_COUNTER_NAME, ERROR_COUNTER_DESC, COUNT_UNIT);
         this.poolStatsHistogram = createHistogram(POOL_STATS_NAME, POOL_STATS_DESC, COUNT_UNIT);
         this.cacheStatsHistogram = createHistogram(CACHE_STATS_NAME, CACHE_STATS_DESC, COUNT_UNIT);
+        this.fdCacheStatsHistogram = createHistogram(FD_CACHE_STATS_NAME, FD_CACHE_STATS_DESC, COUNT_UNIT);
     }
 
     /**
@@ -118,6 +122,25 @@ public class CryptoMetricsService {
         cacheStatsHistogram.record(loads, Tags.create().addTag(STAT_TYPE_TAG, "loads"));
         cacheStatsHistogram.record(evictions, Tags.create().addTag(STAT_TYPE_TAG, "evictions"));
         cacheStatsHistogram.record(avgLoadTimeMs, Tags.create().addTag(STAT_TYPE_TAG, "avg_load_time"));
+    }
+
+    /**
+     * Records FileChannel cache statistics.
+     * @param size current number of cached channels
+     * @param hits hit count
+     * @param misses miss count
+     * @param hitRate hit rate percentage (0-100)
+     * @param evictions eviction count
+     */
+    public void recordFdCacheStats(long size, long hits, long misses, double hitRate, long evictions) {
+        if (fdCacheStatsHistogram == null)
+            return;
+
+        fdCacheStatsHistogram.record(size, Tags.create().addTag(STAT_TYPE_TAG, "size"));
+        fdCacheStatsHistogram.record(hits, Tags.create().addTag(STAT_TYPE_TAG, "hits"));
+        fdCacheStatsHistogram.record(misses, Tags.create().addTag(STAT_TYPE_TAG, "misses"));
+        fdCacheStatsHistogram.record(hitRate, Tags.create().addTag(STAT_TYPE_TAG, "hit_rate"));
+        fdCacheStatsHistogram.record(evictions, Tags.create().addTag(STAT_TYPE_TAG, "evictions"));
     }
 
     /**

--- a/src/main/java/org/opensearch/index/store/pool/PoolBuilder.java
+++ b/src/main/java/org/opensearch/index/store/pool/PoolBuilder.java
@@ -18,6 +18,8 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.index.store.block.RefCountedMemorySegment;
 import org.opensearch.index.store.block_cache.BlockCache;
 import org.opensearch.index.store.block_cache.BlockCacheBuilder;
+import org.opensearch.index.store.block_loader.DirectIOReaderUtil;
+import org.opensearch.index.store.block_loader.FileChannelCache;
 import org.opensearch.index.store.read_ahead.Worker;
 import org.opensearch.index.store.read_ahead.impl.QueuingWorker;
 import org.opensearch.index.store.read_ahead.impl.ReadAheadSizingPolicy;
@@ -53,6 +55,7 @@ public final class PoolBuilder {
         private final TelemetryThread telemetry;
         private final java.util.concurrent.ThreadPoolExecutor removalExecutor;
         private final ExecutorService readAheadExecutor;
+        private final FileChannelCache fileChannelCache;
 
         PoolResources(
             Pool<RefCountedMemorySegment> segmentPool,
@@ -62,7 +65,8 @@ public final class PoolBuilder {
             Worker sharedReadaheadWorker,
             TelemetryThread telemetry,
             java.util.concurrent.ThreadPoolExecutor removalExecutor,
-            ExecutorService readAheadExecutor
+            ExecutorService readAheadExecutor,
+            FileChannelCache fileChannelCache
         ) {
             this.segmentPool = segmentPool;
             this.blockCache = blockCache;
@@ -72,6 +76,7 @@ public final class PoolBuilder {
             this.telemetry = telemetry;
             this.removalExecutor = removalExecutor;
             this.readAheadExecutor = readAheadExecutor;
+            this.fileChannelCache = fileChannelCache;
         }
 
         /**
@@ -131,10 +136,23 @@ public final class PoolBuilder {
         }
 
         /**
+         * Returns the shared FileChannel cache.
+         * Node-level cache of FileChannels bounded by max open FDs.
+         *
+         * @return the file channel cache
+         */
+        public FileChannelCache getFileChannelCache() {
+            return fileChannelCache;
+        }
+
+        /**
          * Closes the shared pool resources, stops the telemetry thread, and shuts down executors.
          */
         @Override
         public void close() {
+            if (fileChannelCache != null) {
+                fileChannelCache.close();
+            }
             if (telemetry != null) {
                 telemetry.close();
             }
@@ -177,10 +195,16 @@ public final class PoolBuilder {
         private final Thread thread;
         private final Pool<RefCountedMemorySegment> pool;
         private final BlockCache<RefCountedMemorySegment> blockCache;
+        private final FileChannelCache fileChannelCache;
 
-        TelemetryThread(Pool<RefCountedMemorySegment> pool, BlockCache<RefCountedMemorySegment> blockCache) {
+        TelemetryThread(
+            Pool<RefCountedMemorySegment> pool,
+            BlockCache<RefCountedMemorySegment> blockCache,
+            FileChannelCache fileChannelCache
+        ) {
             this.pool = pool;
             this.blockCache = blockCache;
+            this.fileChannelCache = fileChannelCache;
             this.thread = new Thread(this::run);
             this.thread.setDaemon(true);
             this.thread.setName("DirectIOBufferPoolStatsLogger");
@@ -205,6 +229,9 @@ public final class PoolBuilder {
             try {
                 pool.recordStats();
                 blockCache.recordStats();
+                if (fileChannelCache != null) {
+                    fileChannelCache.recordStats();
+                }
             } catch (Exception e) {
                 LOGGER.warn("Failed to log cache/pool stats", e);
             }
@@ -288,8 +315,21 @@ public final class PoolBuilder {
         Worker sharedReadaheadWorker = new QueuingWorker(readAheadQueueSize, readAheadExecutor);
         LOGGER.info("Created shared read-ahead worker: queueSize={} executorThreads={}", readAheadQueueSize, threads);
 
+        // Create node-level FileChannel cache with O_DIRECT support
+        int maxFileChannels = PoolSizeCalculator.NODE_MAX_FILE_CHANNELS_SETTING.get(settings);
+        long fdCacheExpireSeconds = PoolSizeCalculator.NODE_FD_CACHE_EXPIRE_SECONDS_SETTING.get(settings);
+        java.nio.file.OpenOption directOpenOption;
+        try {
+            directOpenOption = DirectIOReaderUtil.getDirectOpenOption();
+        } catch (UnsupportedOperationException e) {
+            LOGGER.warn("Direct I/O not available, FileChannelCache will use buffered I/O");
+            directOpenOption = null;
+        }
+        FileChannelCache fileChannelCache = new FileChannelCache(maxFileChannels, fdCacheExpireSeconds, directOpenOption);
+        LOGGER.info("Created shared FileChannel cache: maxOpenFDs={}, expireAfterAccessSeconds={}", maxFileChannels, fdCacheExpireSeconds);
+
         // Start telemetry
-        TelemetryThread telemetry = new TelemetryThread(segmentPool, blockCache);
+        TelemetryThread telemetry = new TelemetryThread(segmentPool, blockCache, fileChannelCache);
 
         return new PoolResources(
             segmentPool,
@@ -299,7 +339,8 @@ public final class PoolBuilder {
             sharedReadaheadWorker,
             telemetry,
             removalExecutor,
-            readAheadExecutor
+            readAheadExecutor,
+            fileChannelCache
         );
     }
 }

--- a/src/main/java/org/opensearch/index/store/pool/PoolSizeCalculator.java
+++ b/src/main/java/org/opensearch/index/store/pool/PoolSizeCalculator.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.index.store.bufferpoolfs.StaticConfigs;
 import org.opensearch.monitor.os.OsProbe;
 
 /**
@@ -46,6 +47,27 @@ public final class PoolSizeCalculator {
      */
     public static final Setting<Double> NODE_WARMUP_PERCENTAGE_SETTING = Setting
         .doubleSetting("node.store.crypto.warmup_percentage", 0.05, 0.0, 1.0, Property.NodeScope);
+
+    /**
+     * Maximum number of cached FileChannels in the node-level FileChannelCache.
+     * Default is {@link StaticConfigs#DEFAULT_MAX_FILE_CHANNELS} (256).
+     */
+    public static final Setting<Integer> NODE_MAX_FILE_CHANNELS_SETTING = Setting
+        .intSetting("node.store.crypto.max_file_channels", StaticConfigs.DEFAULT_MAX_FILE_CHANNELS, 1, Property.NodeScope);
+
+    /**
+     * Expiry time in seconds for idle FileChannels in the FileChannelCache.
+     * Channels not accessed within this duration are evicted.
+     * Default is {@link StaticConfigs#DEFAULT_FD_CACHE_EXPIRE_AFTER_ACCESS_SECONDS} (300s).
+     * Set to 0 to disable time-based expiry (size-based eviction only).
+     */
+    public static final Setting<Long> NODE_FD_CACHE_EXPIRE_SECONDS_SETTING = Setting
+        .longSetting(
+            "node.store.crypto.fd_cache_expire_after_access_seconds",
+            StaticConfigs.DEFAULT_FD_CACHE_EXPIRE_AFTER_ACCESS_SECONDS,
+            0L,
+            Property.NodeScope
+        );
 
     private static final long MB_TO_BYTES = 1024L * 1024L;
     private static final long GB_TO_BYTES = 1024L * 1024L * 1024L;

--- a/src/test/java/org/opensearch/index/store/CryptoDirectoryEncryptionTests.java
+++ b/src/test/java/org/opensearch/index/store/CryptoDirectoryEncryptionTests.java
@@ -89,6 +89,7 @@ public class CryptoDirectoryEncryptionTests extends OpenSearchTestCase {
     private Pool<RefCountedMemorySegment> memorySegmentPool;
     private CaffeineBlockCache<RefCountedMemorySegment, RefCountedMemorySegment> blockCache;
     private Worker readAheadWorker;
+    private org.opensearch.index.store.block_loader.FileChannelCache fileChannelCache;
 
     /**
      * Helper method to register the resolver in the ShardKeyResolverRegistry
@@ -153,6 +154,9 @@ public class CryptoDirectoryEncryptionTests extends OpenSearchTestCase {
             131072, // total memory in bytes (16 * 8192)
             8192    // segment size (block size)
         );
+
+        // Create a FileChannelCache for tests (no O_DIRECT in test env)
+        fileChannelCache = new org.opensearch.index.store.block_loader.FileChannelCache(256, null);
 
         // Create first key provider (Key A) with specific key bytes
         keyProviderA = new MasterKeyProvider() {
@@ -243,6 +247,9 @@ public class CryptoDirectoryEncryptionTests extends OpenSearchTestCase {
     @Override
     public void tearDown() throws Exception {
         // Clean up DirectIO resources
+        if (fileChannelCache != null) {
+            fileChannelCache.close();
+        }
         if (readAheadWorker != null) {
             readAheadWorker.close();
         }
@@ -454,7 +461,8 @@ public class CryptoDirectoryEncryptionTests extends OpenSearchTestCase {
         BlockLoader<RefCountedMemorySegment> blockLoaderA = new CryptoDirectIOBlockLoader(
             memorySegmentPool,
             keyResolverA,
-            encryptionMetadataCache
+            encryptionMetadataCache,
+            fileChannelCache
         );
 
         // Create per-directory cache and worker
@@ -488,7 +496,8 @@ public class CryptoDirectoryEncryptionTests extends OpenSearchTestCase {
                 blockCacheA,
                 blockLoaderA,
                 readAheadWorkerA,
-                encryptionMetadataCache
+                encryptionMetadataCache,
+                fileChannelCache
             )
         ) {
             // Write data
@@ -532,7 +541,8 @@ public class CryptoDirectoryEncryptionTests extends OpenSearchTestCase {
         BlockLoader<RefCountedMemorySegment> blockLoaderA = new CryptoDirectIOBlockLoader(
             memorySegmentPool,
             keyResolverA,
-            encryptionMetadataCache
+            encryptionMetadataCache,
+            fileChannelCache
         );
 
         // Create per-directory cache and worker
@@ -566,7 +576,8 @@ public class CryptoDirectoryEncryptionTests extends OpenSearchTestCase {
                 blockCacheA,
                 blockLoaderA,
                 readAheadWorkerA,
-                encryptionMetadataCache
+                encryptionMetadataCache,
+                fileChannelCache
             )
         ) {
             // Write data
@@ -609,7 +620,8 @@ public class CryptoDirectoryEncryptionTests extends OpenSearchTestCase {
         BlockLoader<RefCountedMemorySegment> blockLoaderA = new CryptoDirectIOBlockLoader(
             memorySegmentPool,
             keyResolverA,
-            encryptionMetadataCache
+            encryptionMetadataCache,
+            fileChannelCache
         );
 
         // Create per-directory cache and worker
@@ -643,7 +655,8 @@ public class CryptoDirectoryEncryptionTests extends OpenSearchTestCase {
                 blockCacheA,
                 blockLoaderA,
                 readAheadWorkerA,
-                encryptionMetadataCache
+                encryptionMetadataCache,
+                fileChannelCache
             )
         ) {
             // Write data
@@ -687,7 +700,8 @@ public class CryptoDirectoryEncryptionTests extends OpenSearchTestCase {
         BlockLoader<RefCountedMemorySegment> blockLoaderA = new CryptoDirectIOBlockLoader(
             memorySegmentPool,
             keyResolverA,
-            encryptionMetadataCache
+            encryptionMetadataCache,
+            fileChannelCache
         );
 
         // Create per-directory cache and worker
@@ -721,7 +735,8 @@ public class CryptoDirectoryEncryptionTests extends OpenSearchTestCase {
                 blockCacheA,
                 blockLoaderA,
                 readAheadWorkerA,
-                encryptionMetadataCache
+                encryptionMetadataCache,
+                fileChannelCache
             )
         ) {
             // Write data

--- a/src/test/java/org/opensearch/index/store/block/BlockLoaderCopyMismatchTests.java
+++ b/src/test/java/org/opensearch/index/store/block/BlockLoaderCopyMismatchTests.java
@@ -96,7 +96,12 @@ public class BlockLoaderCopyMismatchTests extends OpenSearchTestCase {
         EncryptionMetadataCache encryptionMetadataCache = EncryptionMetadataCacheRegistry.getOrCreateCache(indexUuid, shardId, indexName);
         this.encryptionMetadataCache = encryptionMetadataCache;
 
-        BlockLoader<RefCountedMemorySegment> loader = new CryptoDirectIOBlockLoader(segmentPool, keyResolver, encryptionMetadataCache);
+        BlockLoader<RefCountedMemorySegment> loader = new CryptoDirectIOBlockLoader(
+            segmentPool,
+            keyResolver,
+            encryptionMetadataCache,
+            poolResources.getFileChannelCache()
+        );
 
         Worker worker = poolResources.getSharedReadaheadWorker();
 
@@ -119,7 +124,8 @@ public class BlockLoaderCopyMismatchTests extends OpenSearchTestCase {
             directoryCache,
             loader,
             worker,
-            encryptionMetadataCache
+            encryptionMetadataCache,
+            poolResources.getFileChannelCache()
         );
     }
 
@@ -361,7 +367,12 @@ public class BlockLoaderCopyMismatchTests extends OpenSearchTestCase {
         try {
             Pool<RefCountedMemorySegment> pool = poolResources.getSegmentPool();
 
-            BlockLoader<RefCountedMemorySegment> loader = new CryptoDirectIOBlockLoader(pool, keyResolver, encryptionMetadataCache);
+            BlockLoader<RefCountedMemorySegment> loader = new CryptoDirectIOBlockLoader(
+                pool,
+                keyResolver,
+                encryptionMetadataCache,
+                poolResources.getFileChannelCache()
+            );
 
             RefCountedMemorySegment[] blocks = loader.load(filePath, 0, blockCount, 5000);
 
@@ -417,7 +428,12 @@ public class BlockLoaderCopyMismatchTests extends OpenSearchTestCase {
 
         Path filePath = bufferPoolDirectory.getDirectory().resolve(fileName);
         Pool<RefCountedMemorySegment> pool = poolResources.getSegmentPool();
-        BlockLoader<RefCountedMemorySegment> loader = new CryptoDirectIOBlockLoader(pool, keyResolver, encryptionMetadataCache);
+        BlockLoader<RefCountedMemorySegment> loader = new CryptoDirectIOBlockLoader(
+            pool,
+            keyResolver,
+            encryptionMetadataCache,
+            poolResources.getFileChannelCache()
+        );
 
         RefCountedMemorySegment[] blocks = loader.load(filePath, 0, 1, 5000);
         try {
@@ -452,7 +468,12 @@ public class BlockLoaderCopyMismatchTests extends OpenSearchTestCase {
 
         Path filePath = bufferPoolDirectory.getDirectory().resolve(fileName);
         Pool<RefCountedMemorySegment> pool = poolResources.getSegmentPool();
-        BlockLoader<RefCountedMemorySegment> loader = new CryptoDirectIOBlockLoader(pool, keyResolver, encryptionMetadataCache);
+        BlockLoader<RefCountedMemorySegment> loader = new CryptoDirectIOBlockLoader(
+            pool,
+            keyResolver,
+            encryptionMetadataCache,
+            poolResources.getFileChannelCache()
+        );
 
         RefCountedMemorySegment[] blocks = loader.load(filePath, 0, blockCount, 5000);
         try {
@@ -497,7 +518,12 @@ public class BlockLoaderCopyMismatchTests extends OpenSearchTestCase {
 
         Path filePath = bufferPoolDirectory.getDirectory().resolve(fileName);
         Pool<RefCountedMemorySegment> pool = poolResources.getSegmentPool();
-        BlockLoader<RefCountedMemorySegment> loader = new CryptoDirectIOBlockLoader(pool, keyResolver, encryptionMetadataCache);
+        BlockLoader<RefCountedMemorySegment> loader = new CryptoDirectIOBlockLoader(
+            pool,
+            keyResolver,
+            encryptionMetadataCache,
+            poolResources.getFileChannelCache()
+        );
 
         RefCountedMemorySegment[] blocks = loader.load(filePath, 0, 1, 5000);
         try {
@@ -533,7 +559,12 @@ public class BlockLoaderCopyMismatchTests extends OpenSearchTestCase {
 
         Path filePath = bufferPoolDirectory.getDirectory().resolve(fileName);
         Pool<RefCountedMemorySegment> pool = poolResources.getSegmentPool();
-        BlockLoader<RefCountedMemorySegment> loader = new CryptoDirectIOBlockLoader(pool, keyResolver, encryptionMetadataCache);
+        BlockLoader<RefCountedMemorySegment> loader = new CryptoDirectIOBlockLoader(
+            pool,
+            keyResolver,
+            encryptionMetadataCache,
+            poolResources.getFileChannelCache()
+        );
 
         RefCountedMemorySegment[] blocks = loader.load(filePath, 0, blockCount, 5000);
         try {

--- a/src/test/java/org/opensearch/index/store/block_loader/FileChannelCachePropertyTests.java
+++ b/src/test/java/org/opensearch/index/store/block_loader/FileChannelCachePropertyTests.java
@@ -1,0 +1,470 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.block_loader;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.opensearch.index.store.CaffeineThreadLeakFilter;
+import org.opensearch.test.OpenSearchTestCase;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+/**
+ * Property-based tests for {@link FileChannelCache} and {@link RefCountedChannel}.
+ *
+ * <p>Uses randomized iteration (100 trials per property) via OpenSearchTestCase
+ * random utilities. Each trial creates fresh temp files and cache instances to
+ * ensure isolation.
+ *
+ * <h2>Properties under test</h2>
+ * <ol>
+ *   <li>RefCountedChannel: acquire/close round-trip preserves channel validity</li>
+ *   <li>RefCountedChannel: refCount accounting is exact</li>
+ *   <li>RefCountedChannel: acquire on dead channel always throws</li>
+ *   <li>RefCountedChannel: channel closes exactly when last ref is released</li>
+ *   <li>FileChannelCache: acquire always returns a valid, readable channel</li>
+ *   <li>FileChannelCache: acquire is idempotent — same path returns same channel content</li>
+ *   <li>FileChannelCache: eviction does not corrupt in-flight I/O</li>
+ *   <li>FileChannelCache: invalidate + re-acquire yields a fresh channel</li>
+ *   <li>FileChannelCache: close() invalidates all entries</li>
+ *   <li>FileChannelCache: concurrent acquires on same path all succeed</li>
+ *   <li>FileChannelCache: random mix of acquire/invalidate/close never crashes</li>
+ * </ol>
+ */
+@ThreadLeakFilters(filters = { CaffeineThreadLeakFilter.class })
+public class FileChannelCachePropertyTests extends OpenSearchTestCase {
+
+    private static final byte MAGIC = (byte) 0xFE;
+    private static final int FILE_SIZE = 4096;
+
+    private Path tempDir;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        tempDir = createTempDir("fcc-prop-tests");
+    }
+
+    /** Creates a temp file filled with a specific magic byte. */
+    private Path createTestFile(byte magic) throws IOException {
+        Path file = Files.createTempFile(tempDir, "fcc-", ".dat");
+        byte[] data = new byte[FILE_SIZE];
+        java.util.Arrays.fill(data, magic);
+        Files.write(file, data);
+        return file;
+    }
+
+    /** Creates a temp file filled with the default MAGIC byte. */
+    private Path createTestFile() throws IOException {
+        return createTestFile(MAGIC);
+    }
+
+    /** Reads 64 bytes from offset 0 and validates all match the expected magic. */
+    private static boolean readAndValidate(FileChannel fc, byte expectedMagic) {
+        try {
+            ByteBuffer buf = ByteBuffer.allocate(64);
+            int read = fc.read(buf, 0);
+            if (read <= 0)
+                return false;
+            buf.flip();
+            for (int i = 0; i < read; i++) {
+                if (buf.get(i) != expectedMagic)
+                    return false;
+            }
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    // ====================================================================
+    // RefCountedChannel properties
+    // ====================================================================
+
+    /**
+     * Property 1: Acquire/close round-trip.
+     * For any number of acquires N, doing N closes leaves refCount at 1 (base).
+     * Channel remains readable throughout.
+     */
+    public void testAcquireCloseRoundTrip() throws Exception {
+        for (int trial = 0; trial < 100; trial++) {
+            Path file = createTestFile();
+            FileChannel fc = FileChannel.open(file, StandardOpenOption.READ);
+            RefCountedChannel ref = new RefCountedChannel(fc);
+
+            int n = randomIntBetween(1, 50);
+            RefCountedChannel[] acquired = new RefCountedChannel[n];
+
+            for (int i = 0; i < n; i++) {
+                acquired[i] = ref.acquire();
+                assertTrue("Channel must be readable after acquire #" + i, readAndValidate(acquired[i].channel(), MAGIC));
+            }
+
+            for (int i = 0; i < n; i++) {
+                acquired[i].close();
+            }
+
+            // Base ref still held — channel must be open
+            assertTrue("Channel must be readable after all I/O refs released", readAndValidate(ref.channel(), MAGIC));
+            assertTrue(ref.isAlive());
+
+            ref.releaseBase();
+        }
+    }
+
+    /**
+     * Property 2: RefCount accounting is exact.
+     * After K acquires and J closes (J <= K), refCount == 1 + K - J.
+     */
+    public void testRefCountAccounting() throws Exception {
+        for (int trial = 0; trial < 100; trial++) {
+            Path file = createTestFile();
+            FileChannel fc = FileChannel.open(file, StandardOpenOption.READ);
+            RefCountedChannel ref = new RefCountedChannel(fc);
+
+            int acquires = randomIntBetween(1, 30);
+            int closes = randomIntBetween(0, acquires);
+
+            List<RefCountedChannel> refs = new ArrayList<>();
+            for (int i = 0; i < acquires; i++) {
+                refs.add(ref.acquire());
+            }
+            for (int i = 0; i < closes; i++) {
+                refs.get(i).close();
+            }
+
+            assertTrue("Channel must be alive with outstanding refs", ref.isAlive());
+
+            // Clean up remaining
+            for (int i = closes; i < acquires; i++) {
+                refs.get(i).close();
+            }
+            ref.releaseBase();
+        }
+    }
+
+    /**
+     * Property 3: Acquire on dead channel always throws.
+     * After releaseBase with no outstanding refs, acquire must throw.
+     */
+    public void testAcquireOnDeadChannelAlwaysThrows() throws Exception {
+        for (int trial = 0; trial < 100; trial++) {
+            Path file = createTestFile();
+            FileChannel fc = FileChannel.open(file, StandardOpenOption.READ);
+            RefCountedChannel ref = new RefCountedChannel(fc);
+
+            ref.releaseBase(); // refCount -> 0, channel closed
+            assertFalse(ref.isAlive());
+
+            // Every subsequent acquire must throw
+            int attempts = randomIntBetween(1, 20);
+            for (int i = 0; i < attempts; i++) {
+                expectThrows(IllegalStateException.class, ref::acquire);
+            }
+        }
+    }
+
+    /**
+     * Property 4: Channel closes exactly when last ref is released.
+     * With N acquired refs + base, channel stays open until all N+1 are released.
+     */
+    public void testChannelClosesOnLastRefRelease() throws Exception {
+        for (int trial = 0; trial < 100; trial++) {
+            Path file = createTestFile();
+            FileChannel fc = FileChannel.open(file, StandardOpenOption.READ);
+            RefCountedChannel ref = new RefCountedChannel(fc);
+
+            int n = randomIntBetween(1, 20);
+            List<RefCountedChannel> acquired = new ArrayList<>();
+            for (int i = 0; i < n; i++) {
+                acquired.add(ref.acquire());
+            }
+
+            // Release base first — simulates cache eviction
+            ref.releaseBase();
+
+            // Channel must still be open (acquired refs hold it)
+            assertTrue("Channel must be open with " + n + " acquired refs", fc.isOpen());
+
+            // Release all but last
+            for (int i = 0; i < n - 1; i++) {
+                acquired.get(i).close();
+                assertTrue("Channel must be open with " + (n - 1 - i) + " refs remaining", fc.isOpen());
+            }
+
+            // Release last — channel must close
+            acquired.get(n - 1).close();
+            assertFalse("Channel must be closed after last ref released", fc.isOpen());
+        }
+    }
+
+    // ====================================================================
+    // FileChannelCache properties
+    // ====================================================================
+
+    /**
+     * Property 5: Acquire always returns a valid, readable channel.
+     * For any random set of paths, acquire never returns null and the
+     * channel always reads the correct content.
+     */
+    public void testAcquireAlwaysReturnsValidChannel() throws Exception {
+        for (int trial = 0; trial < 100; trial++) {
+            int numFiles = randomIntBetween(1, 10);
+            int cacheSize = randomIntBetween(1, numFiles + 5);
+            FileChannelCache cache = new FileChannelCache(cacheSize, null);
+
+            List<Path> files = new ArrayList<>();
+            for (int i = 0; i < numFiles; i++) {
+                files.add(createTestFile());
+            }
+
+            for (Path file : files) {
+                String path = file.toAbsolutePath().normalize().toString();
+                try (RefCountedChannel ref = cache.acquire(path)) {
+                    assertNotNull("acquire must never return null", ref);
+                    assertNotNull("channel() must never return null", ref.channel());
+                    assertTrue("Channel must be readable", readAndValidate(ref.channel(), MAGIC));
+                }
+            }
+
+            cache.close();
+        }
+    }
+
+    /**
+     * Property 6: Acquire is idempotent — same path returns same content.
+     * Multiple acquires of the same path all read the same data.
+     */
+    public void testAcquireIdempotent() throws Exception {
+        for (int trial = 0; trial < 100; trial++) {
+            Path file = createTestFile();
+            String path = file.toAbsolutePath().normalize().toString();
+            FileChannelCache cache = new FileChannelCache(16, null);
+
+            int acquires = randomIntBetween(2, 20);
+            for (int i = 0; i < acquires; i++) {
+                try (RefCountedChannel ref = cache.acquire(path)) {
+                    assertTrue("Acquire #" + i + " must return readable channel", readAndValidate(ref.channel(), MAGIC));
+                }
+            }
+
+            cache.close();
+        }
+    }
+
+    /**
+     * Property 7: Eviction does not corrupt in-flight I/O.
+     * With cache size=1, acquiring N different paths forces evictions.
+     * A held ref from before eviction must still be readable.
+     */
+    public void testEvictionDoesNotCorruptInFlightIO() throws Exception {
+        for (int trial = 0; trial < 50; trial++) {
+            Path file1 = createTestFile(MAGIC);
+            Path file2 = createTestFile((byte) 0xAB);
+            String path1 = file1.toAbsolutePath().normalize().toString();
+            String path2 = file2.toAbsolutePath().normalize().toString();
+
+            FileChannelCache cache = new FileChannelCache(1, null);
+
+            // Acquire path1 and hold it (simulating in-flight I/O)
+            RefCountedChannel held = cache.acquire(path1);
+
+            // Acquire path2 — forces eviction of path1 from cache
+            int evictions = randomIntBetween(1, 10);
+            for (int i = 0; i < evictions; i++) {
+                try (RefCountedChannel ref = cache.acquire(path2)) {
+                    assertTrue(readAndValidate(ref.channel(), (byte) 0xAB));
+                }
+                // Re-acquire path1 to force more eviction churn
+                try (RefCountedChannel ref = cache.acquire(path1)) {
+                    assertTrue(readAndValidate(ref.channel(), MAGIC));
+                }
+            }
+
+            // The held ref from before eviction must still be valid
+            assertTrue("Held ref must survive eviction churn", readAndValidate(held.channel(), MAGIC));
+            held.close();
+
+            cache.close();
+        }
+    }
+
+    /**
+     * Property 8: Invalidate + re-acquire yields a fresh, valid channel.
+     * After invalidation, the next acquire opens a new FileChannel.
+     */
+    public void testInvalidateAndReacquire() throws Exception {
+        for (int trial = 0; trial < 100; trial++) {
+            Path file = createTestFile();
+            String path = file.toAbsolutePath().normalize().toString();
+            FileChannelCache cache = new FileChannelCache(16, null);
+
+            int cycles = randomIntBetween(1, 20);
+            for (int i = 0; i < cycles; i++) {
+                try (RefCountedChannel ref = cache.acquire(path)) {
+                    assertTrue(readAndValidate(ref.channel(), MAGIC));
+                }
+                cache.invalidate(path);
+            }
+
+            // Final acquire after all invalidations must still work
+            try (RefCountedChannel ref = cache.acquire(path)) {
+                assertTrue("Must get valid channel after invalidation cycles", readAndValidate(ref.channel(), MAGIC));
+            }
+
+            cache.close();
+        }
+    }
+
+    /**
+     * Property 9: close() invalidates all entries.
+     * After cache.close(), all previously cached channels should be released.
+     * New acquires on a closed cache may fail (implementation-dependent).
+     */
+    public void testCacheCloseInvalidatesAll() throws Exception {
+        for (int trial = 0; trial < 50; trial++) {
+            int numFiles = randomIntBetween(1, 10);
+            FileChannelCache cache = new FileChannelCache(numFiles + 5, null);
+
+            List<RefCountedChannel> heldRefs = new ArrayList<>();
+            for (int i = 0; i < numFiles; i++) {
+                Path file = createTestFile();
+                String path = file.toAbsolutePath().normalize().toString();
+                heldRefs.add(cache.acquire(path));
+            }
+
+            cache.close();
+
+            // All held refs must still be valid (in-flight I/O protection)
+            for (RefCountedChannel ref : heldRefs) {
+                assertTrue("Held ref must survive cache.close()", readAndValidate(ref.channel(), MAGIC));
+                ref.close();
+            }
+        }
+    }
+
+    /**
+     * Property 10: Concurrent acquires on same path all succeed.
+     * N threads all acquire the same path — every thread must get a valid channel.
+     */
+    public void testConcurrentAcquireSamePathAllSucceed() throws Exception {
+        for (int trial = 0; trial < 20; trial++) {
+            Path file = createTestFile();
+            String path = file.toAbsolutePath().normalize().toString();
+            FileChannelCache cache = new FileChannelCache(16, null);
+
+            int threadCount = randomIntBetween(2, 16);
+            ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch endLatch = new CountDownLatch(threadCount);
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicBoolean anyFailure = new AtomicBoolean(false);
+
+            for (int i = 0; i < threadCount; i++) {
+                executor.submit(() -> {
+                    try {
+                        startLatch.await();
+                        try (RefCountedChannel ref = cache.acquire(path)) {
+                            if (readAndValidate(ref.channel(), MAGIC)) {
+                                successCount.incrementAndGet();
+                            } else {
+                                anyFailure.set(true);
+                            }
+                        }
+                    } catch (Exception e) {
+                        anyFailure.set(true);
+                    } finally {
+                        endLatch.countDown();
+                    }
+                });
+            }
+
+            startLatch.countDown();
+            assertTrue("Threads must complete within 15s", endLatch.await(15, TimeUnit.SECONDS));
+            executor.shutdown();
+
+            assertFalse("No thread should see invalid data", anyFailure.get());
+            assertEquals("All threads must succeed", threadCount, successCount.get());
+
+            cache.close();
+        }
+    }
+
+    /**
+     * Property 11: Random mix of acquire/invalidate/close never crashes.
+     * Fuzz test: random operations on random paths with a small cache.
+     * No operation should throw an unexpected exception or corrupt state.
+     */
+    public void testRandomOperationMixNeverCrashes() throws Exception {
+        for (int trial = 0; trial < 30; trial++) {
+            int numFiles = randomIntBetween(2, 8);
+            int cacheSize = randomIntBetween(1, numFiles);
+            FileChannelCache cache = new FileChannelCache(cacheSize, null);
+
+            List<String> paths = new ArrayList<>();
+            for (int i = 0; i < numFiles; i++) {
+                Path file = createTestFile();
+                paths.add(file.toAbsolutePath().normalize().toString());
+            }
+
+            List<RefCountedChannel> openRefs = new ArrayList<>();
+            int ops = randomIntBetween(20, 100);
+
+            for (int i = 0; i < ops; i++) {
+                int op = randomIntBetween(0, 3);
+                String path = paths.get(randomIntBetween(0, paths.size() - 1));
+
+                switch (op) {
+                    case 0: // acquire and hold
+                        try {
+                            RefCountedChannel ref = cache.acquire(path);
+                            assertTrue(readAndValidate(ref.channel(), MAGIC));
+                            openRefs.add(ref);
+                        } catch (IOException e) {
+                            // Acceptable if cache was closed
+                        }
+                        break;
+                    case 1: // acquire and immediately release
+                        try (RefCountedChannel ref = cache.acquire(path)) {
+                            assertTrue(readAndValidate(ref.channel(), MAGIC));
+                        } catch (IOException e) {
+                            // Acceptable
+                        }
+                        break;
+                    case 2: // invalidate
+                        cache.invalidate(path);
+                        break;
+                    case 3: // release a held ref
+                        if (!openRefs.isEmpty()) {
+                            int idx = randomIntBetween(0, openRefs.size() - 1);
+                            openRefs.remove(idx).close();
+                        }
+                        break;
+                }
+            }
+
+            // All held refs must still be readable (in-flight I/O guarantee)
+            for (RefCountedChannel ref : openRefs) {
+                assertTrue("Held ref must be readable after random ops", readAndValidate(ref.channel(), MAGIC));
+                ref.close();
+            }
+
+            cache.close();
+        }
+    }
+}

--- a/src/test/java/org/opensearch/index/store/block_loader/FileChannelCacheTests.java
+++ b/src/test/java/org/opensearch/index/store/block_loader/FileChannelCacheTests.java
@@ -1,0 +1,834 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.block_loader;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.store.CaffeineThreadLeakFilter;
+import org.opensearch.index.store.bufferpoolfs.StaticConfigs;
+import org.opensearch.index.store.pool.PoolSizeCalculator;
+import org.opensearch.test.OpenSearchTestCase;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+
+/**
+ * Unit tests for {@link FileChannelCache} covering:
+ * <ul>
+ *   <li>Node setting defaults and overrides for max file channels and expire-after-access</li>
+ *   <li>3-arg constructor with expiry enabled</li>
+ *   <li>Time-based expiry behavior</li>
+ *   <li>Metrics recording via {@link FileChannelCache#recordStats()}</li>
+ *   <li>Size-based eviction combined with time-based expiry</li>
+ * </ul>
+ */
+@ThreadLeakFilters(filters = { CaffeineThreadLeakFilter.class })
+public class FileChannelCacheTests extends OpenSearchTestCase {
+
+    private static final byte MAGIC = (byte) 0xCA;
+    private static final int FILE_SIZE = 4096;
+
+    private Path tempDir;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        tempDir = createTempDir("fcc-unit-tests");
+    }
+
+    private Path createTestFile() throws IOException {
+        Path file = Files.createTempFile(tempDir, "fcc-", ".dat");
+        byte[] data = new byte[FILE_SIZE];
+        java.util.Arrays.fill(data, MAGIC);
+        Files.write(file, data);
+        return file;
+    }
+
+    private static boolean readAndValidate(FileChannel fc, byte expected) {
+        try {
+            ByteBuffer buf = ByteBuffer.allocate(64);
+            int read = fc.read(buf, 0);
+            if (read <= 0)
+                return false;
+            buf.flip();
+            for (int i = 0; i < read; i++) {
+                if (buf.get(i) != expected)
+                    return false;
+            }
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    // ====================================================================
+    // Setting defaults
+    // ====================================================================
+
+    /**
+     * NODE_MAX_FILE_CHANNELS_SETTING defaults to StaticConfigs.DEFAULT_MAX_FILE_CHANNELS (256).
+     */
+    public void testMaxFileChannelsSettingDefault() {
+        Settings settings = Settings.EMPTY;
+        int value = PoolSizeCalculator.NODE_MAX_FILE_CHANNELS_SETTING.get(settings);
+        assertEquals(StaticConfigs.DEFAULT_MAX_FILE_CHANNELS, value);
+        assertEquals(256, value);
+    }
+
+    /**
+     * NODE_FD_CACHE_EXPIRE_SECONDS_SETTING defaults to StaticConfigs.DEFAULT_FD_CACHE_EXPIRE_AFTER_ACCESS_SECONDS (300).
+     */
+    public void testFdCacheExpireSettingDefault() {
+        Settings settings = Settings.EMPTY;
+        long value = PoolSizeCalculator.NODE_FD_CACHE_EXPIRE_SECONDS_SETTING.get(settings);
+        assertEquals(StaticConfigs.DEFAULT_FD_CACHE_EXPIRE_AFTER_ACCESS_SECONDS, value);
+        assertEquals(300L, value);
+    }
+
+    // ====================================================================
+    // Setting overrides
+    // ====================================================================
+
+    /**
+     * NODE_MAX_FILE_CHANNELS_SETTING can be overridden via Settings.
+     */
+    public void testMaxFileChannelsSettingOverride() {
+        Settings settings = Settings.builder().put("node.store.crypto.max_file_channels", 512).build();
+        assertEquals(512, (int) PoolSizeCalculator.NODE_MAX_FILE_CHANNELS_SETTING.get(settings));
+    }
+
+    /**
+     * NODE_FD_CACHE_EXPIRE_SECONDS_SETTING can be overridden via Settings.
+     */
+    public void testFdCacheExpireSettingOverride() {
+        Settings settings = Settings.builder().put("node.store.crypto.fd_cache_expire_after_access_seconds", 600).build();
+        assertEquals(600L, (long) PoolSizeCalculator.NODE_FD_CACHE_EXPIRE_SECONDS_SETTING.get(settings));
+    }
+
+    /**
+     * Setting expire to 0 disables time-based expiry.
+     */
+    public void testFdCacheExpireSettingZeroDisablesExpiry() {
+        Settings settings = Settings.builder().put("node.store.crypto.fd_cache_expire_after_access_seconds", 0).build();
+        assertEquals(0L, (long) PoolSizeCalculator.NODE_FD_CACHE_EXPIRE_SECONDS_SETTING.get(settings));
+    }
+
+    /**
+     * NODE_MAX_FILE_CHANNELS_SETTING rejects values below 1.
+     */
+    public void testMaxFileChannelsSettingRejectsZero() {
+        Settings settings = Settings.builder().put("node.store.crypto.max_file_channels", 0).build();
+        expectThrows(IllegalArgumentException.class, () -> PoolSizeCalculator.NODE_MAX_FILE_CHANNELS_SETTING.get(settings));
+    }
+
+    /**
+     * NODE_FD_CACHE_EXPIRE_SECONDS_SETTING rejects negative values.
+     */
+    public void testFdCacheExpireSettingRejectsNegative() {
+        Settings settings = Settings.builder().put("node.store.crypto.fd_cache_expire_after_access_seconds", -1).build();
+        expectThrows(IllegalArgumentException.class, () -> PoolSizeCalculator.NODE_FD_CACHE_EXPIRE_SECONDS_SETTING.get(settings));
+    }
+
+    // ====================================================================
+    // 3-arg constructor with expiry
+    // ====================================================================
+
+    /**
+     * FileChannelCache with expiry enabled still acquires and reads correctly.
+     */
+    public void testConstructorWithExpiry() throws Exception {
+        Path file = createTestFile();
+        String path = file.toAbsolutePath().normalize().toString();
+
+        FileChannelCache cache = new FileChannelCache(16, 60, null);
+        try (RefCountedChannel ref = cache.acquire(path)) {
+            assertTrue("Channel must be readable with expiry enabled", readAndValidate(ref.channel(), MAGIC));
+        }
+        cache.close();
+    }
+
+    /**
+     * FileChannelCache with expiry=0 (disabled) still works correctly.
+     */
+    public void testConstructorWithExpiryDisabled() throws Exception {
+        Path file = createTestFile();
+        String path = file.toAbsolutePath().normalize().toString();
+
+        FileChannelCache cache = new FileChannelCache(16, 0, null);
+        try (RefCountedChannel ref = cache.acquire(path)) {
+            assertTrue("Channel must be readable with expiry disabled", readAndValidate(ref.channel(), MAGIC));
+        }
+        cache.close();
+    }
+
+    /**
+     * 2-arg constructor (test convenience) delegates to 3-arg with expire=0.
+     */
+    public void testTwoArgConstructorEquivalent() throws Exception {
+        Path file = createTestFile();
+        String path = file.toAbsolutePath().normalize().toString();
+
+        FileChannelCache cache = new FileChannelCache(16, null);
+        try (RefCountedChannel ref = cache.acquire(path)) {
+            assertTrue(readAndValidate(ref.channel(), MAGIC));
+        }
+        cache.close();
+    }
+
+    // ====================================================================
+    // Time-based expiry behavior
+    // ====================================================================
+
+    /**
+     * Entries expire after the configured access timeout.
+     * Uses a raw Caffeine cache with 50ms expiry and a CountDownLatch in the
+     * eviction listener to detect expiry. Spins cleanUp() to trigger maintenance.
+     */
+    public void testExpireAfterAccess() throws Exception {
+        Path file = createTestFile();
+        String path = file.toAbsolutePath().normalize().toString();
+
+        CountDownLatch expired = new CountDownLatch(1);
+
+        Cache<String, RefCountedChannel> cache = Caffeine
+            .newBuilder()
+            .maximumSize(16)
+            .expireAfterAccess(50, TimeUnit.MILLISECONDS)
+            .evictionListener((String key, RefCountedChannel ref, RemovalCause cause) -> {
+                if (ref != null) {
+                    ref.releaseBase();
+                    if (key.equals(path)) {
+                        expired.countDown();
+                    }
+                }
+            })
+            .build();
+
+        // Populate cache
+        FileChannel fc = FileChannel.open(file, StandardOpenOption.READ);
+        RefCountedChannel ref = new RefCountedChannel(fc);
+        cache.put(path, ref);
+
+        // Acquire + release (refCount: 1→2→1)
+        ref.acquire();
+        ref.close();
+
+        // Spin cleanUp until eviction fires — Caffeine is lazy, needs maintenance trigger
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (expired.getCount() > 0 && System.nanoTime() < deadline) {
+            cache.cleanUp();
+        }
+        assertEquals("Entry must expire", 0, expired.getCount());
+
+        // Channel must be closed after expiry (no I/O refs held)
+        assertFalse("Channel must be closed after time-based expiry", fc.isOpen());
+
+        cache.cleanUp();
+    }
+
+    /**
+     * Accessing a cached entry resets the expiry timer.
+     * Uses a raw Caffeine cache with 200ms expiry. Repeatedly accesses the entry
+     * via cleanUp-spin loops shorter than the expiry, then verifies it's still alive.
+     * Uses a CountDownLatch to detect if expiry fires (it shouldn't).
+     */
+    public void testAccessResetsExpiryTimer() throws Exception {
+        Path file = createTestFile();
+        String path = file.toAbsolutePath().normalize().toString();
+
+        CountDownLatch expired = new CountDownLatch(1);
+
+        Cache<String, RefCountedChannel> cache = Caffeine
+            .newBuilder()
+            .maximumSize(16)
+            .expireAfterAccess(200, TimeUnit.MILLISECONDS)
+            .evictionListener((String key, RefCountedChannel ref, RemovalCause cause) -> {
+                if (ref != null) {
+                    ref.releaseBase();
+                    if (key.equals(path)) {
+                        expired.countDown();
+                    }
+                }
+            })
+            .build();
+
+        FileChannel fc = FileChannel.open(file, StandardOpenOption.READ);
+        RefCountedChannel ref1 = new RefCountedChannel(fc);
+        cache.put(path, ref1);
+
+        // Spin for 500ms total (well past the 200ms expiry window), accessing every ~100ms.
+        // Each getIfPresent resets the access timer, so it should never expire.
+        long start = System.nanoTime();
+        long spinDuration = TimeUnit.MILLISECONDS.toNanos(500);
+        long accessInterval = TimeUnit.MILLISECONDS.toNanos(100);
+        long lastAccess = start;
+        while (System.nanoTime() - start < spinDuration) {
+            cache.cleanUp();
+            if (System.nanoTime() - lastAccess >= accessInterval) {
+                RefCountedChannel r = cache.getIfPresent(path);
+                assertNotNull("Entry must still be cached", r);
+                lastAccess = System.nanoTime();
+            }
+        }
+
+        // Latch must NOT have fired — entry was kept alive by repeated access
+        assertEquals("Entry must not have expired during repeated access", 1, expired.getCount());
+        assertTrue("Channel must still be open", fc.isOpen());
+
+        // Cleanup
+        ref1.releaseBase();
+        cache.cleanUp();
+    }
+
+    // ====================================================================
+    // Size + time eviction combined
+    // ====================================================================
+
+    /**
+     * Both size-based and time-based eviction work together.
+     * Uses a raw Caffeine cache with maxSize=2 and 50ms expiry.
+     * CountDownLatches track eviction events for each path.
+     * Spin-cleanUp to trigger maintenance — no sleeps.
+     */
+    public void testSizeAndTimeEvictionCombined() throws Exception {
+        Path file1 = createTestFile();
+        Path file2 = createTestFile();
+        Path file3 = createTestFile();
+        String path1 = file1.toAbsolutePath().normalize().toString();
+        String path2 = file2.toAbsolutePath().normalize().toString();
+        String path3 = file3.toAbsolutePath().normalize().toString();
+
+        CountDownLatch path1Evicted = new CountDownLatch(1);
+        CountDownLatch path2Evicted = new CountDownLatch(1);
+
+        Cache<String, RefCountedChannel> cache = Caffeine
+            .newBuilder()
+            .maximumSize(2)
+            .expireAfterAccess(50, TimeUnit.MILLISECONDS)
+            .evictionListener((String key, RefCountedChannel ref, RemovalCause cause) -> {
+                if (ref != null) {
+                    ref.releaseBase();
+                    if (key.equals(path1))
+                        path1Evicted.countDown();
+                    if (key.equals(path2))
+                        path2Evicted.countDown();
+                }
+            })
+            .build();
+
+        // Fill cache to capacity (2 entries)
+        FileChannel fc1 = FileChannel.open(file1, StandardOpenOption.READ);
+        RefCountedChannel ref1 = new RefCountedChannel(fc1);
+        cache.put(path1, ref1);
+
+        FileChannel fc2 = FileChannel.open(file2, StandardOpenOption.READ);
+        RefCountedChannel ref2 = new RefCountedChannel(fc2);
+        cache.put(path2, ref2);
+
+        // Add 3rd entry — triggers size-based eviction of path1
+        FileChannel fc3 = FileChannel.open(file3, StandardOpenOption.READ);
+        RefCountedChannel ref3 = new RefCountedChannel(fc3);
+        cache.put(path3, ref3);
+
+        // Spin cleanUp until path1 is evicted by size
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (path1Evicted.getCount() > 0 && System.nanoTime() < deadline) {
+            cache.cleanUp();
+        }
+        assertEquals("path1 must be evicted by size", 0, path1Evicted.getCount());
+        assertFalse("path1 channel must be closed", fc1.isOpen());
+
+        // Spin cleanUp until path2 expires by time (50ms)
+        deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (path2Evicted.getCount() > 0 && System.nanoTime() < deadline) {
+            cache.cleanUp();
+        }
+        assertEquals("path2 must expire by time", 0, path2Evicted.getCount());
+        assertFalse("path2 channel must be closed after time expiry", fc2.isOpen());
+
+        // Cleanup
+        ref3.releaseBase();
+        cache.cleanUp();
+    }
+
+    // ====================================================================
+    // Metrics recording
+    // ====================================================================
+
+    /**
+     * recordStats() does not throw when CryptoMetricsService is not initialized.
+     * The method catches IllegalStateException internally.
+     */
+    public void testRecordStatsWithoutMetricsServiceDoesNotThrow() throws Exception {
+        Path file = createTestFile();
+        String path = file.toAbsolutePath().normalize().toString();
+
+        FileChannelCache cache = new FileChannelCache(16, 60, null);
+
+        // Generate some hits and misses
+        try (RefCountedChannel ref = cache.acquire(path)) {
+            assertTrue(readAndValidate(ref.channel(), MAGIC));
+        }
+        // Second acquire should be a hit
+        try (RefCountedChannel ref = cache.acquire(path)) {
+            assertTrue(readAndValidate(ref.channel(), MAGIC));
+        }
+
+        // Should not throw even without CryptoMetricsService initialized
+        cache.recordStats();
+
+        cache.close();
+    }
+
+    /**
+     * estimatedSize() reflects the number of cached entries.
+     */
+    public void testEstimatedSizeReflectsCacheState() throws Exception {
+        FileChannelCache cache = new FileChannelCache(16, null);
+
+        assertEquals("Empty cache should have size 0", 0, cache.estimatedSize());
+
+        List<String> paths = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            Path f = createTestFile();
+            String p = f.toAbsolutePath().normalize().toString();
+            paths.add(p);
+            try (RefCountedChannel ref = cache.acquire(p)) {
+                assertTrue(readAndValidate(ref.channel(), MAGIC));
+            }
+        }
+        assertEquals("Cache should have 5 entries", 5, cache.estimatedSize());
+
+        // Invalidate 2
+        cache.invalidate(paths.get(0));
+        cache.invalidate(paths.get(1));
+        assertEquals("Cache should have 3 entries after invalidation", 3, cache.estimatedSize());
+
+        cache.close();
+        assertEquals("Cache should be empty after close", 0, cache.estimatedSize());
+    }
+
+    // ====================================================================
+    // In-flight I/O safety with expiry
+    // ====================================================================
+
+    /**
+     * A held RefCountedChannel survives time-based expiry.
+     * The channel stays open for in-flight I/O even after the cache evicts it.
+     * Uses a raw Caffeine cache with 50ms expiry and spin-cleanUp to trigger
+     * maintenance. CountDownLatch detects the eviction event.
+     */
+    public void testHeldRefSurvivesTimeExpiry() throws Exception {
+        Path file = createTestFile();
+        String path = file.toAbsolutePath().normalize().toString();
+
+        CountDownLatch expired = new CountDownLatch(1);
+
+        Cache<String, RefCountedChannel> cache = Caffeine
+            .newBuilder()
+            .maximumSize(16)
+            .expireAfterAccess(50, TimeUnit.MILLISECONDS)
+            .evictionListener((String key, RefCountedChannel ref, RemovalCause cause) -> {
+                if (ref != null) {
+                    ref.releaseBase();
+                    if (key.equals(path)) {
+                        expired.countDown();
+                    }
+                }
+            })
+            .build();
+
+        // Insert and acquire I/O ref (refCount: 1→2)
+        FileChannel fc = FileChannel.open(file, StandardOpenOption.READ);
+        RefCountedChannel ref1 = new RefCountedChannel(fc);
+        cache.put(path, ref1);
+        ref1.acquire(); // refCount=2 (base + I/O)
+
+        // Spin cleanUp until eviction fires
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (expired.getCount() > 0 && System.nanoTime() < deadline) {
+            cache.cleanUp();
+        }
+        assertEquals("Eviction listener must fire", 0, expired.getCount());
+
+        // Key invariant: channel must STILL be open — I/O ref is held (refCount=1)
+        assertTrue("Held ref must survive time-based expiry", fc.isOpen());
+        assertTrue("Must still be able to read", readAndValidate(fc, MAGIC));
+
+        // Release I/O ref → refCount 1→0 → channel closes
+        ref1.close();
+        assertFalse("Channel must close after last ref released", fc.isOpen());
+
+        cache.cleanUp();
+    }
+
+    public void testInvalidateByPathPrefix() throws Exception {
+        // Create files in two different "shard" directories
+        Path shardA = tempDir.resolve("shardA");
+        Path shardB = tempDir.resolve("shardB");
+        Files.createDirectories(shardA);
+        Files.createDirectories(shardB);
+
+        Path fileA1 = Files.write(shardA.resolve("seg_0.dat"), new byte[] { MAGIC });
+        Path fileA2 = Files.write(shardA.resolve("seg_1.dat"), new byte[] { MAGIC });
+        Path fileB1 = Files.write(shardB.resolve("seg_0.dat"), new byte[] { MAGIC });
+
+        String pathA1 = fileA1.toAbsolutePath().normalize().toString();
+        String pathA2 = fileA2.toAbsolutePath().normalize().toString();
+        String pathB1 = fileB1.toAbsolutePath().normalize().toString();
+
+        FileChannelCache cache = new FileChannelCache(16, null);
+
+        // Populate cache with all 3 files
+        try (RefCountedChannel r = cache.acquire(pathA1)) {
+            assertTrue(r.channel().isOpen());
+        }
+        try (RefCountedChannel r = cache.acquire(pathA2)) {
+            assertTrue(r.channel().isOpen());
+        }
+        try (RefCountedChannel r = cache.acquire(pathB1)) {
+            assertTrue(r.channel().isOpen());
+        }
+        assertEquals(3, cache.estimatedSize());
+
+        // Invalidate shardA prefix — should remove A1 and A2, keep B1
+        cache.invalidateByPathPrefix(shardA);
+
+        // shardB entry should still be in cache and accessible
+        try (RefCountedChannel r = cache.acquire(pathB1)) {
+            assertTrue("shardB file should still be accessible", r.channel().isOpen());
+        }
+        assertEquals(1, cache.estimatedSize());
+        cache.close();
+    }
+
+    public void testInvalidateByPathPrefixWithHeldRef() throws Exception {
+        Path subDir = tempDir.resolve("shard");
+        Files.createDirectories(subDir);
+        Path file = Files.write(subDir.resolve("seg.dat"), new byte[] { MAGIC });
+        String path = file.toAbsolutePath().normalize().toString();
+
+        FileChannelCache cache = new FileChannelCache(16, null);
+
+        // Acquire and hold — simulating in-flight I/O
+        RefCountedChannel held = cache.acquire(path);
+
+        // Invalidate by prefix while ref is held
+        cache.invalidateByPathPrefix(subDir);
+
+        // Key invariant: held ref must still be valid — channel stays open for in-flight I/O
+        assertTrue("Held ref must survive prefix invalidation", held.channel().isOpen());
+        assertTrue("Must still be able to read through held ref", readAndValidate(held.channel(), MAGIC));
+
+        held.close();
+        cache.close();
+    }
+
+    /**
+     * Verifies that invalidate() actually closes the underlying FileChannel
+     * when no I/O refs are held. This catches FD leaks where the eviction
+     * listener fails to call releaseBase() on explicit invalidation.
+     */
+    public void testInvalidateClosesIdleChannel() throws Exception {
+        Path file = createTestFile();
+        String path = file.toAbsolutePath().normalize().toString();
+
+        FileChannelCache cache = new FileChannelCache(16, null);
+
+        // Acquire and immediately release — channel is now idle in cache
+        FileChannel fc;
+        try (RefCountedChannel ref = cache.acquire(path)) {
+            fc = ref.channel();
+            assertTrue("Channel should be open during I/O", fc.isOpen());
+        }
+        // At this point: refCount=1 (only the cache's base ref)
+
+        // Invalidate the entry — this MUST close the channel since no I/O is in flight
+        cache.invalidate(path);
+
+        // The channel must be closed — if not, we have an FD leak
+        assertFalse("FileChannel must be closed after invalidation with no held refs (FD leak)", fc.isOpen());
+
+        cache.close();
+    }
+
+    /**
+     * Double-close on RefCountedChannel must not go negative or throw.
+     * Guards against accidental double-release from eviction + manual invalidation.
+     */
+    public void testRefCountedChannelDoubleCloseIsIdempotent() throws Exception {
+        Path file = createTestFile();
+        FileChannel fc = FileChannel.open(file, StandardOpenOption.READ);
+        RefCountedChannel ref = new RefCountedChannel(fc);
+
+        // First close releases the base ref (1 -> 0) and closes the channel
+        ref.close();
+        assertFalse("Channel should be closed after first close()", fc.isOpen());
+
+        // Second close must be a no-op — no exception, no negative refCount
+        ref.close();
+        assertFalse("Channel should still be closed after double close()", fc.isOpen());
+        assertFalse("RefCountedChannel should not be alive after double close", ref.isAlive());
+    }
+
+    // ====================================================================
+    // Eviction listener + CountDownLatch tests
+    // ====================================================================
+
+    /**
+     * Size-based eviction with in-flight I/O: proves the eviction listener fires
+     * exactly once (latch goes from 1→0), the channel stays open while a ref is
+     * held, and closes only after the last ref is released.
+     *
+     * Uses a raw Caffeine cache with evictionListener that counts down a latch
+     * per evicted path. No sleeps — purely latch-driven synchronization.
+     */
+    public void testSizeEvictionWithEvictionListenerLatch() throws Exception {
+        Path file1 = createTestFile();
+        Path file2 = createTestFile();
+        String path1 = file1.toAbsolutePath().normalize().toString();
+        String path2 = file2.toAbsolutePath().normalize().toString();
+
+        // Latch: counts down when eviction listener fires for path1
+        CountDownLatch path1Evicted = new CountDownLatch(1);
+
+        Cache<String, RefCountedChannel> cache = Caffeine
+            .newBuilder()
+            .maximumSize(1)
+            .evictionListener((String key, RefCountedChannel ref, RemovalCause cause) -> {
+                if (ref != null) {
+                    ref.releaseBase();
+                    if (key.equals(path1)) {
+                        path1Evicted.countDown();
+                    }
+                }
+            })
+            .build();
+
+        // Insert path1, acquire I/O ref (refCount: 1→2)
+        FileChannel fc1 = FileChannel.open(file1, StandardOpenOption.READ);
+        RefCountedChannel ref1 = new RefCountedChannel(fc1);
+        cache.put(path1, ref1);
+        ref1.acquire(); // refCount=2 (base + I/O)
+
+        // Latch count must be 1 — eviction hasn't happened yet
+        assertEquals("Eviction must not have fired yet", 1, path1Evicted.getCount());
+        assertTrue("Channel must be open before eviction", fc1.isOpen());
+
+        // Insert path2 into size=1 cache → triggers eviction of path1
+        FileChannel fc2 = FileChannel.open(file2, StandardOpenOption.READ);
+        RefCountedChannel ref2 = new RefCountedChannel(fc2);
+        cache.put(path2, ref2);
+        cache.cleanUp(); // force Caffeine maintenance
+
+        // Wait for eviction listener — it fires synchronously during cleanUp
+        assertTrue("Eviction listener must fire for path1", path1Evicted.await(5, TimeUnit.SECONDS));
+
+        // Latch is now 0 — eviction listener fired exactly once
+        assertEquals("Eviction listener must have fired exactly once", 0, path1Evicted.getCount());
+
+        // Key invariant: channel must STILL be open — I/O ref is held (refCount=1)
+        assertTrue("Channel must survive eviction while I/O ref is held", fc1.isOpen());
+        assertTrue("Must still be able to read through held ref", readAndValidate(fc1, MAGIC));
+
+        // Release the I/O ref → refCount 1→0 → channel closes
+        ref1.close();
+        assertFalse("Channel must close after last ref released", fc1.isOpen());
+
+        // Cleanup
+        ref2.releaseBase();
+        cache.cleanUp();
+    }
+
+    /**
+     * Proves that with an ASYNC removalListener, explicit removal (asMap().remove())
+     * does NOT close the FD synchronously — there is a leak window where the FD
+     * stays open because the listener runs on ForkJoinPool.commonPool().
+     *
+     * Uses CountDownLatch to block the async listener, proving the FD is still open
+     * after removal. Then unblocks the listener and verifies it eventually closes.
+     *
+     * Contrasts with FileChannelCache.invalidate() which does manual releaseBase()
+     * inline — closing the FD synchronously with no leak window.
+     */
+    public void testAsyncRemovalListenerLeakWindowVsSyncManualRelease() throws Exception {
+        Path file = createTestFile();
+        String path = file.toAbsolutePath().normalize().toString();
+
+        // --- Part 1: async removalListener has a leak window ---
+        CountDownLatch allowListenerToRun = new CountDownLatch(1);
+        CountDownLatch listenerDone = new CountDownLatch(1);
+
+        Cache<String, RefCountedChannel> asyncCache = Caffeine
+            .newBuilder()
+            .maximumSize(16)
+            .removalListener((String key, RefCountedChannel ref, RemovalCause cause) -> {
+                try {
+                    allowListenerToRun.await(10, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                if (ref != null) {
+                    ref.releaseBase();
+                }
+                listenerDone.countDown();
+            })
+            .build();
+
+        FileChannel fc1 = FileChannel.open(file, StandardOpenOption.READ);
+        RefCountedChannel ref1 = new RefCountedChannel(fc1);
+        asyncCache.put(path, ref1);
+
+        // Simulate acquire + release (refCount: 1→2→1, base only)
+        ref1.acquire();
+        ref1.close();
+
+        // Explicit removal — async listener is blocked
+        RefCountedChannel removed = asyncCache.asMap().remove(path);
+        assertSame(ref1, removed);
+
+        // Listener hasn't run yet — FD is STILL OPEN (this is the leak window)
+        assertEquals("Listener must not have completed yet", 1, listenerDone.getCount());
+        assertTrue("FD must still be open — async listener blocked (LEAK WINDOW)", fc1.isOpen());
+
+        // Unblock the listener
+        allowListenerToRun.countDown();
+        assertTrue("Listener must complete", listenerDone.await(5, TimeUnit.SECONDS));
+        assertFalse("FD closed after async listener finally runs", fc1.isOpen());
+
+        // --- Part 2: our invalidate() closes FD synchronously ---
+        Path file2 = createTestFile();
+        String path2 = file2.toAbsolutePath().normalize().toString();
+
+        FileChannelCache fdCache = new FileChannelCache(16, null);
+        FileChannel fc2;
+        try (RefCountedChannel ref = fdCache.acquire(path2)) {
+            fc2 = ref.channel();
+        }
+        assertTrue("Channel idle in cache, must be open", fc2.isOpen());
+
+        fdCache.invalidate(path2);
+
+        // No latch needed — invalidate() is synchronous
+        assertFalse("FD must be closed immediately after invalidate() (no leak window)", fc2.isOpen());
+        fdCache.close();
+    }
+
+    /**
+     * Concurrent invalidate() racing with acquire() — uses CountDownLatch to
+     * orchestrate the interleaving deterministically.
+     *
+     * Thread A: acquire(path) → holds ref (refCount=2)
+     * Thread B: invalidate(path) → manual releaseBase (refCount 2→1), signals latch
+     * Thread A: awaits latch, verifies channel still open, releases (refCount 1→0, closes)
+     *
+     * Proves: manual releaseBase in invalidate() fires synchronously (latch goes 0),
+     * channel survives while I/O ref held, closes when last ref released.
+     */
+    public void testConcurrentInvalidateWhileAcquireHeld() throws Exception {
+        Path file = createTestFile();
+        String path = file.toAbsolutePath().normalize().toString();
+
+        FileChannelCache cache = new FileChannelCache(16, null);
+
+        CountDownLatch threadAHoldsRef = new CountDownLatch(1);
+        CountDownLatch threadBInvalidated = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicReference<FileChannel> channelRef = new AtomicReference<>();
+
+        Thread threadA = new Thread(() -> {
+            try {
+                RefCountedChannel held = cache.acquire(path);
+                channelRef.set(held.channel());
+                assertTrue("Channel must be open", held.channel().isOpen());
+
+                threadAHoldsRef.countDown();
+
+                assertTrue("Timed out waiting for invalidation", threadBInvalidated.await(5, TimeUnit.SECONDS));
+
+                // Channel must STILL be open — I/O ref held (refCount=1)
+                assertTrue("Channel must survive invalidation while ref held", held.channel().isOpen());
+                assertTrue("Must still read correctly", readAndValidate(held.channel(), MAGIC));
+
+                // Release → refCount 1→0 → channel closes
+                held.close();
+            } catch (Throwable t) {
+                failure.set(t);
+            }
+        }, "thread-A-io");
+
+        Thread threadB = new Thread(() -> {
+            try {
+                assertTrue("Timed out waiting for Thread A", threadAHoldsRef.await(5, TimeUnit.SECONDS));
+
+                cache.invalidate(path);
+
+                // invalidate() is synchronous — releaseBase already called
+                threadBInvalidated.countDown();
+            } catch (Throwable t) {
+                failure.set(t);
+            }
+        }, "thread-B-invalidator");
+
+        threadA.start();
+        threadB.start();
+        threadA.join(10_000);
+        threadB.join(10_000);
+
+        assertNull("Thread failure: " + failure.get(), failure.get());
+        assertFalse("Channel must be closed after all refs released (FD leak)", channelRef.get().isOpen());
+
+        cache.close();
+    }
+
+    /**
+     * Verifies that invalidateByPathPrefix() closes all idle FileChannels
+     * under the prefix. This catches FD leaks on shard close.
+     */
+    public void testInvalidateByPathPrefixClosesIdleChannels() throws Exception {
+        Path shardDir = tempDir.resolve("shard");
+        Files.createDirectories(shardDir);
+
+        Path file1 = Files.write(shardDir.resolve("seg_0.dat"), new byte[] { MAGIC });
+        Path file2 = Files.write(shardDir.resolve("seg_1.dat"), new byte[] { MAGIC });
+        String path1 = file1.toAbsolutePath().normalize().toString();
+        String path2 = file2.toAbsolutePath().normalize().toString();
+
+        FileChannelCache cache = new FileChannelCache(16, null);
+
+        // Populate cache, then release I/O refs — channels are idle
+        FileChannel fc1, fc2;
+        try (RefCountedChannel ref = cache.acquire(path1)) {
+            fc1 = ref.channel();
+        }
+        try (RefCountedChannel ref = cache.acquire(path2)) {
+            fc2 = ref.channel();
+        }
+
+        assertTrue("Channel 1 should be open while cached", fc1.isOpen());
+        assertTrue("Channel 2 should be open while cached", fc2.isOpen());
+
+        // Invalidate by prefix — both channels must close (no in-flight I/O)
+        cache.invalidateByPathPrefix(shardDir);
+
+        assertFalse("FileChannel 1 must be closed after prefix invalidation (FD leak)", fc1.isOpen());
+        assertFalse("FileChannel 2 must be closed after prefix invalidation (FD leak)", fc2.isOpen());
+
+        cache.close();
+    }
+}

--- a/src/test/java/org/opensearch/index/store/block_loader/FileChannelCacheTests.java
+++ b/src/test/java/org/opensearch/index/store/block_loader/FileChannelCacheTests.java
@@ -797,6 +797,138 @@ public class FileChannelCacheTests extends OpenSearchTestCase {
     }
 
     /**
+     * Evict-then-re-acquire same path opens two FDs simultaneously.
+     *
+     * Scenario:
+     *   Thread A acquires ref for path (refCount=2: base + I/O)
+     *   Cache evicts the entry (size pressure) → base ref released (refCount=1)
+     *   Thread B acquires same path → cache miss → opens NEW FileChannel
+     *   Both FDs are open simultaneously and both work
+     *   Thread A releases → old FD closes (refCount 1→0)
+     *   Thread B releases → new FD stays in cache (refCount=1)
+     *
+     * This is safe because Lucene guarantees immutability: same path = same content.
+     * The temporary FD overshoot is bounded by concurrent in-flight I/Os at eviction time.
+     */
+    public void testEvictThenReAcquireSamePathOpensTwoFDs() throws Exception {
+        Path file = createTestFile();
+        String path = file.toAbsolutePath().normalize().toString();
+
+        CountDownLatch evicted = new CountDownLatch(1);
+
+        // maxSize=1 so inserting a second entry evicts the first
+        Cache<String, RefCountedChannel> rawCache = Caffeine
+            .newBuilder()
+            .maximumSize(1)
+            .evictionListener((String key, RefCountedChannel ref, RemovalCause cause) -> {
+                if (ref != null) {
+                    ref.releaseBase();
+                    if (key.equals(path)) {
+                        evicted.countDown();
+                    }
+                }
+            })
+            .build();
+
+        // Thread A: insert path and hold an I/O ref (refCount: 1→2)
+        FileChannel fcOld = FileChannel.open(file, StandardOpenOption.READ);
+        RefCountedChannel refOld = new RefCountedChannel(fcOld);
+        rawCache.put(path, refOld);
+        refOld.acquire(); // refCount=2 (base + I/O)
+
+        // Evict path by inserting a different key into the size=1 cache
+        Path dummyFile = createTestFile();
+        String dummyPath = dummyFile.toAbsolutePath().normalize().toString();
+        FileChannel fcDummy = FileChannel.open(dummyFile, StandardOpenOption.READ);
+        RefCountedChannel refDummy = new RefCountedChannel(fcDummy);
+        rawCache.put(dummyPath, refDummy);
+        rawCache.cleanUp();
+
+        // Wait for eviction of path
+        assertTrue("Eviction must fire for path", evicted.await(5, TimeUnit.SECONDS));
+
+        // Old FD must still be open — Thread A holds an I/O ref (refCount=1)
+        assertTrue("Old FD must survive eviction while I/O ref held", fcOld.isOpen());
+
+        // Thread B: re-acquire same path → cache miss → opens a NEW FD
+        FileChannel fcNew = FileChannel.open(file, StandardOpenOption.READ);
+        RefCountedChannel refNew = new RefCountedChannel(fcNew);
+        rawCache.put(path, refNew);
+        refNew.acquire(); // refCount=2 (base + I/O)
+
+        // Both FDs are open simultaneously
+        assertTrue("Old FD must still be open", fcOld.isOpen());
+        assertTrue("New FD must be open", fcNew.isOpen());
+        assertNotSame("Must be different FileChannel instances", fcOld, fcNew);
+
+        // Both FDs read the same content (Lucene immutability guarantee)
+        assertTrue("Old FD must read correctly", readAndValidate(fcOld, MAGIC));
+        assertTrue("New FD must read correctly", readAndValidate(fcNew, MAGIC));
+
+        // Thread A finishes I/O → release old ref → refCount 1→0 → old FD closes
+        refOld.close();
+        assertFalse("Old FD must close after last ref released", fcOld.isOpen());
+
+        // New FD still open (Thread B's I/O ref + cache base)
+        assertTrue("New FD must still be open", fcNew.isOpen());
+
+        // Thread B finishes I/O → release I/O ref → refCount 2→1 (cache base remains)
+        refNew.close();
+        assertTrue("New FD must stay open — cache still holds base ref", fcNew.isOpen());
+
+        // Cleanup
+        refDummy.releaseBase();
+        refNew.releaseBase();
+        rawCache.cleanUp();
+        assertFalse("New FD must close after cache cleanup", fcNew.isOpen());
+    }
+
+    /**
+     * Same scenario as above but using the real FileChannelCache API.
+     * Proves that acquire() transparently opens a new FD when the old one was evicted.
+     */
+    public void testEvictThenReAcquireViaFileChannelCacheAPI() throws Exception {
+        // maxSize=1 so the second distinct path evicts the first
+        FileChannelCache cache = new FileChannelCache(1, null);
+
+        Path file1 = createTestFile();
+        Path file2 = createTestFile();
+        String path1 = file1.toAbsolutePath().normalize().toString();
+        String path2 = file2.toAbsolutePath().normalize().toString();
+
+        // Thread A: acquire path1 and hold ref (simulating in-flight I/O)
+        RefCountedChannel heldRef = cache.acquire(path1);
+        FileChannel fcOld = heldRef.channel();
+        assertTrue("Old channel must be open", fcOld.isOpen());
+
+        // Evict path1 by loading path2 into the size=1 cache
+        try (RefCountedChannel ref2 = cache.acquire(path2)) {
+            assertTrue(readAndValidate(ref2.channel(), MAGIC));
+        }
+        cache.cleanUp(); // force eviction
+
+        // Old channel must still be open — heldRef keeps it alive
+        assertTrue("Old channel must survive eviction", fcOld.isOpen());
+
+        // Thread B: re-acquire path1 → cache miss → new FD
+        try (RefCountedChannel newRef = cache.acquire(path1)) {
+            FileChannel fcNew = newRef.channel();
+            assertTrue("New channel must be open", fcNew.isOpen());
+            assertNotSame("Must be a different FileChannel", fcOld, fcNew);
+
+            // Both readable simultaneously
+            assertTrue("Old channel readable", readAndValidate(fcOld, MAGIC));
+            assertTrue("New channel readable", readAndValidate(fcNew, MAGIC));
+        }
+
+        // Release Thread A's ref → old FD closes
+        heldRef.close();
+        assertFalse("Old channel must close after release", fcOld.isOpen());
+
+        cache.close();
+    }
+
+    /**
      * Verifies that invalidateByPathPrefix() closes all idle FileChannels
      * under the prefix. This catches FD leaks on shard close.
      */

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/BlockSlotTinyCacheIntegrationTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/BlockSlotTinyCacheIntegrationTests.java
@@ -4,10 +4,6 @@
  */
 package org.opensearch.index.store.bufferpoolfs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -324,23 +320,28 @@ public class BlockSlotTinyCacheIntegrationTests extends OpenSearchTestCase {
 
         @Override
         public BlockCacheValue<RefCountedMemorySegment> getOrLoad(BlockCacheKey key) throws IOException {
-            return cache.computeIfAbsent(key, k -> {
-                // Simulate cache full - evict oldest entry
-                if (cache.size() >= poolSize) {
-                    evictOne();
-                }
+            BlockCacheValue<RefCountedMemorySegment> existing = cache.get(key);
+            if (existing != null) {
+                return existing;
+            }
 
-                // Get segment from pool (round-robin)
-                int idx = poolIndex.getAndIncrement() % poolSize;
-                RefCountedMemorySegment segment = pool[idx];
+            // Evict BEFORE inserting to avoid recursive ConcurrentHashMap update.
+            // computeIfAbsent + cache.remove inside the lambda is illegal (recursive update).
+            if (cache.size() >= poolSize) {
+                evictOne();
+            }
 
-                // If segment is in use, reset it (simulates recycling)
-                if (segment.getRefCount() == 0) {
-                    segment.reset();
-                }
+            // Get segment from pool (round-robin)
+            int idx = poolIndex.getAndIncrement() % poolSize;
+            RefCountedMemorySegment segment = pool[idx];
 
-                return segment;
-            });
+            // If segment is in use, reset it (simulates recycling)
+            if (segment.getRefCount() == 0) {
+                segment.reset();
+            }
+
+            cache.putIfAbsent(key, segment);
+            return cache.get(key);
         }
 
         private void evictOne() {

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/BufferPoolDirectoryTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/BufferPoolDirectoryTests.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.bufferpoolfs;
+
+import static org.opensearch.index.store.CryptoDirectoryFactory.DEFAULT_CRYPTO_PROVIDER;
+
+import java.nio.file.Path;
+import java.security.Provider;
+import java.security.Security;
+
+import org.apache.lucene.store.AlreadyClosedException;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.FSLockFactory;
+import org.apache.lucene.store.IOContext;
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.common.crypto.MasterKeyProvider;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.store.CryptoDirectoryFactory;
+import org.opensearch.index.store.DummyKeyProvider;
+import org.opensearch.index.store.block.RefCountedMemorySegment;
+import org.opensearch.index.store.block_cache.BlockCache;
+import org.opensearch.index.store.block_cache.CaffeineBlockCache;
+import org.opensearch.index.store.block_loader.BlockLoader;
+import org.opensearch.index.store.block_loader.CryptoDirectIOBlockLoader;
+import org.opensearch.index.store.cipher.EncryptionMetadataCache;
+import org.opensearch.index.store.cipher.EncryptionMetadataCacheRegistry;
+import org.opensearch.index.store.key.KeyResolver;
+import org.opensearch.index.store.pool.Pool;
+import org.opensearch.index.store.pool.PoolBuilder;
+import org.opensearch.index.store.read_ahead.Worker;
+import org.opensearch.test.OpenSearchTestCase;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
+/**
+ * Unit tests for {@link BufferPoolDirectory}.
+ */
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class BufferPoolDirectoryTests extends OpenSearchTestCase {
+
+    private BufferPoolDirectory directory;
+    private PoolBuilder.PoolResources poolResources;
+    private boolean originalWriteCacheEnabled;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        originalWriteCacheEnabled = CryptoDirectoryFactory.isWriteCacheEnabled();
+        CryptoDirectoryFactory.setNodeSettings(Settings.builder().put("node.store.crypto.write_cache_enabled", false).build());
+
+        Path path = createTempDir();
+        Provider provider = Security.getProvider(DEFAULT_CRYPTO_PROVIDER);
+        MasterKeyProvider keyProvider = DummyKeyProvider.create();
+
+        Settings nodeSettings = Settings
+            .builder()
+            .put("plugins.crypto.enabled", true)
+            .put("node.store.crypto.pool_size_percentage", 0.05)
+            .put("node.store.crypto.warmup_percentage", 0.0)
+            .put("node.store.crypto.cache_to_pool_ratio", 0.8)
+            .build();
+
+        this.poolResources = PoolBuilder.build(nodeSettings);
+        Pool<RefCountedMemorySegment> segmentPool = poolResources.getSegmentPool();
+
+        String indexUuid = randomAlphaOfLength(10);
+        String indexName = randomAlphaOfLength(10);
+        FSDirectory fsDirectory = FSDirectory.open(path);
+        int shardId = 0;
+
+        KeyResolver keyResolver = new TestKeyResolver(indexUuid, indexName, fsDirectory, provider, keyProvider, shardId);
+        EncryptionMetadataCache encryptionMetadataCache = EncryptionMetadataCacheRegistry.getOrCreateCache(indexUuid, shardId, indexName);
+
+        BlockLoader<RefCountedMemorySegment> loader = new CryptoDirectIOBlockLoader(
+            segmentPool,
+            keyResolver,
+            encryptionMetadataCache,
+            poolResources.getFileChannelCache()
+        );
+
+        Worker worker = poolResources.getSharedReadaheadWorker();
+
+        @SuppressWarnings("unchecked")
+        CaffeineBlockCache<RefCountedMemorySegment, RefCountedMemorySegment> sharedCache =
+            (CaffeineBlockCache<RefCountedMemorySegment, RefCountedMemorySegment>) poolResources.getBlockCache();
+
+        BlockCache<RefCountedMemorySegment> directoryCache = new CaffeineBlockCache<>(
+            sharedCache.getCache(),
+            loader,
+            poolResources.getMaxCacheBlocks()
+        );
+
+        this.directory = new BufferPoolDirectory(
+            path,
+            FSLockFactory.getDefault(),
+            provider,
+            keyResolver,
+            segmentPool,
+            directoryCache,
+            loader,
+            worker,
+            encryptionMetadataCache,
+            poolResources.getFileChannelCache()
+        );
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        CryptoDirectoryFactory
+            .setNodeSettings(Settings.builder().put("node.store.crypto.write_cache_enabled", originalWriteCacheEnabled).build());
+        // directory may already be closed by the test
+        try {
+            this.directory.close();
+        } catch (AlreadyClosedException e) {
+            // expected if test already closed it
+        }
+        this.poolResources.close();
+        super.tearDown();
+    }
+
+    /**
+     * Verifies that close() calls super.close() so that ensureOpen() throws
+     * AlreadyClosedException on subsequent operations. Without super.close(),
+     * the directory appears open and operations silently proceed on stale state.
+     *
+     * We test via createTempOutput since its ensureOpen() call is not wrapped in
+     * a catch block that calls CryptoMetricsService (which isn't initialized in
+     * unit tests).
+     */
+    public void testCloseMarksDirectoryAsClosed() throws Exception {
+        // Close the directory
+        directory.close();
+
+        // After close, createTempOutput should throw AlreadyClosedException from ensureOpen()
+        expectThrows(AlreadyClosedException.class, () -> directory.createTempOutput("test", "tmp", IOContext.DEFAULT));
+    }
+}

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputConcurrencyTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputConcurrencyTests.java
@@ -99,7 +99,7 @@ public class CachedMemorySegmentIndexInputConcurrencyTests extends OpenSearchTes
                             long offset = blockNum * BLOCK_SIZE + (i % 100);
 
                             if (offset < fileLength) {
-                                byte value = input.readByte(offset);
+                                byte value = input.clone().readByte(offset);
                                 byte expected = (byte) (blockNum + 1);
 
                                 if (value != expected) {

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputFromDirectoryTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputFromDirectoryTests.java
@@ -115,7 +115,12 @@ public class CachedMemorySegmentIndexInputFromDirectoryTests extends BaseIndexIn
 
         EncryptionMetadataCache encryptionMetadataCache = EncryptionMetadataCacheRegistry.getOrCreateCache(indexUuid, shardId, indexName);
 
-        BlockLoader<RefCountedMemorySegment> loader = new CryptoDirectIOBlockLoader(segmentPool, keyResolver, encryptionMetadataCache);
+        BlockLoader<RefCountedMemorySegment> loader = new CryptoDirectIOBlockLoader(
+            segmentPool,
+            keyResolver,
+            encryptionMetadataCache,
+            poolResources.getFileChannelCache()
+        );
 
         Worker worker = poolResources.getSharedReadaheadWorker();
 
@@ -137,7 +142,8 @@ public class CachedMemorySegmentIndexInputFromDirectoryTests extends BaseIndexIn
             directoryCache,
             loader,
             worker,
-            encryptionMetadataCache
+            encryptionMetadataCache,
+            poolResources.getFileChannelCache()
         );
     }
 

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/WriteCacheSettingTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/WriteCacheSettingTests.java
@@ -86,7 +86,12 @@ public class WriteCacheSettingTests extends OpenSearchTestCase {
         KeyResolver keyResolver = new TestKeyResolver(indexUuid, indexName, fsDirectory, provider, keyProvider, shardId);
         EncryptionMetadataCache encryptionMetadataCache = EncryptionMetadataCacheRegistry.getOrCreateCache(indexUuid, shardId, indexName);
 
-        BlockLoader<RefCountedMemorySegment> loader = new CryptoDirectIOBlockLoader(segmentPool, keyResolver, encryptionMetadataCache);
+        BlockLoader<RefCountedMemorySegment> loader = new CryptoDirectIOBlockLoader(
+            segmentPool,
+            keyResolver,
+            encryptionMetadataCache,
+            poolResources.getFileChannelCache()
+        );
 
         Worker worker = poolResources.getSharedReadaheadWorker();
 
@@ -105,7 +110,8 @@ public class WriteCacheSettingTests extends OpenSearchTestCase {
             directoryCache,
             loader,
             worker,
-            encryptionMetadataCache
+            encryptionMetadataCache,
+            poolResources.getFileChannelCache()
         );
     }
 


### PR DESCRIPTION

Add a Caffeine-backed FileChannelCache that caches FileChannel instances per normalized path, bounded by max open FDs (default 256) with optional expireAfterAccess TTL (default 300s). Each entry is wrapped in a RefCountedChannel that guarantees in-flight I/O keeps the channel open even after cache eviction or explicit invalidation.

Key components:
- RefCountedChannel: CAS-based ref counting with AutoCloseable support. acquire() never returns null, throws IllegalStateException on dead channel. close() via try-with-resources releases the I/O ref.
- FileChannelCache: Caffeine cache with eviction listener that calls releaseBase(). acquire() retries up to 3 times on stale entries. Unwraps Caffeine RuntimeException to surface original IOException.
- CryptoDirectIOBlockLoader: uses try-with-resources for FileChannel lifecycle. Passes pre-computed normalizedPath to readFooterFromDisk.
- BufferPoolDirectory: calls super.close() so ensureOpen() properly throws AlreadyClosedException. Invalidates FD cache on close/delete.
- FD cache invalidation wired into directory close, file delete, and CryptoDirectoryPlugin.afterIndexRemoved().
- Configurable via PoolSizeCalculator settings. FD cache stats published via CryptoMetricsService.recordFdCacheStats().
- JCStress uses quick mode when run via ./gradlew test, default mode when run explicitly via ./gradlew jcstress.

Tests:
- 8 JCStress tests for concurrency contracts
- 11 property tests for API contracts
- FileChannelCacheTests with latch-based deterministic concurrency
- BufferPoolDirectoryTests for close behavior
- 5 FD cache integration tests (index delete, close, force-merge, multi-index isolation, full cleanup)

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
