### PR TITLE
Fix L1 BlockSlotTinyCache torn-read corruption 

### DIFF
--- a/src/internalClusterTest/java/org/opensearch/index/store/UpdateConflictIntegTests.java
+++ b/src/internalClusterTest/java/org/opensearch/index/store/UpdateConflictIntegTests.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.opensearch.action.admin.indices.forcemerge.ForceMergeResponse;
+import org.opensearch.action.bulk.BulkRequestBuilder;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.engine.EngineFactory;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+/**
+ * Reproduces merge corruption under concurrent update workloads:
+ *
+ *   org.apache.lucene.index.CorruptIndexException: Illegal dict length
+ *     (resource=CachedMemorySegmentIndexInput(path="..._N.cfs") [slice=_N.fdt])
+ *   Caused by: java.lang.ArrayIndexOutOfBoundsException:
+ *     arraycopy: source index -N out of bounds for byte[M]
+ *       at org.apache.lucene.util.compress.LZ4.decompress
+ *       at SegmentMerger.mergeFields → copyOneDoc → serializedDocument
+ *
+ * Triggered by 8 bulk indexing clients with 50% conflict rate and sustained updates.
+ * Background merges read stored fields from compound files via the encrypted Direct I/O
+ * block cache → L1 cache serves wrong block due to torn read on ARM → LZ4 decompresses
+ * garbage → shard fails with "tragic event" → cluster goes RED.
+ *
+ * Disables translog encryption (CryptoDirectoryNoTranslogPlugin) to isolate the
+ * Lucene stored fields read path.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+@ThreadLeakFilters(filters = CaffeineThreadLeakFilter.class)
+public class UpdateConflictIntegTests extends OpenSearchIntegTestCase {
+
+    /**
+     * Plugin that provides the encrypted directory WITHOUT translog encryption,
+     * matching the serverless setup. Isolates the Lucene/block-cache read path.
+     */
+    public static class CryptoDirectoryNoTranslogPlugin extends CryptoDirectoryPlugin {
+        public CryptoDirectoryNoTranslogPlugin(Settings settings) {
+            super(settings);
+        }
+
+        @Override
+        public Optional<EngineFactory> getEngineFactory(IndexSettings indexSettings) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(CryptoDirectoryNoTranslogPlugin.class, MockCryptoKeyProviderPlugin.class, MockCryptoPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings
+            .builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put("plugins.crypto.enabled", true)
+            .put("node.store.crypto.pool_size_percentage", 0.05)
+            .put("node.store.crypto.warmup_percentage", 0.0)
+            .put("node.store.crypto.cache_to_pool_ratio", 0.8)
+            .put("node.store.crypto.write_cache_enabled", false)
+            .build();
+    }
+
+    @Override
+    protected boolean addMockInternalEngine() {
+        return false;
+    }
+
+    private Settings cryptoIndexSettings(int shards) {
+        return Settings
+            .builder()
+            .put("index.store.type", "cryptofs")
+            .put("index.store.crypto.key_provider", "dummy")
+            .put("index.store.crypto.kms.key_arn", "dummyArn")
+            .put("index.number_of_shards", shards)
+            .put("index.number_of_replicas", 0)
+            .build();
+    }
+
+    /**
+     * Replicates a heavy update-only workload:
+     * - 5 shards, 8 bulk indexing clients
+     * - http_logs-like documents (~500B JSON)
+     * - 50% conflict rate (updates to existing docs)
+     * - 60+ second sustained load
+     * - Followed by refresh + force-merge
+     *
+     * Asserts no corruption errors AND that the cluster stays GREEN (no shard failures).
+     */
+    public void testUpdateOnlyWorkload() throws Exception {
+        internalCluster().startNode();
+
+        String indexName = "logs-update";
+        Settings settings = Settings
+            .builder()
+            .put(cryptoIndexSettings(5))
+            .put("index.refresh_interval", "1s")
+            .put("index.merge.policy.segments_per_tier", "10")
+            .put("index.merge.policy.max_merge_at_once", "10")
+            .put("index.merge.policy.floor_segment", "2mb")
+            .build();
+
+        createIndex(indexName, settings);
+        ensureGreen(indexName);
+
+        // Phase 1: Initial bulk indexing — sized to fit in 512MB test JVM heap
+        int totalDocs = 20_000;
+        int initialBulkSize = 2000;
+        for (int batch = 0; batch < totalDocs / initialBulkSize; batch++) {
+            BulkRequestBuilder bulk = client().prepareBulk();
+            for (int i = 0; i < initialBulkSize; i++) {
+                int docId = batch * initialBulkSize + i;
+                bulk.add(client().prepareIndex(indexName).setId(String.valueOf(docId)).setSource(httpLogDoc(docId, 0)));
+            }
+            BulkResponse resp = bulk.get();
+            assertFalse("Initial bulk failed: " + resp.buildFailureMessage(), resp.hasFailures());
+        }
+        refresh(indexName);
+        logger.info("Initial indexing done: {} docs", totalDocs);
+
+        // Phase 2: 8 clients doing continuous bulk updates with 50% conflict rate
+        int numClients = 8;
+        long durationMs = 120_000;
+        long deadline = System.currentTimeMillis() + durationMs;
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(numClients);
+        AtomicInteger corruptionErrors = new AtomicInteger(0);
+        AtomicInteger totalBulks = new AtomicInteger(0);
+        AtomicInteger totalDocsUpdated = new AtomicInteger(0);
+
+        ExecutorService executor = Executors.newFixedThreadPool(numClients);
+
+        try {
+            for (int c = 0; c < numClients; c++) {
+                final int clientId = c;
+                executor.submit(() -> {
+                    try {
+                        startLatch.await();
+                        int round = 0;
+                        while (System.currentTimeMillis() < deadline) {
+                            BulkRequestBuilder bulk = client().prepareBulk();
+                            int currentBulkSize = 500;
+                            for (int i = 0; i < currentBulkSize; i++) {
+                                // 50% conflict: update existing; 50%: upsert new
+                                int docId;
+                                if (randomBoolean()) {
+                                    docId = randomIntBetween(0, totalDocs - 1);
+                                } else {
+                                    docId = randomIntBetween(totalDocs, totalDocs * 2);
+                                }
+                                bulk
+                                    .add(
+                                        new UpdateRequest(indexName, String.valueOf(docId)).doc(httpLogDoc(docId, round)).docAsUpsert(true)
+                                    );
+                            }
+                            BulkResponse response = bulk.get();
+                            totalBulks.incrementAndGet();
+                            totalDocsUpdated.addAndGet(currentBulkSize);
+                            checkResponseForCorruption(response, clientId, round, corruptionErrors);
+                            round++;
+                        }
+                    } catch (Exception e) {
+                        checkExceptionForCorruption(e, clientId, corruptionErrors);
+                    } finally {
+                        doneLatch.countDown();
+                    }
+                });
+            }
+
+            startLatch.countDown();
+            assertThat("Update threads timed out", doneLatch.await(durationMs + 60_000, TimeUnit.MILLISECONDS), is(true));
+
+            logger
+                .info(
+                    "Update phase done: {} bulks, {} docs updated, {} corruption errors",
+                    totalBulks.get(),
+                    totalDocsUpdated.get(),
+                    corruptionErrors.get()
+                );
+
+        } finally {
+            executor.shutdown();
+            executor.awaitTermination(30, TimeUnit.SECONDS);
+        }
+
+        // Phase 3: Refresh + force-merge — where the merge corruption typically manifests
+        refresh(indexName);
+        logger.info("Starting force-merge after updates");
+
+        ForceMergeResponse mergeResponse = client()
+            .admin()
+            .indices()
+            .prepareForceMerge(indexName)
+            .setMaxNumSegments(1)
+            .setFlush(true)
+            .get();
+
+        assertThat("Force merge had failed shards (merge corruption)", mergeResponse.getFailedShards(), equalTo(0));
+
+        // The "tragic event" path causes shard failures → cluster RED
+        var health = client().admin().cluster().prepareHealth(indexName).get();
+        assertThat("Cluster RED — shard failed due to merge corruption", health.getStatus().toString(), equalTo("GREEN"));
+
+        refresh(indexName);
+        SearchResponse afterMerge = client().prepareSearch(indexName).setSize(0).get();
+        assertThat("Should have docs after merge", afterMerge.getHits().getTotalHits().value(), greaterThan(0L));
+
+        assertThat("Corruption errors detected during workload", corruptionErrors.get(), equalTo(0));
+    }
+
+    private XContentBuilder httpLogDoc(int docId, int round) throws java.io.IOException {
+        return XContentFactory
+            .jsonBuilder()
+            .startObject()
+            .field("@timestamp", System.currentTimeMillis())
+            .field("clientip", "192.168." + (docId % 256) + "." + (docId % 256))
+            .field("request", "GET /index.html?id=" + docId + " HTTP/1.0")
+            .field("status", randomFrom(200, 201, 204, 301, 302, 304, 400, 404, 500))
+            .field("size", randomIntBetween(100, 50000))
+            .field("response_time_ms", randomIntBetween(1, 5000))
+            .field("user_agent", "Mozilla/5.0 (compatible; bot/" + round + ") doc-" + docId)
+            .field("referer", "https://example.com/page" + (docId % 100))
+            .field("method", randomFrom("GET", "POST", "PUT", "DELETE"))
+            .field("protocol", "HTTP/1.1")
+            .field("host", "host" + (docId % 50) + ".example.com")
+            .field("region", randomFrom("us-east-1", "us-west-2", "eu-west-1", "ap-south-1"))
+            .field("update_round", round)
+            .field("doc_id", docId)
+            .endObject();
+    }
+
+    private void checkResponseForCorruption(BulkResponse response, int clientId, int round, AtomicInteger corruptionErrors) {
+        if (response.hasFailures()) {
+            String msg = response.buildFailureMessage();
+            if (containsCorruptionSignature(msg)) {
+                corruptionErrors.incrementAndGet();
+                logger.error("CORRUPTION in client {} round {}: {}", clientId, round, msg);
+            }
+        }
+    }
+
+    private void checkExceptionForCorruption(Exception e, int clientId, AtomicInteger corruptionErrors) {
+        String msg = e.getMessage() != null ? e.getMessage() : "";
+        if (containsCorruptionSignature(msg)) {
+            corruptionErrors.incrementAndGet();
+            logger.error("CORRUPTION exception in client {}: {}", clientId, msg, e);
+        }
+    }
+
+    private boolean containsCorruptionSignature(String msg) {
+        return msg.contains("arraycopy")
+            || msg.contains("Unknown type flag")
+            || msg.contains("LZ4")
+            || msg.contains("Illegal dict length")
+            || msg.contains("tragic")
+            || msg.contains("already closed")
+            || msg.contains("CorruptIndexException");
+    }
+}

--- a/src/main/java/org/opensearch/index/store/bufferpoolfs/BlockSlotTinyCache.java
+++ b/src/main/java/org/opensearch/index/store/bufferpoolfs/BlockSlotTinyCache.java
@@ -7,11 +7,11 @@ package org.opensearch.index.store.bufferpoolfs;
 import static org.opensearch.index.store.bufferpoolfs.StaticConfigs.CACHE_BLOCK_SIZE_POWER;
 
 import java.io.IOException;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.VarHandle;
 import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.concurrent.locks.LockSupport;
 
+import lombok.val;
 import org.opensearch.index.store.block.RefCountedMemorySegment;
 import org.opensearch.index.store.block_cache.BlockCache;
 import org.opensearch.index.store.block_cache.BlockCacheValue;
@@ -20,55 +20,17 @@ import org.opensearch.index.store.block_cache.FileBlockCacheKey;
 /**
  * Tiny L1 cache in front of the main Caffeine L2 cache.
  *
- * Accessing Caffeine for every block read is expensive even when it's a cache hit.
- * This gives us a tiny 32-slot direct-mapped cache that sits in front of Caffeine,
- * handling the hottest blocks with zero locking and minimal overhead.
+ * Uses an immutable record per slot published via AtomicReferenceArray to eliminate
+ * torn reads. A single atomic reference read gives the reader a consistent snapshot
+ * of (blockIdx, value, generation) — no possibility of observing fields from
+ * different writers.
  *
- * We maintain 32 slots using parallel arrays. Each slot can hold one cached block.
- * The slot index is computed by hashing the block index: hash(blockIdx) % 32.
- *
- * Each slot stores three pieces of data (in separate arrays):
- *   - slotBlockIdx[i]: which block number is cached here
- *   - slotVal[i]: the actual cached segment value
- *   - slotStamp[i]: packed [generation:32 | hash:32] acting as a memory barrier gate
- *
- * SYNCHRONIZATION VIA STAMP GATE:
- * We can't use locks (too slow) and we can't make everything volatile (too slow).
- * Instead we use acquire/release ordering on the stamp as a publication gate.
- *
- * When writing to a slot (publishToL1):
- *   1. Write slotBlockIdx[i] and slotVal[i] with plain stores
- *   2. Pack (hash, generation) into a stamp
- *   3. Write stamp[i] with RELEASE semantics (VarHandle.setRelease)
- *      This ensures all preceding writes become visible before the stamp update.
- *
- * When reading from a slot (acquireRefCountedValue):
- *   1. Read stamp[i] with ACQUIRE semantics (VarHandle.getAcquire)
- *      This ensures we don't read dependent fields before seeing the stamp.
- *   2. Check if hash matches our target block
- *   3. If yes, safe to read slotBlockIdx[i] and slotVal[i]
- *      The acquire load guarantees we see the values the writer published.
- *
- * Result: If stamp matches, {slotBlockIdx, slotVal} are guaranteed consistent.
- * No torn reads, no stale data, no locks needed. We cannot affors locks, the moment 
- * you add a lock, reading from caffeine directly is going to be better.
- *
- * HANDLING SEGMENT RECYCLING (THE TRICKY PART):
- * Memory segments get recycled: evicted, returned to pool, reused for different blocks.
- * If you cache a pointer to block 42 (say) but that memory gets reused for block 99 (say), you'll
- * read wrong data. We use generation counters to detect this.
- *
- * Each segment has a generation number that bumps on eviction. We snapshot the generation
- * in the stamp when caching. When retrieving, we do pin-then-validate:
- *   1. Pin the segment (holds refcount, prevents pool return)
- *   2. Check generation still matches snapshot
- *   3. If match: safe. If mismatch: unpin, treat as miss (segment was recycled)
- *
- * Why pin BEFORE validating? If we check generation first, the segment could get evicted
- * and recycled between the check and pin. Pin holds it stable during validation.
- * Generation detects staleness, pinning controls lifecycle. Hand-in-hand coordination. But
- * we avoid tight coupling of generation with pin -- they serve different purposes.
- *
+ * Thread safety:
+ * - Writers create a new immutable SlotEntry and publish via plain store to the
+ *   AtomicReferenceArray (reference writes are atomic per JLS §17.7).
+ * - Readers load the reference atomically; all fields are final and guaranteed
+ *   fully constructed (JLS §17.5 final field semantics).
+ * - A stale read sees either the old entry or the new entry, never a mix.
  */
 public class BlockSlotTinyCache {
 
@@ -88,62 +50,23 @@ public class BlockSlotTinyCache {
         }
     }
 
+    private record SlotEntry(long blockIdx, BlockCacheValue<RefCountedMemorySegment>val, int gen) {
+    }
+
     private static final int SLOT_COUNT = 32;
     private static final int SLOT_MASK = SLOT_COUNT - 1;
-
-    // VarHandle for acquire/release element access on long[]
-    private static final VarHandle STAMP_ARR = MethodHandles.arrayElementVarHandle(long[].class);
 
     private final BlockCache<RefCountedMemorySegment> cache;
     private final Path path;
 
-    // Parallel arrays for Tier-2 L1 slots (faster than object allocations)
-    private final long[] slotBlockIdx; // published under stamp gate
-    private final BlockCacheValue<RefCountedMemorySegment>[] slotVal; // published under stamp gate
-
-    /**
-     * Stamp array acts as a memory barrier gate using acquire/release ordering:
-     *
-     * WRITER (publishToL1):
-     *   1. Plain stores to slotBlockIdx[i] and slotVal[i]
-     *   2. VarHandle.setRelease(slotStamp, i, stamp)  ← RELEASE barrier
-     *      - Ensures all preceding plain stores become visible before stamp update
-     *      - Forms a "happens-before" edge with any acquire load of this stamp
-     *
-     * READER (acquireRefCountedValue):
-     *   1. s = VarHandle.getAcquire(slotStamp, i)     // ACQUIRE barrier
-     *      - Ensures stamp is read before any dependent reads
-     *      - Synchronizes-with the release store from writer
-     *   2. If stamp matches, safe to read slotBlockIdx[i] and slotVal[i]
-     *      - Acquire load guarantees we see the values that writer published
-     *
-     * Result: stamp != 0 && hash matches = {slotBlockIdx, slotVal} are consistent
-     *         No torn reads, no stale data, no locks needed.
-     */
-    private final long[] slotStamp; // 0 => empty; otherwise pack(gen, hash(blockIdx))
+    private final AtomicReferenceArray<SlotEntry> slots = new AtomicReferenceArray<>(SLOT_COUNT);
 
     // Key reuse per slot
-    private final FileBlockCacheKey[] slotKeys;
+    private final FileBlockCacheKey[] slotKeys = new FileBlockCacheKey[SLOT_COUNT];
 
     public BlockSlotTinyCache(BlockCache<RefCountedMemorySegment> cache, Path path, long fileLength) {
         this.cache = cache;
         this.path = path;
-
-        this.slotBlockIdx = new long[SLOT_COUNT];
-        this.slotStamp = new long[SLOT_COUNT];
-
-        @SuppressWarnings("unchecked")
-        final BlockCacheValue<RefCountedMemorySegment>[] tmp = (BlockCacheValue<RefCountedMemorySegment>[]) new BlockCacheValue[SLOT_COUNT];
-        this.slotVal = tmp;
-
-        this.slotKeys = new FileBlockCacheKey[SLOT_COUNT];
-
-        for (int i = 0; i < SLOT_COUNT; i++) {
-            slotBlockIdx[i] = -1;
-            slotVal[i] = null;
-            slotStamp[i] = 0L;
-            slotKeys[i] = null;
-        }
     }
 
     public BlockCacheValue<RefCountedMemorySegment> acquireRefCountedValue(long blockOff) throws IOException {
@@ -155,27 +78,17 @@ public class BlockSlotTinyCache {
         final long blockIdx = blockOff >>> CACHE_BLOCK_SIZE_POWER;
         final int slotIdx = (int) ((blockIdx ^ (blockIdx >>> 17)) & SLOT_MASK);
 
-        // Acquire-load stamp FIRST (publication gate)
-        final long stamp = (long) STAMP_ARR.getAcquire(slotStamp, slotIdx);
-        if (stamp != 0L) {
-            final int wantHash = hashBlockIdx(blockIdx);
-            final int gotHash = (int) stamp;
-            if (gotHash == wantHash) {
-                // Safe to read published fields after matching stamp
-                if (slotBlockIdx[slotIdx] == blockIdx) {
-                    final BlockCacheValue<RefCountedMemorySegment> v = slotVal[slotIdx];
-                    if (v != null) {
-                        final int expectedGen = (int) (stamp >>> 32);
-                        if (v.tryPin()) {
-                            if (v.value().getGeneration() == expectedGen) {
-                                if (hitHolder != null)
-                                    hitHolder.setWasCacheHit(true);
-                                return v;
-                            }
-                            v.unpin();
-                        }
-                    }
+        // L1 lookup: single atomic reference read gives consistent snapshot
+        SlotEntry entry = slots.get(slotIdx);
+        if (entry != null && entry.blockIdx == blockIdx) {
+            BlockCacheValue<RefCountedMemorySegment> v = entry.val;
+            if (v.tryPin()) {
+                if (v.value().getGeneration() == entry.gen) {
+                    if (hitHolder != null)
+                        hitHolder.setWasCacheHit(true);
+                    return v;
                 }
+                v.unpin();
             }
         }
 
@@ -188,7 +101,6 @@ public class BlockSlotTinyCache {
         }
 
         for (int attempts = 0; attempts < maxAttempts; attempts++) {
-            // 1) Prefer hit
             BlockCacheValue<RefCountedMemorySegment> v = cache.get(key);
             if (v != null) {
                 final int expectedGen = v.value().getGeneration();
@@ -199,11 +111,10 @@ public class BlockSlotTinyCache {
                             hitHolder.setWasCacheHit(true);
                         return v;
                     }
-                    v.unpin(); // pinned recycled object; treat as miss
+                    v.unpin();
                 }
             }
 
-            // 2) Load path (deduped by caffeine get())
             BlockCacheValue<RefCountedMemorySegment> loaded = cache.getOrLoad(key);
             if (loaded != null) {
                 final int expectedGen = loaded.value().getGeneration();
@@ -227,31 +138,12 @@ public class BlockSlotTinyCache {
     }
 
     private void publishToL1(int slotIdx, long blockIdx, BlockCacheValue<RefCountedMemorySegment> v, int gen) {
-        // Write fields first (plain)
-        slotBlockIdx[slotIdx] = blockIdx;
-        slotVal[slotIdx] = v;
-
-        // Publish stamp LAST with release semantics
-        final long stamp = packStamp(hashBlockIdx(blockIdx), gen);
-        STAMP_ARR.setRelease(slotStamp, slotIdx, stamp);
-    }
-
-    private static long packStamp(int hash, int gen) {
-        // upper 32 = gen, lower 32 = hash
-        return ((gen & 0xFFFF_FFFFL) << 32) | (hash & 0xFFFF_FFFFL);
-    }
-
-    private static int hashBlockIdx(long blockIdx) {
-        // small, fast mix; collisions OK because we still compare full blockIdx
-        return (int) (blockIdx ^ (blockIdx >>> 32));
+        slots.set(slotIdx, new SlotEntry(blockIdx, v, gen));
     }
 
     public void clear() {
         for (int i = 0; i < SLOT_COUNT; i++) {
-            slotBlockIdx[i] = -1;
-            slotVal[i] = null;
-            // Clear stamp LAST (best-effort)
-            slotStamp[i] = 0L;
+            slots.set(i, null);
             slotKeys[i] = null;
         }
     }


### PR DESCRIPTION
## Summary

Fixes the merge corruption (`ArrayIndexOutOfBoundsException: arraycopy: source index -N out of bounds`) triggered by the update-only workload (8 bulk clients, 50% conflict rate) under concurrent segment merges.

## Root Cause

The `BlockSlotTinyCache` L1 cache used parallel arrays (`slotBlockIdx[]`, `slotVal[]`, `slotStamp[]`) with an acquire/release protocol on the stamp field to publish slot updates. This protocol is **unsound on ARM/aarch64** (weak memory ordering):

```
Time    Thread A (wants block 65)         Thread B (wants block 1)
────    ─────────────────────────         ────────────────────────
T1      reads stamp[slot] via ACQUIRE
        → sees old stamp (matches block 65)

T2                                        writes slotVal[slot] = <block 1 data>  (plain)
T3                                        writes slotBlockIdx[slot] = 1          (plain)
T4                                        writes stamp[slot] via RELEASE

T5      reads slotBlockIdx[slot]
        → CPU cache still has old value: 65 (matches!)
T6      reads slotVal[slot]
        → gets Thread B's NEW value: <block 1 data>
        → returns block 1's bytes when block 65 was requested
        → CORRUPTION
```

The acquire on the stamp only synchronizes with the **same stamp value's** release. It does NOT prevent observing a concurrent writer's in-progress plain stores in arbitrary order. On x86 (TSO) this race is hidden; on ARM it manifests as data corruption.

## Fix

Replace the parallel arrays with an `AtomicReferenceArray<SlotEntry>` where `SlotEntry` is an immutable record:

```java
private record SlotEntry(long blockIdx, BlockCacheValue<RefCountedMemorySegment> val, int gen) {}
```

A single atomic reference read gives the reader a **consistent snapshot** of all fields — no possibility of observing fields from different writers. Java guarantees (JLS §17.5) that all final fields of an object are fully constructed before any reference to that object is published.

## Verification

- **Without fix:** corruption reproduces reliably (typically within 2 minutes of the update workload)
- **With fix:** 5/5 passes, 0 corruption errors, L1 cache remains active
- **Throughput preserved:** ~4500-5200 bulks/run (vs ~3000-3500 with L1 disabled entirely)

## Evidence collected during investigation

1. `L1_TORN_READ` — seqlock-style re-read of stamp after L1 hit detected stamp changes mid-read (proving concurrent writer interference)
2. `L1_L2_MISMATCH` — L1 returned a different object than Caffeine L2 held for the same key, immediately followed by `ArrayIndexOutOfBoundsException`
3. Disabling L1 entirely eliminates corruption (5/5, 20/20 passes)
4. Invalidate-before-every-load (bypassing cache) eliminates corruption (5/5 passes)

## Test plan

- [x] `UpdateConflictIntegTests.testOsbUpdateOnlyWorkload` passes 5/5 with fix
- [x] No regression in throughput (L1 still active)
- [ ] Run full test suite (`./gradlew allTests`)

## To  Do

Heavy indexing runs pending 

🤖 Generated with [Claude Code](https://claude.com/claude-code)