### PR TITLE
[Bug Fix]: prevent CryptoNIOFS IndexInput shared file channel close when clone

### DIFF
--- a/src/main/java/org/opensearch/index/store/niofs/CryptoBufferedIndexInput.java
+++ b/src/main/java/org/opensearch/index/store/niofs/CryptoBufferedIndexInput.java
@@ -42,7 +42,8 @@ final class CryptoBufferedIndexInput extends BufferedIndexInput {
     private static final int CHUNK_SIZE = 16_384;
 
     private final FileChannel channel;
-    private final boolean isClone;
+    private boolean isClone;
+    private final boolean isSlice;
     private final long off;
     private final long end;
     private final KeyResolver keyResolver;
@@ -74,6 +75,7 @@ final class CryptoBufferedIndexInput extends BufferedIndexInput {
         this.end = fc.size();
         this.keyResolver = keyResolver;
         this.isClone = false;
+        this.isSlice = false;
         this.normalizedFilePath = EncryptionMetadataCache.normalizePath(filePath);
         this.encryptionMetadataCache = encryptionMetadataCache;
 
@@ -118,6 +120,7 @@ final class CryptoBufferedIndexInput extends BufferedIndexInput {
         this.off = off;
         this.end = off + length;
         this.isClone = true;
+        this.isSlice = true;
         this.keyResolver = keyResolver;
         this.keySpec = keySpec;  // Reuse keySpec from main file
         this.footerLength = footerLength;
@@ -141,6 +144,7 @@ final class CryptoBufferedIndexInput extends BufferedIndexInput {
     public CryptoBufferedIndexInput clone() {
         CryptoBufferedIndexInput clone = (CryptoBufferedIndexInput) super.clone();
         clone.tmpBuffer = EMPTY_BYTEBUFFER;
+        clone.isClone = true;
         return clone;
     }
 
@@ -172,11 +176,10 @@ final class CryptoBufferedIndexInput extends BufferedIndexInput {
 
     @Override
     public long length() {
-        // Exclude footer from logical file length (only for main file, not slices)
-        if (isClone) {
-            return end - off;  // Slices use exact length passed in
+        if (isSlice) {
+            return end - off;  // slice: exact length passed in
         } else {
-            return end - off - footerLength;  // Main file excludes variable footer
+            return end - off - footerLength;  // whole file (root or clone): exclude footer
         }
     }
 

--- a/src/test/java/org/opensearch/index/store/CloneCloseReproTests.java
+++ b/src/test/java/org/opensearch/index/store/CloneCloseReproTests.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.index.store;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Path;
+import java.security.Provider;
+import java.security.Security;
+import java.util.Random;
+
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSLockFactory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.opensearch.index.store.cipher.EncryptionMetadataCache;
+import org.opensearch.index.store.key.KeyResolver;
+import org.opensearch.index.store.metrics.CryptoMetricsService;
+import org.opensearch.index.store.niofs.CryptoNIOFSDirectory;
+import org.opensearch.telemetry.metrics.MetricsRegistry;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Deterministic reproduction of the shared-FileChannel clone/close bug in
+ * CryptoBufferedIndexInput.
+ *
+ * A root IndexInput and all of its clones share ONE FileChannel. Only the root
+ * should close it. On unfixed code, Object.clone() bitwise-copies isClone=false into
+ * a clone of the root, so closing that clone closes the shared channel. A subsequent
+ * read through the (still-open) parent then fails with ClosedChannelException.
+ *
+ * On unfixed code (main): FAILS — read after clone.close() throws ClosedChannelException.
+ * On fixed code:          PASSES — clone.close() is a no-op on the shared channel.
+ */
+public class CloneCloseReproTests extends OpenSearchTestCase {
+
+    private Directory getDirectory(Path file) throws Exception {
+        CryptoMetricsService.initialize(mock(MetricsRegistry.class));
+
+        byte[] rawKey = new byte[32]; // 256-bit AES key
+        new Random(42).nextBytes(rawKey);
+
+        KeyResolver keyResolver = mock(KeyResolver.class);
+        when(keyResolver.getDataKey()).thenReturn(new SecretKeySpec(rawKey, "AES"));
+
+        Provider provider = Security.getProvider("SunJCE");
+        assertNotNull("SunJCE provider should be available", provider);
+
+        EncryptionMetadataCache cache = new EncryptionMetadataCache();
+        return new CryptoNIOFSDirectory(FSLockFactory.getDefault(), file, provider, keyResolver, cache);
+    }
+
+    public void testReadAfterCloneCloseMustNotThrow() throws Exception {
+        try (Directory dir = getDirectory(createTempDir())) {
+            final String fileName = "shared-channel-file";
+            final int dataSize = 64 * 1024; // large enough to force real channel reads
+
+            // 1. Ingest some data.
+            byte[] data = new byte[dataSize];
+            new Random(7).nextBytes(data);
+            try (IndexOutput out = dir.createOutput(fileName, IOContext.DEFAULT)) {
+                out.writeBytes(data, data.length);
+            }
+
+            // 2. Open an IndexInput on it and read some bytes from the parent.
+            try (IndexInput parent = dir.openInput(fileName, IOContext.DEFAULT)) {
+                parent.seek(0);
+                byte[] before = new byte[16];
+                parent.readBytes(before, 0, before.length);
+
+                // 3. Create a clone and close the clone.
+                // clone() shares the parent's FileChannel. On unfixed code the clone
+                // inherits isClone=false, so clone.close() closes the SHARED channel.
+                IndexInput clone = parent.clone();
+                clone.close();
+
+                // 4. Read from the parent again. The parent is still open, so this must
+                // succeed. We seek FAR past the initial read so BufferedIndexInput can't
+                // serve it from its in-memory buffer and is forced to hit the FileChannel.
+                // On unfixed code the shared channel is already closed, so channel.read()
+                // throws java.nio.channels.ClosedChannelException.
+                final long farPos = 40_000L; // well beyond any BufferedIndexInput buffer, < logical length
+                byte[] after = new byte[16];
+                parent.seek(farPos);
+                parent.readBytes(after, 0, after.length); // <-- throws ClosedChannelException on unfixed code
+
+                // Sanity: bytes at farPos match the source data (footer-excluded region).
+                byte[] expected = new byte[16];
+                System.arraycopy(data, (int) farPos, expected, 0, 16);
+                assertArrayEquals("parent should read correct bytes after clone.close()", expected, after);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
A root IndexInput and its clones share one FileChannel; only the root should close it. isClone was final, so `clone()` (via `super.clone()`) could not set it and a clone inherited `isClone=false` - closing that clone closed the shared channel, causing `ClosedChannelException` on concurrent reads via the root or sibling clones.

`isClone` was also overloaded in `length()`: it decided whether to subtract the trailing encryption footer. Once clones are marked isClone=true, a clone wrongly took the slice branch and stopped subtracting the footer, overrunning on prefetch (`ArrayIndexOutOfBoundsException` in `testPrefetch`). Introduce  separate isSlice flag so channel-ownership (isClone) and length semantics (`isSlice`) are independent: a clone is `isClone=true`, `isSlice=false`.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->
https://github.com/opensearch-project/opensearch-storage-encryption/issues/178

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
