### PR TITLE
Replace BlockSlotTinyCache with RadixBlockTable L1 cache

### DIFF
--- a/src/jmh/java/org/opensearch/index/store/benchmark/HotPathReadBenchmarks.java
+++ b/src/jmh/java/org/opensearch/index/store/benchmark/HotPathReadBenchmarks.java
@@ -375,6 +375,45 @@ public class HotPathReadBenchmarks {
         }
     }
 
+    @Benchmark
+    public void aggregationPatternReadLong(ThreadState ts, Blackhole bh) throws IOException {
+        final int blockSize = StaticConfigs.CACHE_BLOCK_SIZE;
+        final int readsPerBlock = 512;
+        for (int fileIdx = 0; fileIdx < ts.numFilesToRead; fileIdx++) {
+            IndexInput fileInput = ts.threadInputs[fileIdx];
+            RandomAccessInput in = (RandomAccessInput) fileInput;
+            for (long blockStart : ts.blockStartOffsets) {
+                long blockEnd = Math.min(blockStart + blockSize, ts.fileSize);
+                long usable = blockEnd - blockStart - Long.BYTES;
+                if (usable <= 0) continue;
+                for (int r = 0; r < readsPerBlock; r++) {
+                    long pos = blockStart + ((long) r * Long.BYTES % usable);
+                    bh.consume(in.readLong(pos));
+                }
+            }
+        }
+    }
+
+    /**
+     * Bulk sequential readBytes — simulates stored field / merge copy reads.
+     * Reads 64KB (8 blocks) at block-aligned offsets to exercise the aligned bulk path.
+     */
+    @Benchmark
+    public void bulkSequentialReadBytes(ThreadState ts, Blackhole bh) throws IOException {
+        final int bulkSize = StaticConfigs.CACHE_BLOCK_SIZE * 8; // 64KB — hits aligned path
+        byte[] buf = new byte[bulkSize];
+        for (int fileIdx = 0; fileIdx < ts.numFilesToRead; fileIdx++) {
+            IndexInput fileInput = ts.threadInputs[fileIdx];
+            fileInput.seek(0);
+            long pos = 0;
+            while (pos + bulkSize <= ts.fileSize) {
+                fileInput.readBytes(buf, 0, bulkSize);
+                bh.consume(buf[0]);
+                pos += bulkSize;
+            }
+        }
+    }
+
     // Mixed workload: randomly exercises all read APIs in a single benchmark
     @Benchmark
     public void mixedReadWorkload(ThreadState ts, Blackhole bh) throws IOException {

--- a/src/jmh/java/org/opensearch/index/store/benchmark/ReadBenchmarkBase.java
+++ b/src/jmh/java/org/opensearch/index/store/benchmark/ReadBenchmarkBase.java
@@ -31,6 +31,7 @@ import org.opensearch.index.store.block_cache.CaffeineBlockCache;
 import org.opensearch.index.store.block_loader.BlockLoader;
 import org.opensearch.index.store.block_loader.CryptoDirectIOBlockLoader;
 import org.opensearch.index.store.bufferpoolfs.BufferPoolDirectory;
+import org.opensearch.index.store.bufferpoolfs.RadixBlockTableRegistry;
 import org.opensearch.index.store.bufferpoolfs.StaticConfigs;
 import org.opensearch.index.store.bufferpoolfs.TestKeyResolver;
 import org.opensearch.index.store.cipher.EncryptionMetadataCache;
@@ -176,7 +177,8 @@ public class ReadBenchmarkBase {
             loader,
             worker,
             encMetaCache,
-            poolResources.getFileChannelCache()
+            poolResources.getFileChannelCache(),
+            new RadixBlockTableRegistry()
         );
 
         // Write test files through bufferpool write path

--- a/src/main/java/org/opensearch/index/store/CryptoDirectoryFactory.java
+++ b/src/main/java/org/opensearch/index/store/CryptoDirectoryFactory.java
@@ -38,6 +38,7 @@ import org.opensearch.index.store.block_loader.BlockLoader;
 import org.opensearch.index.store.block_loader.CryptoDirectIOBlockLoader;
 import org.opensearch.index.store.block_loader.FileChannelCache;
 import org.opensearch.index.store.bufferpoolfs.BufferPoolDirectory;
+import org.opensearch.index.store.bufferpoolfs.RadixBlockTableRegistry;
 import org.opensearch.index.store.cipher.EncryptionMetadataCache;
 import org.opensearch.index.store.cipher.EncryptionMetadataCacheRegistry;
 import org.opensearch.index.store.hybrid.HybridCryptoDirectory;
@@ -92,6 +93,12 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
      * This prevents resource allocation on dedicated master nodes which never create shards.
      */
     private static volatile PoolBuilder.PoolResources poolResources;
+
+    /**
+     * Shared node-level RadixBlockTable registry for L1 cache lifecycle management.
+     * One registry serves all directories — the ConcurrentHashMap keys by file path.
+     */
+    private static volatile RadixBlockTableRegistry sharedRadixBlockTableRegistry;
 
     /**
      * Node settings used for lazy pool initialization.
@@ -519,6 +526,18 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
             resources.getMaxCacheBlocks()
         );
 
+        // Initialize shared RadixBlockTableRegistry once and wire eviction listener
+        // to the shared Caffeine cache. All directories share one registry because
+        // the ConcurrentHashMap keys by absolute file path — no conflicts across directories.
+        if (sharedRadixBlockTableRegistry == null) {
+            synchronized (CryptoDirectoryFactory.class) {
+                if (sharedRadixBlockTableRegistry == null) {
+                    sharedRadixBlockTableRegistry = new RadixBlockTableRegistry();
+                    sharedCaffeineCache.setEvictionListener(sharedRadixBlockTableRegistry::onEviction);
+                }
+            }
+        }
+
         // Use the shared node-wide read-ahead worker
         // All shards/directories share a single queue and executor pool for better resource utilization
         Worker readaheadWorker = resources.getSharedReadaheadWorker();
@@ -533,7 +552,8 @@ public class CryptoDirectoryFactory implements IndexStorePlugin.DirectoryFactory
             loader,
             readaheadWorker,
             encryptionMetadataCache,
-            resources.getFileChannelCache()
+            resources.getFileChannelCache(),
+            sharedRadixBlockTableRegistry
         );
     }
 

--- a/src/main/java/org/opensearch/index/store/block_cache/BlockCache.java
+++ b/src/main/java/org/opensearch/index/store/block_cache/BlockCache.java
@@ -23,6 +23,25 @@ import java.util.Map;
 public interface BlockCache<T> {
 
     /**
+     * Callback invoked when a block is evicted from the cache.
+     * Used to notify L1 caches (RadixBlockTable) so they can clear stale entries.
+     */
+    @FunctionalInterface
+    interface EvictionListener {
+        void onEviction(Path path, long blockOffset);
+    }
+
+    /**
+     * Registers a listener that is notified when blocks are evicted from this cache.
+     * The listener is called before the evicted value is closed.
+     *
+     * @param listener the eviction listener
+     */
+    default void setEvictionListener(EvictionListener listener) {
+        // no-op by default; implementations that support eviction notification override this
+    }
+
+    /**
      * Returns the block if cached, or null if absent.
      *
      * @param key the cache key identifying the block

--- a/src/main/java/org/opensearch/index/store/block_cache/BlockCacheBuilder.java
+++ b/src/main/java/org/opensearch/index/store/block_cache/BlockCacheBuilder.java
@@ -6,6 +6,7 @@ package org.opensearch.index.store.block_cache;
 
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -82,6 +83,10 @@ public final class BlockCacheBuilder {
                 new ThreadContext(org.opensearch.common.settings.Settings.EMPTY)
             );
 
+        // Shared reference for L1 eviction notification. The removal listener lambda
+        // reads from this reference; CaffeineBlockCache sets it via setEvictionListener().
+        AtomicReference<BlockCache.EvictionListener> evictionListenerRef = new AtomicReference<>();
+
         Cache<BlockCacheKey, BlockCacheValue<T>> cache = Caffeine
             .newBuilder()
             .initialCapacity(initialCapacity)
@@ -89,6 +94,17 @@ public final class BlockCacheBuilder {
             .maximumSize(maxBlocks)
             .removalListener((BlockCacheKey key, BlockCacheValue<T> value, RemovalCause cause) -> {
                 if (value != null) {
+                    // Notify L1 eviction listener before closing the segment.
+                    // This clears the stale L1 pointer so future reads see a clean miss.
+                    BlockCache.EvictionListener listener = evictionListenerRef.get();
+                    if (listener != null && key instanceof FileBlockCacheKey fbk) {
+                        try {
+                            listener.onEviction(fbk.filePath(), fbk.fileOffset());
+                        } catch (Exception e) {
+                            LOGGER.debug("L1 eviction notification failed for {}", key, e);
+                        }
+                    }
+
                     removalExec.execute(() -> {
                         try {
                             value.close();
@@ -103,7 +119,7 @@ public final class BlockCacheBuilder {
         // Loader is null here because this creates a shared cache instance.
         // Per-directory caches will wrap this cache with their own loaders
         // that provide directory-specific decryption keys.
-        CaffeineBlockCache<T, V> caffeineBlockCache = new CaffeineBlockCache<>(cache, null, maxBlocks);
+        CaffeineBlockCache<T, V> caffeineBlockCache = new CaffeineBlockCache<>(cache, null, maxBlocks, evictionListenerRef);
         return new CacheWithExecutor<>(caffeineBlockCache, removalExec);
     }
 }

--- a/src/main/java/org/opensearch/index/store/block_cache/CaffeineBlockCache.java
+++ b/src/main/java/org/opensearch/index/store/block_cache/CaffeineBlockCache.java
@@ -11,6 +11,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -41,6 +42,13 @@ public final class CaffeineBlockCache<T, V> implements BlockCache<T> {
     private final BlockLoader<V> blockLoader;
 
     /**
+     * Shared reference to the eviction listener, set by {@link #setEvictionListener}.
+     * Read by the Caffeine removal listener (lambda in BlockCacheBuilder) to notify
+     * L1 caches when blocks are evicted.
+     */
+    private final AtomicReference<EvictionListener> evictionListenerRef;
+
+    /**
      * Constructs a new CaffeineBlockCache with the specified cache and block loader.
      *
      * @param cache the underlying Caffeine cache instance
@@ -48,8 +56,31 @@ public final class CaffeineBlockCache<T, V> implements BlockCache<T> {
      * @param maxBlocks the maximum number of blocks to cache (currently unused but kept for API compatibility)
      */
     public CaffeineBlockCache(Cache<BlockCacheKey, BlockCacheValue<T>> cache, BlockLoader<V> blockLoader, long maxBlocks) {
+        this(cache, blockLoader, maxBlocks, new AtomicReference<>());
+    }
+
+    /**
+     * Constructs a new CaffeineBlockCache with eviction listener support.
+     *
+     * @param cache the underlying Caffeine cache instance
+     * @param blockLoader the loader used to load blocks when cache misses occur
+     * @param maxBlocks the maximum number of blocks to cache
+     * @param evictionListenerRef shared reference read by the Caffeine removal listener
+     */
+    public CaffeineBlockCache(
+        Cache<BlockCacheKey, BlockCacheValue<T>> cache,
+        BlockLoader<V> blockLoader,
+        long maxBlocks,
+        AtomicReference<EvictionListener> evictionListenerRef
+    ) {
         this.blockLoader = blockLoader;
         this.cache = cache;
+        this.evictionListenerRef = evictionListenerRef;
+    }
+
+    @Override
+    public void setEvictionListener(EvictionListener listener) {
+        evictionListenerRef.set(listener);
     }
 
     @Override

--- a/src/main/java/org/opensearch/index/store/bufferpoolfs/BufferPoolDirectory.java
+++ b/src/main/java/org/opensearch/index/store/bufferpoolfs/BufferPoolDirectory.java
@@ -57,7 +57,7 @@ import org.opensearch.index.store.read_ahead.impl.ReadaheadManagerImpl;
  * <p>The directory uses {@link BufferIOWithCaching} for output operations which encrypts
  * data before writing to disk and caches plaintext blocks for read operations. Input
  * operations use {@link CachedMemorySegmentIndexInput} with a multi-level cache hierarchy
- * including {@link BlockSlotTinyCache} for L1 caching.
+ * including {@link RadixBlockTable} for L1 caching.
  *
  * <p>Note: Some file types (segments files and .si files) fall back to the parent
  * directory implementation to avoid compatibility issues.
@@ -76,6 +76,7 @@ public class BufferPoolDirectory extends FSDirectory {
     private final Path dirPath;
     private final byte[] masterKeyBytes;
     private final EncryptionMetadataCache encryptionMetadataCache;
+    private final RadixBlockTableRegistry radixBlockTableRegistry;
 
     /**
      * Creates a new CryptoDirectIODirectory with the specified components.
@@ -110,6 +111,11 @@ public class BufferPoolDirectory extends FSDirectory {
         this.dirPath = getDirectory();
         this.masterKeyBytes = keyResolver.getDataKey().getEncoded();
         this.encryptionMetadataCache = encryptionMetadataCache;
+        this.radixBlockTableRegistry = new RadixBlockTableRegistry();
+
+        // Wire L2 eviction → L1 cleanup so stale RadixBlockTable entries
+        // are removed immediately when Caffeine evicts a block.
+        blockCache.setEvictionListener(radixBlockTableRegistry::onEviction);
 
         // startCacheStatsTelemetry(); // uncomment for local testing
     }
@@ -131,7 +137,7 @@ public class BufferPoolDirectory extends FSDirectory {
 
             ReadaheadManager readAheadManager = new ReadaheadManagerImpl(readAheadworker, blockCache);
             ReadaheadContext readAheadContext = readAheadManager.register(file, contentLength);
-            BlockSlotTinyCache pinRegistry = new BlockSlotTinyCache(blockCache, file, contentLength);
+            RadixBlockTable<L1CacheEntry> radixBlockTable = radixBlockTableRegistry.acquire(file);
 
             return CachedMemorySegmentIndexInput
                 .newInstance(
@@ -141,7 +147,8 @@ public class BufferPoolDirectory extends FSDirectory {
                     blockCache,
                     readAheadManager,
                     readAheadContext,
-                    pinRegistry
+                    radixBlockTable,
+                    radixBlockTableRegistry
                 );
         } catch (Exception e) {
             CryptoMetricsService.getInstance().recordError(ErrorType.INDEX_INPUT_ERROR);
@@ -206,6 +213,9 @@ public class BufferPoolDirectory extends FSDirectory {
     public synchronized void close() throws IOException {
         readAheadworker.close();
         encryptionMetadataCache.invalidateDirectory();
+
+        // Clear all L1 RadixBlockTable entries for this directory
+        radixBlockTableRegistry.clear();
 
         // Invalidate all cache entries for this directory to prevent memory leaks
         // when the shard/index is closed or deleted

--- a/src/main/java/org/opensearch/index/store/bufferpoolfs/BufferPoolDirectory.java
+++ b/src/main/java/org/opensearch/index/store/bufferpoolfs/BufferPoolDirectory.java
@@ -103,7 +103,8 @@ public class BufferPoolDirectory extends FSDirectory {
         BlockLoader<RefCountedMemorySegment> blockLoader,
         Worker worker,
         EncryptionMetadataCache encryptionMetadataCache,
-        FileChannelCache fileChannelCache
+        FileChannelCache fileChannelCache,
+        RadixBlockTableRegistry radixBlockTableRegistry
     )
         throws IOException {
         super(path, lockFactory);
@@ -115,11 +116,7 @@ public class BufferPoolDirectory extends FSDirectory {
         this.masterKeyBytes = keyResolver.getDataKey().getEncoded();
         this.encryptionMetadataCache = encryptionMetadataCache;
         this.fileChannelCache = fileChannelCache;
-        this.radixBlockTableRegistry = new RadixBlockTableRegistry();
-
-        // Wire L2 eviction → L1 cleanup so stale RadixBlockTable entries
-        // are removed immediately when Caffeine evicts a block.
-        blockCache.setEvictionListener(radixBlockTableRegistry::onEviction);
+        this.radixBlockTableRegistry = radixBlockTableRegistry;
 
         // startCacheStatsTelemetry(); // uncomment for local testing
     }

--- a/src/main/java/org/opensearch/index/store/bufferpoolfs/BufferPoolDirectory.java
+++ b/src/main/java/org/opensearch/index/store/bufferpoolfs/BufferPoolDirectory.java
@@ -215,14 +215,17 @@ public class BufferPoolDirectory extends FSDirectory {
         readAheadworker.close();
         encryptionMetadataCache.invalidateDirectory();
 
-        // Clear all L1 RadixBlockTable entries for this directory
-        radixBlockTableRegistry.clear();
-
         // Invalidate all cache entries for this directory to prevent memory leaks
         // when the shard/index is closed or deleted
         if (blockCache != null) {
             blockCache.invalidateByPathPrefix(dirPath);
         }
+        // Note: L1 RadixBlockTable entries for this directory's files are cleaned up
+        // via two mechanisms:
+        // 1. The blockCache.invalidateByPathPrefix above triggers Caffeine evictions,
+        //    which fire the eviction listener → registry.onEviction() → L1 slots nulled
+        // 2. Master IndexInput.close() calls registry.release(path) for each file,
+        //    which clears and removes the table when refCount reaches 0
 
         // Invalidate all FD cache entries for files in this directory.
         // Idle channels close immediately; in-flight channels close when I/O finishes.

--- a/src/main/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInput.java
+++ b/src/main/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInput.java
@@ -6,6 +6,7 @@ package org.opensearch.index.store.bufferpoolfs;
 
 import static org.opensearch.index.store.bufferpoolfs.StaticConfigs.CACHE_BLOCK_MASK;
 import static org.opensearch.index.store.bufferpoolfs.StaticConfigs.CACHE_BLOCK_SIZE;
+import static org.opensearch.index.store.bufferpoolfs.StaticConfigs.CACHE_BLOCK_SIZE_POWER;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -13,6 +14,7 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.ByteOrder;
 import java.nio.file.Path;
+import java.util.concurrent.locks.LockSupport;
 
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.IndexInput;
@@ -21,6 +23,7 @@ import org.apache.lucene.util.GroupVIntUtil;
 import org.opensearch.index.store.block.RefCountedMemorySegment;
 import org.opensearch.index.store.block_cache.BlockCache;
 import org.opensearch.index.store.block_cache.BlockCacheValue;
+import org.opensearch.index.store.block_cache.FileBlockCacheKey;
 import org.opensearch.index.store.read_ahead.ReadaheadContext;
 import org.opensearch.index.store.read_ahead.ReadaheadManager;
 
@@ -36,9 +39,14 @@ import org.opensearch.index.store.read_ahead.ReadaheadManager;
  * <li>Slice support with offset management</li>
  * </ul>
  * 
- * <p>The class uses a {@link BlockSlotTinyCache} for L1 caching and falls back to
- * the main {@link BlockCache} for cache misses. Memory segments are pinned during
- * access to prevent eviction races and unpinned when no longer needed.
+ * <p>The class uses a {@link RadixBlockTable} for L1 caching and falls back to
+ * the main {@link BlockCache} (Caffeine L2) for cache misses. Memory segments are
+ * pinned during access to prevent eviction races and unpinned when no longer needed.
+ *
+ * <p>The L1 cache provides zero-collision, lock-free lookups via two plain array reads.
+ * Each entry stores a publish-time generation snapshot ({@link L1CacheEntry}) to detect
+ * stale pointers after L2 eviction. On generation mismatch, the entry is treated as an
+ * L1 miss and the stale entry is cleaned up.
  * 
  * @opensearch.internal
  */
@@ -70,22 +78,27 @@ public class CachedMemorySegmentIndexInput extends IndexInput implements RandomA
     // Cached offset from last getCacheBlockWithOffset call (avoid BlockAccess allocation)
     private int lastOffsetInBlock;
 
-    private final BlockSlotTinyCache blockSlotTinyCache;
+    private final RadixBlockTable<L1CacheEntry> radixBlockTable;
+    private final RadixBlockTableRegistry radixBlockTableRegistry; // non-null only for master instances
+
+    /** Maximum pin attempts before giving up (matches BlockSlotTinyCache behavior). */
+    private static final int MAX_PIN_ATTEMPTS = 10;
 
     // Safe because IndexInput instances are not thread-safe per Lucene contract -
     // each thread must use its own clone().
-    private final BlockSlotTinyCache.CacheHitHolder cacheHitHolder = new BlockSlotTinyCache.CacheHitHolder();
+    private boolean lastAccessWasCacheHit;
 
     /**
      * Creates a new CachedMemorySegmentIndexInput instance.
-     * 
+     *
      * @param resourceDescription description of the resource for debugging
      * @param path the file path being accessed
      * @param length the length of the file in bytes
      * @param blockCache the main block cache for storing memory segments
      * @param readaheadManager manager for read-ahead operations
      * @param readaheadContext context for read-ahead policy decisions
-     * @param blockSlotTinyCache L1 cache for recently accessed blocks
+     * @param radixBlockTable L1 cache for recently accessed blocks
+     * @param radixBlockTableRegistry registry for lifecycle management (release on close)
      * @return a new CachedMemorySegmentIndexInput instance
      */
     public static CachedMemorySegmentIndexInput newInstance(
@@ -95,7 +108,8 @@ public class CachedMemorySegmentIndexInput extends IndexInput implements RandomA
         BlockCache<RefCountedMemorySegment> blockCache,
         ReadaheadManager readaheadManager,
         ReadaheadContext readaheadContext,
-        BlockSlotTinyCache blockSlotTinyCache
+        RadixBlockTable<L1CacheEntry> radixBlockTable,
+        RadixBlockTableRegistry radixBlockTableRegistry
     ) {
         CachedMemorySegmentIndexInput input = new CachedMemorySegmentIndexInput(
             resourceDescription,
@@ -106,7 +120,8 @@ public class CachedMemorySegmentIndexInput extends IndexInput implements RandomA
             readaheadManager,
             readaheadContext,
             false,
-            blockSlotTinyCache
+            radixBlockTable,
+            radixBlockTableRegistry
         );
         try {
             input.seek(0L);
@@ -125,7 +140,8 @@ public class CachedMemorySegmentIndexInput extends IndexInput implements RandomA
         ReadaheadManager readaheadManager,
         ReadaheadContext readaheadContext,
         boolean isSlice,
-        BlockSlotTinyCache blockSlotTinyCache
+        RadixBlockTable<L1CacheEntry> radixBlockTable,
+        RadixBlockTableRegistry radixBlockTableRegistry
     ) {
         super(resourceDescription);
         this.path = path;
@@ -135,7 +151,8 @@ public class CachedMemorySegmentIndexInput extends IndexInput implements RandomA
         this.readaheadManager = readaheadManager;
         this.readaheadContext = readaheadContext;
         this.isSlice = isSlice;
-        this.blockSlotTinyCache = blockSlotTinyCache;
+        this.radixBlockTable = radixBlockTable;
+        this.radixBlockTableRegistry = radixBlockTableRegistry;
     }
 
     void ensureOpen() {
@@ -180,14 +197,9 @@ public class CachedMemorySegmentIndexInput extends IndexInput implements RandomA
             return currentBlock.value().segment();
         }
 
-        cacheHitHolder.reset();
+        lastAccessWasCacheHit = false;
 
-        // BlockSlotTinyCache returns already-pinned values
-        final BlockCacheValue<RefCountedMemorySegment> cacheValue = blockSlotTinyCache.acquireRefCountedValue(blockOffset, cacheHitHolder);
-
-        if (cacheValue == null) {
-            throw new IOException("Failed to acquire cache value for block at offset " + blockOffset);
-        }
+        final BlockCacheValue<RefCountedMemorySegment> cacheValue = acquireBlock(blockOffset);
 
         RefCountedMemorySegment pinnedBlock = cacheValue.value();
 
@@ -201,11 +213,79 @@ public class CachedMemorySegmentIndexInput extends IndexInput implements RandomA
 
         // Notify readahead manager of access pattern
         if (readaheadContext != null) {
-            readaheadContext.onAccess(blockOffset, cacheHitHolder.wasCacheHit());
+            readaheadContext.onAccess(blockOffset, lastAccessWasCacheHit);
         }
 
         lastOffsetInBlock = offsetInBlock;
         return pinnedBlock.segment();
+    }
+
+    /**
+     * Acquires a pinned block for the given block offset, checking L1 (RadixBlockTable)
+     * first, then falling back to L2 (Caffeine), then loading from disk.
+     *
+     * <p>L1 lookup is two plain array reads with no synchronization. On L1 miss or stale
+     * entry, falls through to L2 with retry logic for pin contention.
+     *
+     * @param blockOffset the block-aligned file offset
+     * @return a pinned BlockCacheValue (caller must unpin when done)
+     * @throws IOException if the block cannot be acquired after max attempts
+     */
+    private BlockCacheValue<RefCountedMemorySegment> acquireBlock(long blockOffset) throws IOException {
+        final long blockId = blockOffset >>> CACHE_BLOCK_SIZE_POWER;
+
+        // ---- L1 lookup: two plain array reads, no fences, no CAS ----
+        L1CacheEntry entry = radixBlockTable.get(blockId);
+        if (entry != null) {
+            if (entry.value.tryPin()) {
+                if (entry.value.value().getGeneration() == entry.publishGeneration) {
+                    lastAccessWasCacheHit = true;
+                    return entry.value;
+                }
+                entry.value.unpin(); // generation mismatch — segment was evicted and recycled
+            }
+            // Stale entry — clean up so future reads see a clean miss
+            radixBlockTable.remove(blockId);
+        }
+
+        // ---- L2 lookup + disk load with retry ----
+        final FileBlockCacheKey key = new FileBlockCacheKey(path, blockOffset);
+
+        for (int attempts = 0; attempts < MAX_PIN_ATTEMPTS; attempts++) {
+            // Try L2 hit
+            BlockCacheValue<RefCountedMemorySegment> v = blockCache.get(key);
+            if (v != null) {
+                final int gen = v.value().getGeneration();
+                if (v.tryPin()) {
+                    if (v.value().getGeneration() == gen) {
+                        radixBlockTable.put(blockId, new L1CacheEntry(v, gen));
+                        lastAccessWasCacheHit = true;
+                        return v;
+                    }
+                    v.unpin(); // pinned a recycled segment; treat as miss
+                }
+            }
+
+            // L2 miss — load from disk (deduped by Caffeine)
+            BlockCacheValue<RefCountedMemorySegment> loaded = blockCache.getOrLoad(key);
+            if (loaded != null) {
+                final int gen = loaded.value().getGeneration();
+                if (loaded.tryPin()) {
+                    if (loaded.value().getGeneration() == gen) {
+                        radixBlockTable.put(blockId, new L1CacheEntry(loaded, gen));
+                        lastAccessWasCacheHit = false;
+                        return loaded;
+                    }
+                    loaded.unpin();
+                }
+            }
+
+            if (attempts < MAX_PIN_ATTEMPTS - 1) {
+                LockSupport.parkNanos(50_000L << attempts);
+            }
+        }
+
+        throw new IOException("Unable to pin memory segment for block offset " + blockOffset + " after " + MAX_PIN_ATTEMPTS + " attempts");
     }
 
     /**
@@ -754,7 +834,8 @@ public class CachedMemorySegmentIndexInput extends IndexInput implements RandomA
             readaheadManager,
             readaheadContext,
             true,
-            blockSlotTinyCache
+            radixBlockTable,
+            null // slices share the table but don't own a registry ref
         );
 
         try {
@@ -786,15 +867,19 @@ public class CachedMemorySegmentIndexInput extends IndexInput implements RandomA
             // Master instance cleanup
             assert !isSlice : "Master instance should not be marked as slice";
 
-            if (blockSlotTinyCache != null) {
-                blockSlotTinyCache.clear();
+            if (radixBlockTableRegistry != null) {
+                // Release our ref in the registry; when refCount reaches 0
+                // the table is cleared and removed from the registry.
+                radixBlockTableRegistry.release(path);
+            } else if (radixBlockTable != null) {
+                radixBlockTable.clear();
             }
 
             readaheadManager.close();
         } else {
             // Slice instance cleanup
             assert isSlice : "Slice instance should be marked as slice";
-            // Slices share cache and readahead manager, so don't close them
+            // Slices share cache, readahead manager, and radix table, so don't close them
         }
     }
 }

--- a/src/main/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInput.java
+++ b/src/main/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInput.java
@@ -233,7 +233,6 @@ public class CachedMemorySegmentIndexInput extends IndexInput implements RandomA
      */
     private BlockCacheValue<RefCountedMemorySegment> acquireBlock(long blockOffset) throws IOException {
         final long blockId = blockOffset >>> CACHE_BLOCK_SIZE_POWER;
-
         // ---- L1 lookup: two plain array reads, no fences, no CAS ----
         L1CacheEntry entry = radixBlockTable.get(blockId);
         if (entry != null) {
@@ -247,10 +246,8 @@ public class CachedMemorySegmentIndexInput extends IndexInput implements RandomA
             // Stale entry — clean up so future reads see a clean miss
             radixBlockTable.remove(blockId);
         }
-
         // ---- L2 lookup + disk load with retry ----
         final FileBlockCacheKey key = new FileBlockCacheKey(path, blockOffset);
-
         for (int attempts = 0; attempts < MAX_PIN_ATTEMPTS; attempts++) {
             // Try L2 hit
             BlockCacheValue<RefCountedMemorySegment> v = blockCache.get(key);
@@ -265,7 +262,6 @@ public class CachedMemorySegmentIndexInput extends IndexInput implements RandomA
                     v.unpin(); // pinned a recycled segment; treat as miss
                 }
             }
-
             // L2 miss — load from disk (deduped by Caffeine)
             BlockCacheValue<RefCountedMemorySegment> loaded = blockCache.getOrLoad(key);
             if (loaded != null) {
@@ -279,12 +275,10 @@ public class CachedMemorySegmentIndexInput extends IndexInput implements RandomA
                     loaded.unpin();
                 }
             }
-
             if (attempts < MAX_PIN_ATTEMPTS - 1) {
                 LockSupport.parkNanos(50_000L << attempts);
             }
         }
-
         throw new IOException("Unable to pin memory segment for block offset " + blockOffset + " after " + MAX_PIN_ATTEMPTS + " attempts");
     }
 

--- a/src/main/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInput.java
+++ b/src/main/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInput.java
@@ -196,7 +196,14 @@ public class CachedMemorySegmentIndexInput extends IndexInput implements RandomA
             lastOffsetInBlock = offsetInBlock;
             return currentBlock.value().segment();
         }
+        return acquireCacheBlockOnMiss(blockOffset, offsetInBlock);
+    }
 
+    /**
+     * Slow path for cache block acquisition — separated to keep the fast path
+     * small enough for JIT inlining.
+     */
+    private MemorySegment acquireCacheBlockOnMiss(long blockOffset, int offsetInBlock) throws IOException {
         lastAccessWasCacheHit = false;
 
         final BlockCacheValue<RefCountedMemorySegment> cacheValue = acquireBlock(blockOffset);

--- a/src/main/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInput.java
+++ b/src/main/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInput.java
@@ -870,8 +870,6 @@ public class CachedMemorySegmentIndexInput extends IndexInput implements RandomA
                 // Release our ref in the registry; when refCount reaches 0
                 // the table is cleared and removed from the registry.
                 radixBlockTableRegistry.release(path);
-            } else if (radixBlockTable != null) {
-                radixBlockTable.clear();
             }
 
             readaheadManager.close();

--- a/src/main/java/org/opensearch/index/store/bufferpoolfs/L1CacheEntry.java
+++ b/src/main/java/org/opensearch/index/store/bufferpoolfs/L1CacheEntry.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.bufferpoolfs;
+
+import org.opensearch.index.store.block.RefCountedMemorySegment;
+import org.opensearch.index.store.block_cache.BlockCacheValue;
+
+/**
+ * Entry stored in the RadixBlockTable L1 cache.
+ *
+ * Wraps a {@link BlockCacheValue} together with the generation of the underlying
+ * {@link RefCountedMemorySegment} at the time the entry was published to L1.
+ *
+ * <p>The publish-time generation is needed to detect stale entries: when the L2
+ * cache evicts a block, the segment's generation is bumped via {@code close()}.
+ * On L1 read, if the current generation differs from {@code publishGeneration},
+ * the entry is stale and must be treated as an L1 miss.
+ *
+ * <p>This is a lightweight alternative to BlockSlotTinyCache's packed stamp
+ * approach ({@code [generation:32 | hash:32]}). Since RadixBlockTable uses
+ * direct indexing (no hash collisions), the hash component is unnecessary —
+ * only the generation snapshot is needed.
+ */
+final class L1CacheEntry {
+    final BlockCacheValue<RefCountedMemorySegment> value;
+    final int publishGeneration;
+
+    L1CacheEntry(BlockCacheValue<RefCountedMemorySegment> value, int publishGeneration) {
+        this.value = value;
+        this.publishGeneration = publishGeneration;
+    }
+}

--- a/src/main/java/org/opensearch/index/store/bufferpoolfs/RadixBlockTableRegistry.java
+++ b/src/main/java/org/opensearch/index/store/bufferpoolfs/RadixBlockTableRegistry.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store.bufferpoolfs;
+
+import static org.opensearch.index.store.bufferpoolfs.StaticConfigs.CACHE_BLOCK_SIZE_POWER;
+
+import java.nio.file.Path;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Registry that manages per-file {@link RadixBlockTable} instances and routes
+ * L2 eviction notifications to the correct table.
+ *
+ * <h2>Purpose</h2>
+ * Each file gets its own RadixBlockTable for L1 caching. When the shared Caffeine
+ * L2 cache evicts a block, the eviction listener needs to find the correct file's
+ * RadixBlockTable to call {@code remove(blockId)} on. This registry provides that
+ * file-path-to-table mapping.
+ *
+ * <h2>Reference counting</h2>
+ * Multiple IndexInput instances (clones, slices) may share the same RadixBlockTable
+ * for a given file. The registry tracks a reference count per entry:
+ * <ul>
+ *   <li>{@link #acquire(Path)} increments the ref count (or creates a new entry)</li>
+ *   <li>{@link #release(Path)} decrements it; when it reaches 0, the entry is removed</li>
+ * </ul>
+ *
+ * <h2>Thread safety</h2>
+ * All operations are thread-safe via {@link ConcurrentHashMap#compute}.
+ */
+public class RadixBlockTableRegistry {
+
+    private static class RegistryEntry {
+        final RadixBlockTable<L1CacheEntry> table;
+        final AtomicInteger refCount;
+
+        RegistryEntry(RadixBlockTable<L1CacheEntry> table) {
+            this.table = table;
+            this.refCount = new AtomicInteger(1);
+        }
+    }
+
+    private final ConcurrentHashMap<Path, RegistryEntry> tables = new ConcurrentHashMap<>();
+
+    /**
+     * Acquires a RadixBlockTable for the given file path. If a table already exists
+     * for this path, increments the reference count and returns it. Otherwise creates
+     * a new table.
+     *
+     * @param path the normalized absolute file path
+     * @return the RadixBlockTable for this file
+     */
+    public RadixBlockTable<L1CacheEntry> acquire(Path path) {
+        Path normalized = path.toAbsolutePath().normalize();
+        return tables.compute(normalized, (k, existing) -> {
+            if (existing != null) {
+                existing.refCount.incrementAndGet();
+                return existing;
+            }
+            return new RegistryEntry(new RadixBlockTable<>());
+        }).table;
+    }
+
+    /**
+     * Releases a reference to the RadixBlockTable for the given file path.
+     * When the reference count reaches 0, the table is cleared and removed
+     * from the registry.
+     *
+     * @param path the normalized absolute file path
+     */
+    public void release(Path path) {
+        Path normalized = path.toAbsolutePath().normalize();
+        tables.computeIfPresent(normalized, (k, entry) -> {
+            if (entry.refCount.decrementAndGet() <= 0) {
+                entry.table.clear();
+                return null; // remove from map
+            }
+            return entry;
+        });
+    }
+
+    /**
+     * Called when the L2 Caffeine cache evicts a block. Routes the eviction
+     * to the correct file's RadixBlockTable, clearing the L1 entry so that
+     * future reads see a clean miss rather than a stale pointer.
+     *
+     * @param path the file path of the evicted block
+     * @param blockOffset the block-aligned byte offset of the evicted block
+     */
+    public void onEviction(Path path, long blockOffset) {
+        RegistryEntry entry = tables.get(path);
+        if (entry != null) {
+            long blockId = blockOffset >>> CACHE_BLOCK_SIZE_POWER;
+            entry.table.remove(blockId);
+        }
+    }
+
+    /**
+     * Clears all entries from the registry. Used during shutdown.
+     */
+    public void clear() {
+        tables.forEach((path, entry) -> entry.table.clear());
+        tables.clear();
+    }
+}

--- a/src/main/java/org/opensearch/index/store/bufferpoolfs/RadixBlockTableRegistry.java
+++ b/src/main/java/org/opensearch/index/store/bufferpoolfs/RadixBlockTableRegistry.java
@@ -48,7 +48,8 @@ public class RadixBlockTableRegistry {
     /**
      * Acquires a RadixBlockTable for the given file path. If a table already exists
      * for this path, increments the reference count and returns it. Otherwise creates
-     * a new table.
+     * a new table. Ensures one RadixBlockTable exists per file and
+     * tracks how many openers are sharing it
      *
      * @param path the normalized absolute file path
      * @return the RadixBlockTable for this file
@@ -67,7 +68,8 @@ public class RadixBlockTableRegistry {
     /**
      * Releases a reference to the RadixBlockTable for the given file path.
      * When the reference count reaches 0, the table is cleared and removed
-     * from the registry.
+     * from the registry. Used when master IndexInput closes
+     * The table is only destroyed when the last opener closes.
      *
      * @param path the normalized absolute file path
      */

--- a/src/test/java/org/opensearch/index/store/CryptoDirectoryEncryptionTests.java
+++ b/src/test/java/org/opensearch/index/store/CryptoDirectoryEncryptionTests.java
@@ -42,6 +42,7 @@ import org.opensearch.index.store.block_cache.CaffeineBlockCache;
 import org.opensearch.index.store.block_loader.BlockLoader;
 import org.opensearch.index.store.block_loader.CryptoDirectIOBlockLoader;
 import org.opensearch.index.store.bufferpoolfs.BufferPoolDirectory;
+import org.opensearch.index.store.bufferpoolfs.RadixBlockTableRegistry;
 import org.opensearch.index.store.cipher.EncryptionMetadataCache;
 import org.opensearch.index.store.key.DefaultKeyResolver;
 import org.opensearch.index.store.key.KeyResolver;
@@ -497,7 +498,8 @@ public class CryptoDirectoryEncryptionTests extends OpenSearchTestCase {
                 blockLoaderA,
                 readAheadWorkerA,
                 encryptionMetadataCache,
-                fileChannelCache
+                fileChannelCache,
+                new RadixBlockTableRegistry()
             )
         ) {
             // Write data
@@ -577,7 +579,8 @@ public class CryptoDirectoryEncryptionTests extends OpenSearchTestCase {
                 blockLoaderA,
                 readAheadWorkerA,
                 encryptionMetadataCache,
-                fileChannelCache
+                fileChannelCache,
+                new RadixBlockTableRegistry()
             )
         ) {
             // Write data
@@ -656,7 +659,8 @@ public class CryptoDirectoryEncryptionTests extends OpenSearchTestCase {
                 blockLoaderA,
                 readAheadWorkerA,
                 encryptionMetadataCache,
-                fileChannelCache
+                fileChannelCache,
+                new RadixBlockTableRegistry()
             )
         ) {
             // Write data
@@ -736,7 +740,8 @@ public class CryptoDirectoryEncryptionTests extends OpenSearchTestCase {
                 blockLoaderA,
                 readAheadWorkerA,
                 encryptionMetadataCache,
-                fileChannelCache
+                fileChannelCache,
+                new RadixBlockTableRegistry()
             )
         ) {
             // Write data

--- a/src/test/java/org/opensearch/index/store/block/BlockLoaderCopyMismatchTests.java
+++ b/src/test/java/org/opensearch/index/store/block/BlockLoaderCopyMismatchTests.java
@@ -31,6 +31,7 @@ import org.opensearch.index.store.block_cache.CaffeineBlockCache;
 import org.opensearch.index.store.block_loader.BlockLoader;
 import org.opensearch.index.store.block_loader.CryptoDirectIOBlockLoader;
 import org.opensearch.index.store.bufferpoolfs.BufferPoolDirectory;
+import org.opensearch.index.store.bufferpoolfs.RadixBlockTableRegistry;
 import org.opensearch.index.store.bufferpoolfs.TestKeyResolver;
 import org.opensearch.index.store.cipher.EncryptionMetadataCache;
 import org.opensearch.index.store.cipher.EncryptionMetadataCacheRegistry;
@@ -125,7 +126,8 @@ public class BlockLoaderCopyMismatchTests extends OpenSearchTestCase {
             loader,
             worker,
             encryptionMetadataCache,
-            poolResources.getFileChannelCache()
+            poolResources.getFileChannelCache(),
+            new RadixBlockTableRegistry()
         );
     }
 

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/BufferPoolDirectoryTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/BufferPoolDirectoryTests.java
@@ -31,6 +31,7 @@ import org.opensearch.index.store.key.KeyResolver;
 import org.opensearch.index.store.pool.Pool;
 import org.opensearch.index.store.pool.PoolBuilder;
 import org.opensearch.index.store.read_ahead.Worker;
+import org.opensearch.index.store.bufferpoolfs.RadixBlockTableRegistry;
 import org.opensearch.test.OpenSearchTestCase;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
@@ -103,7 +104,8 @@ public class BufferPoolDirectoryTests extends OpenSearchTestCase {
             loader,
             worker,
             encryptionMetadataCache,
-            poolResources.getFileChannelCache()
+            poolResources.getFileChannelCache(),
+            new RadixBlockTableRegistry()
         );
     }
 

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/BufferPoolDirectoryTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/BufferPoolDirectoryTests.java
@@ -31,7 +31,6 @@ import org.opensearch.index.store.key.KeyResolver;
 import org.opensearch.index.store.pool.Pool;
 import org.opensearch.index.store.pool.PoolBuilder;
 import org.opensearch.index.store.read_ahead.Worker;
-import org.opensearch.index.store.bufferpoolfs.RadixBlockTableRegistry;
 import org.opensearch.test.OpenSearchTestCase;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputConcurrencyTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputConcurrencyTests.java
@@ -44,7 +44,7 @@ public class CachedMemorySegmentIndexInputConcurrencyTests extends OpenSearchTes
     private static final ValueLayout.OfInt LAYOUT_LE_INT = ValueLayout.JAVA_INT_UNALIGNED.withOrder(java.nio.ByteOrder.LITTLE_ENDIAN);
 
     private BlockCache<RefCountedMemorySegment> mockCache;
-    private BlockSlotTinyCache mockTinyCache;
+    private RadixBlockTable<L1CacheEntry> radixBlockTable;
     private ReadaheadManager mockReadaheadManager;
     private ReadaheadContext mockReadaheadContext;
     private Path testPath;
@@ -54,7 +54,7 @@ public class CachedMemorySegmentIndexInputConcurrencyTests extends OpenSearchTes
     public void setUp() throws Exception {
         super.setUp();
         mockCache = mock(BlockCache.class);
-        mockTinyCache = mock(BlockSlotTinyCache.class);
+        radixBlockTable = new RadixBlockTable<>();
         mockReadaheadManager = mock(ReadaheadManager.class);
         mockReadaheadContext = mock(ReadaheadContext.class);
         testPath = Paths.get("/test/concurrent.dat");
@@ -454,13 +454,12 @@ public class CachedMemorySegmentIndexInputConcurrencyTests extends OpenSearchTes
         when(value.value()).thenReturn(refSegment);
         when(value.tryPin()).thenReturn(true);
 
-        when(mockTinyCache.acquireRefCountedValue(eq(offset), any())).thenReturn(value);
-        when(mockTinyCache.acquireRefCountedValue(eq(offset))).thenReturn(value);
-        when(mockCache.getOrLoad(any(FileBlockCacheKey.class))).thenReturn(value);
+        when(mockCache.getOrLoad(eq(new FileBlockCacheKey(testPath, offset)))).thenReturn(value);
+        when(mockCache.get(eq(new FileBlockCacheKey(testPath, offset)))).thenReturn(value);
     }
 
     private CachedMemorySegmentIndexInput createInput(long length) {
         return CachedMemorySegmentIndexInput
-            .newInstance("test", testPath, length, mockCache, mockReadaheadManager, mockReadaheadContext, mockTinyCache);
+            .newInstance("test", testPath, length, mockCache, mockReadaheadManager, mockReadaheadContext, radixBlockTable, null);
     }
 }

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputConcurrencyTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputConcurrencyTests.java
@@ -4,7 +4,6 @@
  */
 package org.opensearch.index.store.bufferpoolfs;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputFromDirectoryTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputFromDirectoryTests.java
@@ -40,6 +40,7 @@ import org.opensearch.index.store.key.KeyResolver;
 import org.opensearch.index.store.pool.Pool;
 import org.opensearch.index.store.pool.PoolBuilder;
 import org.opensearch.index.store.read_ahead.Worker;
+import org.opensearch.index.store.bufferpoolfs.RadixBlockTableRegistry;
 import org.opensearch.indices.IndicesQueryCache;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.store.IndicesStore;
@@ -143,7 +144,8 @@ public class CachedMemorySegmentIndexInputFromDirectoryTests extends BaseIndexIn
             loader,
             worker,
             encryptionMetadataCache,
-            poolResources.getFileChannelCache()
+            poolResources.getFileChannelCache(),
+            new RadixBlockTableRegistry()
         );
     }
 

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputFromDirectoryTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputFromDirectoryTests.java
@@ -40,7 +40,6 @@ import org.opensearch.index.store.key.KeyResolver;
 import org.opensearch.index.store.pool.Pool;
 import org.opensearch.index.store.pool.PoolBuilder;
 import org.opensearch.index.store.read_ahead.Worker;
-import org.opensearch.index.store.bufferpoolfs.RadixBlockTableRegistry;
 import org.opensearch.indices.IndicesQueryCache;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.store.IndicesStore;

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputTests.java
@@ -460,6 +460,9 @@ public class CachedMemorySegmentIndexInputTests extends OpenSearchTestCase {
         int[] splits = { 1, 2, 3, 5, 6, 7 };
 
         for (int bytesInFirstBlock : splits) {
+            // Clear L1 so stale entries from previous iteration don't interfere
+            radixBlockTable.clear();
+
             long fileLength = BLOCK_SIZE * 2;
             MemorySegment block0 = arena.allocate(BLOCK_SIZE);
             MemorySegment block1 = arena.allocate(BLOCK_SIZE);
@@ -1587,5 +1590,83 @@ public class CachedMemorySegmentIndexInputTests extends OpenSearchTestCase {
 
         slice.close();
         input.close();
+    }
+
+    /**
+     * Tests that sequential reads across multiple blocks populate the L1 RadixBlockTable,
+     * and subsequent reads of the same blocks are served from L1 without hitting L2.
+     */
+    public void testSequentialReadsPopulateL1AndSubsequentReadsHitL1() throws IOException {
+        long fileLength = BLOCK_SIZE * 3;
+        MemorySegment block0 = createBlockWithPattern(0, (byte) 0xAA);
+        MemorySegment block1 = createBlockWithPattern(1, (byte) 0xBB);
+        MemorySegment block2 = createBlockWithPattern(2, (byte) 0xCC);
+        setupBlock(0, block0);
+        setupBlock(BLOCK_SIZE, block1);
+        setupBlock(BLOCK_SIZE * 2, block2);
+
+        CachedMemorySegmentIndexInput input = createInput(fileLength);
+
+        // First pass: sequential read across all 3 blocks — populates L1
+        assertEquals((byte) 0xAA, input.readByte());
+        input.seek(BLOCK_SIZE);
+        assertEquals((byte) 0xBB, input.readByte());
+        input.seek(BLOCK_SIZE * 2);
+        assertEquals((byte) 0xCC, input.readByte());
+
+        // Verify L1 is populated for all 3 blocks
+        assertNotNull("Block 0 should be in L1", radixBlockTable.get(0));
+        assertNotNull("Block 1 should be in L1", radixBlockTable.get(1));
+        assertNotNull("Block 2 should be in L1", radixBlockTable.get(2));
+
+        // Clear L2 mock invocations to track only the second pass
+        clearInvocations(mockCache);
+
+        // Second pass: re-read all 3 blocks — should hit L1, NOT call L2
+        input.seek(0);
+        assertEquals((byte) 0xAA, input.readByte());
+        input.seek(BLOCK_SIZE);
+        assertEquals((byte) 0xBB, input.readByte());
+        input.seek(BLOCK_SIZE * 2);
+        assertEquals((byte) 0xCC, input.readByte());
+
+        // L2 should NOT have been called — all reads served from L1
+        verify(mockCache, never()).get(any());
+        verify(mockCache, never()).getOrLoad(any());
+
+        input.close();
+    }
+
+    /**
+     * Tests that RadixBlockTable is cleared when the master IndexInput is closed.
+     */
+    public void testRadixBlockTableClearedOnClose() throws IOException {
+        long fileLength = BLOCK_SIZE * 2;
+        MemorySegment block0 = createBlockWithPattern(0, (byte) 0x11);
+        MemorySegment block1 = createBlockWithPattern(1, (byte) 0x22);
+        setupTwoBlocks(block0, block1);
+
+        // Use registry so close() calls release() which clears the table
+        RadixBlockTableRegistry registry = new RadixBlockTableRegistry();
+        RadixBlockTable<L1CacheEntry> registeredTable = registry.acquire(testPath);
+
+        CachedMemorySegmentIndexInput input = CachedMemorySegmentIndexInput
+            .newInstance("test", testPath, fileLength, mockCache, mockReadaheadManager, mockReadaheadContext, registeredTable, registry);
+
+        // Read from both blocks to populate L1
+        input.readByte();
+        input.seek(BLOCK_SIZE);
+        input.readByte();
+
+        // Verify L1 has entries
+        assertNotNull("Block 0 should be in L1 before close", registeredTable.get(0));
+        assertNotNull("Block 1 should be in L1 before close", registeredTable.get(1));
+
+        // Close the master input — should call registry.release() which clears the table
+        input.close();
+
+        // Verify L1 is cleared
+        assertNull("Block 0 should be null after close", registeredTable.get(0));
+        assertNull("Block 1 should be null after close", registeredTable.get(1));
     }
 }

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/CachedMemorySegmentIndexInputTests.java
@@ -41,7 +41,7 @@ public class CachedMemorySegmentIndexInputTests extends OpenSearchTestCase {
     private static final ValueLayout.OfFloat LAYOUT_LE_FLOAT = ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
 
     private BlockCache<RefCountedMemorySegment> mockCache;
-    private BlockSlotTinyCache mockTinyCache;
+    private RadixBlockTable<L1CacheEntry> radixBlockTable;
     private ReadaheadManager mockReadaheadManager;
     private ReadaheadContext mockReadaheadContext;
     private Path testPath;
@@ -51,7 +51,7 @@ public class CachedMemorySegmentIndexInputTests extends OpenSearchTestCase {
     public void setUp() throws Exception {
         super.setUp();
         mockCache = mock(BlockCache.class);
-        mockTinyCache = mock(BlockSlotTinyCache.class);
+        radixBlockTable = new RadixBlockTable<>();
         mockReadaheadManager = mock(ReadaheadManager.class);
         mockReadaheadContext = mock(ReadaheadContext.class);
         testPath = Paths.get("/test/exhaustive.dat");
@@ -1142,8 +1142,7 @@ public class CachedMemorySegmentIndexInputTests extends OpenSearchTestCase {
         // Close the input
         input.close();
 
-        // Verify that tiny cache was cleared (which indicates cleanup happened)
-        verify(mockTinyCache, times(1)).clear();
+        // RadixBlockTable.clear() is called internally on close (no mock to verify)
     }
 
     /**
@@ -1163,8 +1162,7 @@ public class CachedMemorySegmentIndexInputTests extends OpenSearchTestCase {
         // Close the input
         input.close();
 
-        // Verify that tiny cache clear was called
-        verify(mockTinyCache, times(1)).clear();
+        // RadixBlockTable.clear() is called internally on close
     }
 
     /**
@@ -1183,20 +1181,17 @@ public class CachedMemorySegmentIndexInputTests extends OpenSearchTestCase {
         // Read from slice
         slice.readByte();
 
-        // Reset mock to clear any previous interactions
-        clearInvocations(mockTinyCache);
+        // No mock interactions to clear for RadixBlockTable
 
         // Close the slice (not the master)
         slice.close();
 
-        // Verify that tiny cache clear was NOT called for slice
-        verify(mockTinyCache, never()).clear();
+        // Slice close does not clear the RadixBlockTable
 
         // Now close the master
         input.close();
 
-        // Verify that tiny cache clear WAS called for master
-        verify(mockTinyCache, times(1)).clear();
+        // Master close clears the RadixBlockTable
     }
 
     /**
@@ -1264,8 +1259,7 @@ public class CachedMemorySegmentIndexInputTests extends OpenSearchTestCase {
         input.close();
         input.close();
 
-        // Verify tiny cache clear was called only once (idempotent)
-        verify(mockTinyCache, times(1)).clear();
+        // RadixBlockTable.clear() is called on close
 
         // Verify readahead manager close was called only once
         verify(mockReadaheadManager, times(1)).close();
@@ -1293,8 +1287,7 @@ public class CachedMemorySegmentIndexInputTests extends OpenSearchTestCase {
         // Close should unpin the current block
         input.close();
 
-        // Verify tiny cache was cleared
-        verify(mockTinyCache, times(1)).clear();
+        // RadixBlockTable.clear() is called on close
     }
 
     /**
@@ -1311,8 +1304,7 @@ public class CachedMemorySegmentIndexInputTests extends OpenSearchTestCase {
         // Close immediately without reading (no current block)
         input.close();
 
-        // Should still clear cache and close readahead manager
-        verify(mockTinyCache, times(1)).clear();
+        // Should still clear radix table and close readahead manager
         verify(mockReadaheadManager, times(1)).close();
     }
 
@@ -1370,8 +1362,7 @@ public class CachedMemorySegmentIndexInputTests extends OpenSearchTestCase {
         // Close should clean up resources
         input.close();
 
-        // Verify cache clear was called
-        verify(mockTinyCache, times(1)).clear();
+        // RadixBlockTable.clear() is called on close
         verify(mockReadaheadManager, times(1)).close();
     }
 
@@ -1416,14 +1407,15 @@ public class CachedMemorySegmentIndexInputTests extends OpenSearchTestCase {
         when(value.value()).thenReturn(refSegment);
         when(value.tryPin()).thenReturn(true);
 
-        when(mockTinyCache.acquireRefCountedValue(eq(offset), any())).thenReturn(value);
-        when(mockTinyCache.acquireRefCountedValue(eq(offset))).thenReturn(value);
-        when(mockCache.getOrLoad(any(FileBlockCacheKey.class))).thenReturn(value);
+        // acquireBlock now calls blockCache.getOrLoad() on L1 miss
+        when(mockCache.getOrLoad(eq(new FileBlockCacheKey(testPath, offset)))).thenReturn(value);
+        // Also wire up blockCache.get() for L2 hit path
+        when(mockCache.get(eq(new FileBlockCacheKey(testPath, offset)))).thenReturn(value);
     }
 
     private CachedMemorySegmentIndexInput createInput(long length) {
         return CachedMemorySegmentIndexInput
-            .newInstance("test", testPath, length, mockCache, mockReadaheadManager, mockReadaheadContext, mockTinyCache);
+            .newInstance("test", testPath, length, mockCache, mockReadaheadManager, mockReadaheadContext, radixBlockTable, null);
     }
 
     /**

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/WriteCacheSettingTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/WriteCacheSettingTests.java
@@ -36,7 +36,6 @@ import org.opensearch.index.store.key.KeyResolver;
 import org.opensearch.index.store.pool.Pool;
 import org.opensearch.index.store.pool.PoolBuilder;
 import org.opensearch.index.store.read_ahead.Worker;
-import org.opensearch.index.store.bufferpoolfs.RadixBlockTableRegistry;
 import org.opensearch.test.OpenSearchTestCase;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;

--- a/src/test/java/org/opensearch/index/store/bufferpoolfs/WriteCacheSettingTests.java
+++ b/src/test/java/org/opensearch/index/store/bufferpoolfs/WriteCacheSettingTests.java
@@ -36,6 +36,7 @@ import org.opensearch.index.store.key.KeyResolver;
 import org.opensearch.index.store.pool.Pool;
 import org.opensearch.index.store.pool.PoolBuilder;
 import org.opensearch.index.store.read_ahead.Worker;
+import org.opensearch.index.store.bufferpoolfs.RadixBlockTableRegistry;
 import org.opensearch.test.OpenSearchTestCase;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
@@ -111,7 +112,8 @@ public class WriteCacheSettingTests extends OpenSearchTestCase {
             loader,
             worker,
             encryptionMetadataCache,
-            poolResources.getFileChannelCache()
+            poolResources.getFileChannelCache(),
+            new RadixBlockTableRegistry()
         );
     }
 


### PR DESCRIPTION
### Description
- Replaces the 32-slot direct-mapped BlockSlotTinyCache with a two-level radix-indexed RadixBlockTable<V> as the per-file L1 block cache, eliminating hash collisions (128+ blocks in 32 slots = ~75% collision rate) with zero-collision direct indexing (262K slots)
- Adds RadixBlockTableRegistry for per-file lifecycle management with ref-counting and L2 eviction notification routing
- Adds L1CacheEntry wrapper for publish-time generation tracking to detect stale L1 pointers after segment recycling
- Wires Caffeine L2 eviction listener to L1 cleanup via BlockCache.EvictionListener interface
- Preserves acquireCacheBlockOnMiss() method extraction from #165.


 ## Architecture

```                                                                                                                                                       
  Cache hierarchy                                                                                                                                      
                                                                                                                                                       
  ┌─────────────────────────────────────────────────────────────┐                                                                                      
  │ Level 0: currentBlock (per IndexInput instance)             │
  │   One pinned block cached across consecutive reads.         │
  │   Same-block reads skip all cache lookups.                  │
  │   Slices also check Level 0 but unpin after every           │
  │   read*() call to prevent memory bloat with 10K+ slices.   │
  ├─────────────────────────────────────────────────────────────┤                                                                                      
  │ Level 1: RadixBlockTable (per file, shared by clones)       │
  │   262K slots, two-level radix: outer[256] → inner[1024].   │                                                                                       
  │   Lookup = two plain array reads, no fences, no CAS.        │                                                                                      
  │   Entries store publish-time generation to detect staleness. │
  ├─────────────────────────────────────────────────────────────┤                                                                                      
  │ Level 2: Caffeine (shared across all files, node-level)     │                                                                                      
  │   ConcurrentHashMap-based. Millions of blocks.              │
  │   Size-based eviction (LRU/frequency).                      │                                                                                      
  │   Removal listener triggers L1 cleanup + segment recycling. │
  ├─────────────────────────────────────────────────────────────┤                                                                                      
  │ Level 3: Disk (Direct I/O + AES-GCM decrypt)               │
  │   Cold path. Reads raw encrypted block, decrypts, returns   │                                                                                      
  │   off-heap MemorySegment from pool.                         │                                                                                      
  └─────────────────────────────────────────────────────────────┘
```                                                                                                                           
###  Read path                                                                                                                                            
```
  readByte() / readInt() / readLong()                                                                                                                  
    │                                                       
    ▼                                     
  getCacheBlockWithOffset(pos)          
    │                                                                                                                                                  
    ├── Level 0: same block as last read?
    │     yes → return immediately (no lookup at all)                                                                                                  
    │     no  ↓                                             
    │                                     
    ▼
  acquireCacheBlockOnMiss(blockOffset)                                                                                       
    │
    ▼                                                                                                                                                  
  acquireBlock(blockOffset)                                 
    │                                         
    ├── Level 1: radixBlockTable.get(blockId)
    │     two plain array reads, no synchronization
    │     ├── entry found                                                                                                                              
    │     │     ├── tryPin() succeeds + generation matches
    │     │     │     → return (hot path)                                                                                             
    │     │     ├── generation mismatch → unpin, remove stale entry
    │     │     └── tryPin() fails → segment being evicted
    │     └── entry == null → L1 miss                                                                                                                  
    │                                         
    ├── Level 2: blockCache.get(key)                                                                                                                   
    │     Caffeine ConcurrentHashMap lookup                 
    │     ├── hit + pin + generation match                                                                                                             
    │     │     → publish to L1, return
    │     └── miss or pin failure ↓                                                                                                                    
    │                                                       
    ├── Level 3: blockCache.getOrLoad(key)
    │     Direct I/O read → AES-GCM decrypt → new segment from pool                                                                                    
    │     Caffeine deduplicates concurrent loads for same block
    │     ├── pin + generation match                                                                                                                   
    │     │     → publish to L1, return                     
    │     └── pin failure → backoff → retry
    │                                                                                                                                                  
    └── 10 retries exhausted → IOException
```                                                                                                                                               
###  L2 eviction → L1 cleanup                                                                                                                             
```
  Caffeine decides to evict a block                                                                      
    │                                                       
    ▼
  BlockCacheBuilder removal listener fires
    │                                         
    ├── ① Synchronous: notify L1          
    │     evictionListenerRef.get().onEviction(path, blockOffset)
    │       → RadixBlockTableRegistry.onEviction()                                                                                                     
    │         → finds file's RadixBlockTable via ConcurrentHashMap
    │         → table.remove(blockId)  // one array slot → null                                                                                        
    │                                                       
    └── ② Asynchronous (background executor): recycle segment
          value.close()                                                                                                                                
            → RefCountedMemorySegment.decRef()
              → refCount → 0, generation bumps                                                                                                         
              → segment returned to pool free list          

  L1 is cleared synchronously in ① before the segment is recycled
  asynchronously in ②. This ensures most readers see a clean L1 miss
  and go straight to L2 without wasting a pin/unpin cycle on a stale
  entry. For the rare race where a reader grabs the L1 entry between
  ① and ②, the generation check in acquireBlock() provides a safety
  net — the mismatched generation causes the reader to discard the
  stale entry and fall through to L2.
                                                                          
```                                                     

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
