### PR TITLE
Add fast path for current block reuse

### DIFF
--- a/src/main/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInput.java
+++ b/src/main/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInput.java
@@ -169,17 +169,23 @@ public class CachedMemorySegmentIndexInput extends IndexInput implements RandomA
     private MemorySegment getCacheBlockWithOffset(long pos) throws IOException {
         final long fileOffset = absoluteBaseOffset + pos;
         final long blockOffset = fileOffset & ~CACHE_BLOCK_MASK;
-        final int offsetInBlock = (int) (fileOffset - blockOffset);
+        lastOffsetInBlock = (int) (fileOffset - blockOffset);
 
         // Fast path: reuse current block if still valid.
         // this access is safe without generation check because currentBlock
         // is pinned (refCount > 1) so it cannot be returned to pool or reused
         // for different data while we hold it.
         if (blockOffset == currentBlockOffset && currentBlock != null) {
-            lastOffsetInBlock = offsetInBlock;
             return currentBlock.value().segment();
         }
+        return acquireCacheBlockOnMiss(blockOffset);
+    }
 
+    /**
+    * Slow path for cache block acquisition — separated to keep the fast path
+    * small enough for JIT inlining.
+    */
+    private MemorySegment acquireCacheBlockOnMiss(long blockOffset) throws IOException {
         cacheHitHolder.reset();
 
         // BlockSlotTinyCache returns already-pinned values
@@ -204,7 +210,6 @@ public class CachedMemorySegmentIndexInput extends IndexInput implements RandomA
             readaheadContext.onAccess(blockOffset, cacheHitHolder.wasCacheHit());
         }
 
-        lastOffsetInBlock = offsetInBlock;
         return pinnedBlock.segment();
     }
 

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputTests.java
@@ -1427,6 +1427,54 @@ public class CachedMemorySegmentIndexInputTests extends OpenSearchTestCase {
     }
 
     /**
+     * Tests that consecutive reads within the same block reuse the cached block
+     * without calling acquireRefCountedValue again (fast path).
+     */
+    public void testFastPathReusesCurrentBlock() throws IOException {
+        long fileLength = BLOCK_SIZE * 2;
+        MemorySegment block0 = createBlockWithPattern(0, (byte) 0xAB);
+        setupOneBlock(block0);
+        CachedMemorySegmentIndexInput input = createInput(fileLength);
+        // First read triggers slow path — acquires from L1/L2
+        byte b1 = input.readByte();
+        assertEquals((byte) 0xAB, b1);
+        verify(mockTinyCache, times(1)).acquireRefCountedValue(eq(0L), any());
+        // Subsequent reads within same block should NOT call acquireRefCountedValue again
+        byte b2 = input.readByte();
+        assertEquals((byte) 0xAB, b2);
+        byte b3 = input.readByte();
+        assertEquals((byte) 0xAB, b3);
+        // Still only 1 call — fast path reused currentBlock
+        verify(mockTinyCache, times(1)).acquireRefCountedValue(eq(0L), any());
+        input.close();
+    }
+
+    /**
+     * Tests that reading across a block boundary triggers the slow path
+     * (acquireRefCountedValue called for the new block).
+     */
+    public void testSlowPathOnBlockTransition() throws IOException {
+        long fileLength = BLOCK_SIZE * 2;
+        MemorySegment block0 = createBlockWithPattern(0, (byte) 0x11);
+        MemorySegment block1 = createBlockWithPattern(1, (byte) 0x22);
+        setupTwoBlocks(block0, block1);
+        CachedMemorySegmentIndexInput input = createInput(fileLength);
+        // Read from block 0
+        input.readByte();
+        verify(mockTinyCache, times(1)).acquireRefCountedValue(eq(0L), any());
+        // Seek to block 1
+        input.seek(BLOCK_SIZE);
+        input.readByte();
+        // Now acquireRefCountedValue called for block 1 offset
+        verify(mockTinyCache, times(1)).acquireRefCountedValue(eq((long) BLOCK_SIZE), any());
+        // Read more from block 1 — should reuse (no additional calls)
+        input.readByte();
+        input.readByte();
+        verify(mockTinyCache, times(1)).acquireRefCountedValue(eq((long) BLOCK_SIZE), any());
+        input.close();
+    }
+
+    /**
      * Test for the bug that caused negative file offsets in production.
      *
      * The old MultiSegmentImpl implementation would double-count offsets when creating slices,


### PR DESCRIPTION
### Description
Add fast path for current block reuse

### Related Issues
part of https://github.com/opensearch-project/opensearch-storage-encryption/issues/162

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
